### PR TITLE
STM3240G-eval board

### DIFF
--- a/src/modules/boards.zig
+++ b/src/modules/boards.zig
@@ -32,6 +32,12 @@ pub const stm32f4discovery = Board{
     .chip = chips.stm32f407vg,
 };
 
+pub const stm3240geval = Board{
+    .name = "STM3240GEVAL",
+    .path = root_path ++ "boards/stm3240geval/stm3240geval.zig",
+    .chip = chips.stm32f407vg,
+};
+
 pub const stm32f429idiscovery = Board{
     .name = "STM32F429IDISCOVERY",
     .path = root_path ++ "boards/stm32f429idiscovery/stm32f429idiscovery.zig",

--- a/src/modules/boards/stm3240geval/stm3240geval.zig
+++ b/src/modules/boards/stm3240geval/stm3240geval.zig
@@ -1,0 +1,13 @@
+pub const chip = @import("chip");
+pub const micro = @import("microzig");
+
+pub const pin_map = .{
+    // LD1 green
+    .@"LD1" = "PG6",
+    // LD2 orange
+    .@"LD2" = "PG8",
+    // LD3 red
+    .@"LD3" = "PI9",
+    // LD4 blue
+    .@"LD4" = "PC7",
+};


### PR DESCRIPTION
Same chip as `stm32f4discovery`.
Currently exposes only the 4 LEDs.
Will add more as I continue working with the board.