### PR TITLE
Make the microzig package public to allow it to be passed as dependency.

### DIFF
--- a/src/main.zig
+++ b/src/main.zig
@@ -188,13 +188,13 @@ pub fn addEmbeddedExecutable(
     return exe;
 }
 
-const pkgs = struct {
+pub const pkgs = struct {
     const mmio = std.build.Pkg{
         .name = "microzig-mmio",
         .source = .{ .path = root_path ++ "core/mmio.zig" },
     };
 
-    const microzig = std.build.Pkg{
+    pub const microzig = std.build.Pkg{
         .name = "microzig",
         .source = .{ .path = root_path ++ "core/import-package.zig" },
     };


### PR DESCRIPTION
Make the microzig package public.

When creating hal libraries, microzig must be available to the hal.

Having it public permit the following pattern:

`libs/stm32l0x1/lib.zig`

```zig
pub fn Lib(comptime microzig: anytype) type {
    return struct {
        pub const chips = struct {
            pub const stm32l011f3px = microzig.Chip{
                .name = "STM32L011F3Px",
                .path = root() ++ "src/registers.zig",
                .cpu = microzig.cpus.cortex_m0plus,
                .memory_regions = &.{
                    .{ .kind = .flash, .offset = 0x08000000, .length = 8 * 1024 },
                    .{ .kind = .ram, .offset = 0x20000000, .length = 2 * 1024 },
                },
            };
            pub const stm32l011f4px = microzig.Chip{
                .name = "STM32L011F4Px",
                .path = root() ++ "src/registers.zig",
                .cpu = microzig.cpus.cortex_m0plus,
                .memory_regions = &.{
                    .{ .kind = .flash, .offset = 0x08000000, .length = 16 * 1024 },
                    .{ .kind = .ram, .offset = 0x20000000, .length = 2 * 1024 },
                },
            };
        };
        pub const pkg = Pkg{
            .name = "stm32l0x1",
            .source = .{
                .path = root() ++ "src/lib.zig",
            },
            .dependencies = &.{microzig.pkgs.microzig},
        };
    };
}
```

`app/build.zig`

```
    const microzig = @import("libs/microzig/src/main.zig");
    const stm32l0x1 = @import("libs/stm32l0x1/lib.zig").Lib(microzig);
    const packages = .{ stm32l0x1.pkg }; 
    const exe = microzig.addEmbeddedExecutable(
        b,
        name,
        "src/" ++ path,
        .{ .chip = stm32l0x1.chips.stm32l011f3px },
        .{ .packages = &packages },
    ) catch @panic("failed to create embedded executable");

```

Then, in the `lib` `@import("microzig")` will work as expected.

This pattern allows for easy and flexible library composition.