### PR TITLE
Add executable methods and fix recursive call

### DIFF
--- a/src/main.zig
+++ b/src/main.zig
@@ -69,7 +69,7 @@ pub const EmbeddedExecutable = struct {
     }
 
     pub fn addIncludePath(exe: *EmbeddedExecutable, path: []const u8) void {
-        exe.addIncludePath(path);
+        exe.inner.addIncludePath(path);
     }
 
     pub fn addSystemIncludePath(exe: *EmbeddedExecutable, path: []const u8) void {
@@ -78,6 +78,15 @@ pub const EmbeddedExecutable = struct {
 
     pub fn addCSourceFile(exe: *EmbeddedExecutable, file: []const u8, flags: []const []const u8) void {
         exe.inner.addCSourceFile(file, flags);
+    }
+
+    pub fn addOptions(exe: *EmbeddedExecutable, package_name: []const u8, options: *std.build.OptionsStep) void {
+        exe.inner.addOptions(package_name, options);
+        exe.addPackage(.{ .name = package_name, .source = options.getSource() });
+    }
+
+    pub fn addObjectFile(exe: *EmbeddedExecutable, source_file: []const u8) void {
+        exe.inner.addObjectFile(source_file);
     }
 };
 


### PR DESCRIPTION
Add executable methods (addOptions, addObjectFile) and fix recursive call in addIncludePath.

For #72.