### PR TITLE
uart: allow selecting the tx/rx pins

### DIFF
--- a/src/core/uart.zig
+++ b/src/core/uart.zig
@@ -2,8 +2,8 @@ const std = @import("std");
 const micro = @import("microzig.zig");
 const chip = @import("chip");
 
-pub fn Uart(comptime index: usize) type {
-    const SystemUart = chip.Uart(index);
+pub fn Uart(comptime index: usize, comptime pins: Pins) type {
+    const SystemUart = chip.Uart(index, pins);
     return struct {
         const Self = @This();
 
@@ -63,7 +63,14 @@ pub fn Uart(comptime index: usize) type {
     };
 }
 
-/// A UART configuration. The config defaults to the *8N1* setting, so "8 data bits, no parity, 1 stop bit" which is the 
+/// The pin configuration. This is used to optionally configure specific pins to be used with the chosen UART.
+/// This makes sense only with microcontrollers supporting multiple pins for a UART peripheral.
+pub const Pins = struct {
+    tx: ?type = null,
+    rx: ?type = null,
+};
+
+/// A UART configuration. The config defaults to the *8N1* setting, so "8 data bits, no parity, 1 stop bit" which is the
 /// most common serial format.
 pub const Config = struct {
     /// TODO: Make this optional, to support STM32F303 et al. auto baud-rate detection?

--- a/src/modules/boards/stm32f3discovery/stm32f3discovery.zig
+++ b/src/modules/boards/stm32f3discovery/stm32f3discovery.zig
@@ -25,7 +25,7 @@ pub const pin_map = .{
 };
 
 pub fn debugWrite(string: []const u8) void {
-    const uart1 = micro.Uart(1).getOrInit(.{
+    const uart1 = micro.Uart(1, .{}).getOrInit(.{
         .baud_rate = 9600,
         .data_bits = .eight,
         .parity = null,

--- a/src/modules/chips/atmega328p/atmega328p.zig
+++ b/src/modules/chips/atmega328p/atmega328p.zig
@@ -94,8 +94,11 @@ pub const uart = struct {
     };
 };
 
-pub fn Uart(comptime index: usize) type {
+pub fn Uart(comptime index: usize, comptime pins: micro.uart.Pins) type {
     if (index != 0) @compileError("Atmega328p only has a single uart!");
+    if (pins.tx != null or pins.rx != null)
+        @compileError("Atmega328p has fixed pins for uart!");
+
     return struct {
         const Self = @This();
 

--- a/src/modules/chips/lpc1768/lpc1768.zig
+++ b/src/modules/chips/lpc1768/lpc1768.zig
@@ -115,7 +115,10 @@ pub const uart = struct {
     };
 };
 
-pub fn Uart(comptime index: usize) type {
+pub fn Uart(comptime index: usize, comptime pins: micro.uart.Pins) type {
+    if (pins.tx != null or pins.rx != null)
+        @compileError("TODO: custom pins are not currently supported");
+
     return struct {
         const UARTn = switch (index) {
             0 => regs.UART0,

--- a/src/modules/chips/stm32f303/stm32f303.zig
+++ b/src/modules/chips/stm32f303/stm32f303.zig
@@ -132,8 +132,10 @@ pub const uart = struct {
     };
 };
 
-pub fn Uart(comptime index: usize) type {
+pub fn Uart(comptime index: usize, comptime pins: micro.uart.Pins) type {
     if (!(index == 1)) @compileError("TODO: only USART1 is currently supported");
+    if (pins.tx != null or pins.rx != null)
+        @compileError("TODO: custom pins are not currently supported");
 
     return struct {
         parity_read_mask: u8,

--- a/tests/uart-sync.zig
+++ b/tests/uart-sync.zig
@@ -3,13 +3,25 @@ const micro = @import("microzig");
 // Configures the led_pin and uart index
 const cfg = if (micro.config.has_board)
     switch (micro.config.board_name) {
-        .@"mbed LPC1768" => .{ .led_pin = micro.Pin("LED-1"), .uart_idx = 1 },
-        .@"STM32F3DISCOVERY" => .{ .led_pin = micro.Pin("LD3"), .uart_idx = 1 },
-        .@"STM32F4DISCOVERY" => .{ .led_pin = micro.Pin("LD5"), .uart_idx = 2 },
+        .@"mbed LPC1768" => .{
+            .led_pin = micro.Pin("LED-1"),
+            .uart_idx = 1,
+            .pins = .{},
+        },
+        .@"STM32F3DISCOVERY" => .{
+            .led_pin = micro.Pin("LD3"),
+            .uart_idx = 1,
+            .pins = .{},
+        },
+        .@"STM32F4DISCOVERY" => .{
+            .led_pin = micro.Pin("LD5"),
+            .uart_idx = 2,
+            .pins = .{ .tx = micro.Pin("PA2"), .rx = micro.Pin("PA3") },
+        },
         else => @compileError("unknown board"),
     }
 else switch (micro.config.chip_name) {
-    .@"NXP LPC1768" => .{ .led_pin = micro.Pin("P1.18"), .uart_idx = 1 },
+    .@"NXP LPC1768" => .{ .led_pin = micro.Pin("P1.18"), .uart_idx = 1, .pins = .{} },
     else => @compileError("unknown chip"),
 };
 
@@ -20,7 +32,7 @@ pub fn main() !void {
     });
     led.init();
 
-    var uart = micro.Uart(cfg.uart_idx).init(.{
+    var uart = micro.Uart(cfg.uart_idx, cfg.pins).init(.{
         .baud_rate = 9600,
         .stop_bits = .one,
         .parity = null,


### PR DESCRIPTION
Some microcontrollers allow routing multiple pins to the same UART peripheral.
This commit allows selecting specific pins on these platforms.