### PR TITLE
add hal package option

### DIFF
--- a/src/main.zig
+++ b/src/main.zig
@@ -28,6 +28,10 @@ fn root() []const u8 {
 
 pub const BuildOptions = struct {
     packages: ?[]const Pkg = null,
+
+    // a hal package is a package with ergonomic wrappers for registers for a
+    // given mcu, it's only dependency can be microzig
+    hal_package_path: ?std.build.FileSource = null,
 };
 
 pub fn addEmbeddedExecutable(
@@ -155,6 +159,13 @@ pub fn addEmbeddedExecutable(
     exe.addPackage(config_pkg);
     exe.addPackage(chip_pkg);
     exe.addPackage(cpu_pkg);
+
+    if (options.hal_package_path) |hal_package_path|
+        exe.addPackage(.{
+            .name = "hal",
+            .path = hal_package_path,
+            .dependencies = &.{pkgs.microzig},
+        });
 
     switch (backing) {
         .board => |board| {


### PR DESCRIPTION
The idea here is that someone could write an `nrf52` package that makes working with registers more readable. Similar to how the sdk has some nice-to-use functions for setting up gpio. This sort of package would depend on microzig only. 

Wrt to the generalized interfaces we've discussed, I see packages like these having implementations that can fully take advantage of hardware, and can return a generalized structure. This would be analogous to how you could have a `CountingReader`, and a `GzipReader`, but you call `reader()` on them to get a generalized reader.