### PR TITLE
 ATmega328p uart

### DIFF
--- a/src/modules/chips/atmega328p/atmega328p.zig
+++ b/src/modules/chips/atmega328p/atmega328p.zig
@@ -17,6 +17,10 @@ pub const clock = struct {
     };
 };
 
+pub const clock_frequencies = .{
+    .cpu = 16_000_000,
+};
+
 pub fn parsePin(comptime spec: []const u8) type {
     const invalid_format_msg = "The given pin '" ++ spec ++ "' has an invalid format. Pins must follow the format \"P{Port}{Pin}\" scheme.";
 
@@ -106,7 +110,7 @@ pub fn Uart(comptime index: usize, comptime pins: micro.uart.Pins) type {
             const pclk = micro.clock.get().cpu;
             const divider = ((pclk + (8 * baud_rate)) / (16 * baud_rate)) - 1;
 
-            return std.math.cast(u12, divider) catch return error.UnsupportedBaudRate;
+            return std.math.cast(u12, divider) orelse return error.UnsupportedBaudRate;
         }
 
         fn computeBaudRate(divider: u12) u32 {

--- a/tests/uart-sync.zig
+++ b/tests/uart-sync.zig
@@ -28,6 +28,7 @@ const cfg = if (micro.config.has_board)
 else switch (micro.config.chip_name) {
     .@"NXP LPC1768" => .{ .led_pin = micro.Pin("P1.18"), .uart_idx = 1, .pins = .{} },
     .@"GD32VF103x8" => .{ .led_pin = micro.Pin("PA2"), .uart_idx = 1, .pins = .{} },
+    .@"ATmega328p" => .{ .led_pin = micro.Pin("PB5"), .uart_idx = 0, .pins = .{} },
     else => @compileError("unknown chip"),
 };
 


### PR DESCRIPTION
uart-sync.zig
- Added support for ATmega328p
  - "PB5" is the builtin led of Arduino UNO

atmega328p.zig:
- Fixed compile error in fn computeDivider
  - std.math.cast changed from error  to optional
  - https://github.com/ziglang/zig/commit/0e6285c8fc31ff866df96847fe34e660da38b4a9
- Added pub const clock_frequencies
  - 16 MHz is the default freq. of Arduino UNO