### PR TITLE
Updated code to regz rewrite and added fix for i2c on ATmega328P

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -62,7 +62,7 @@ pub fn build(b: *std.build.Builder) !void {
         },
         .optimize = optimize,
     });
-    exe.install();
+    exe.installArtifact(b);
 }
 ----
 

--- a/src/core/experimental/clock.zig
+++ b/src/core/experimental/clock.zig
@@ -1,18 +1,21 @@
 const std = @import("std");
-const micro = @import("microzig");
-const chip = @import("chip");
+const hal = @import("hal");
+const app = struct {}; // workaround for error: no package named 'app' available within package 'root.microzig'
+const board = @import("board");
+const cpu = @import("cpu");
+const config = @import("config");
 
 /// An enumeration of clock sources.
 pub const Source = enum {
     none,
     application,
     board,
-    chip,
+    hal,
     cpu,
 };
 
 /// A struct containing the frequency in hertz for each clock domain
-pub const Clocks = std.enums.EnumFieldStruct(chip.clock.Domain, u32, null);
+pub const Clocks = std.enums.EnumFieldStruct(hal.clock.Domain, u32, null);
 
 /// Is `true` when microzig has a clock frequency available.
 /// Clock can be provided by several clock sources
@@ -23,10 +26,10 @@ pub const is_dynamic = has_clock and !@typeInfo(@TypeOf(&@field(clock_source_typ
 
 /// Contains the source which provides microzig with clock information.
 pub const source: Source = switch (clock_source_type) {
-    micro.app => .application,
-    micro.board => .board,
-    micro.chip => .chip,
-    micro.cpu => .cpu,
+    app => .application,
+    board => .board,
+    hal => .hal,
+    cpu => .cpu,
     no_clock_source_type => .none,
     else => unreachable,
 };
@@ -46,14 +49,14 @@ pub inline fn get() Clocks {
 const freq_decl_name = "clock_frequencies";
 
 const no_clock_source_type = opaque {};
-const clock_source_type = if (@hasDecl(micro.app, freq_decl_name))
-    micro.app
-else if (micro.config.has_board and @hasDecl(micro.board, freq_decl_name))
-    micro.board
-else if (@hasDecl(micro.chip, freq_decl_name))
-    micro.chip
-else if (@hasDecl(micro.cpu, freq_decl_name))
-    micro.cpu
+const clock_source_type = if (@hasDecl(app, freq_decl_name))
+    app
+else if (config.has_board and @hasDecl(board, freq_decl_name))
+    board
+else if (@hasDecl(hal, freq_decl_name))
+    hal
+else if (@hasDecl(cpu, freq_decl_name))
+    cpu
 else
     no_clock_source_type;
 

--- a/src/core/experimental/debug.zig
+++ b/src/core/experimental/debug.zig
@@ -1,5 +1,6 @@
 const std = @import("std");
-const micro = @import("microzig");
+const config = @import("config");
+const board = @import("board");
 
 pub fn busy_sleep(comptime limit: comptime_int) void {
     if (limit <= 0) @compileError("limit must be non-negative!");
@@ -27,12 +28,12 @@ fn writer_write(ctx: void, string: []const u8) DebugErr!usize {
 const DebugWriter = std.io.Writer(void, DebugErr, writer_write);
 
 pub fn write(string: []const u8) void {
-    if (!micro.config.has_board)
+    if (!config.has_board)
         return;
-    if (!@hasDecl(micro.board, "debugWrite"))
+    if (!@hasDecl(board, "debugWrite"))
         return;
 
-    micro.board.debug_write(string);
+    board.debug_write(string);
 }
 
 pub fn writer() DebugWriter {

--- a/src/core/experimental/i2c.zig
+++ b/src/core/experimental/i2c.zig
@@ -1,9 +1,9 @@
 const std = @import("std");
-const micro = @import("microzig");
-const chip = @import("chip");
+const hal = @import("hal");
+const cfg = @import("config");
 
 pub fn I2CController(comptime index: usize, comptime pins: Pins) type {
-    const SystemI2CController = chip.I2CController(index, pins);
+    const SystemI2CController = hal.I2CController(index, pins);
 
     const I2CDevice = struct {
         const Device = @This();
@@ -128,6 +128,7 @@ pub fn I2CController(comptime index: usize, comptime pins: Pins) type {
         const Self = @This();
 
         internal: SystemI2CController,
+        variable_so_struct_is_not_of_size_zero_and_mcu_hangs_when_returning_struct_on_avr: if (std.mem.eql(u8, cfg.chip_name, "ATmega328P")) u8 else void = undefined,
 
         pub fn init(config: Config) InitError!Self {
             return Self{

--- a/src/core/experimental/uart.zig
+++ b/src/core/experimental/uart.zig
@@ -1,9 +1,9 @@
 const std = @import("std");
-const micro = @import("microzig");
-const chip = @import("chip");
+const hal = @import("hal");
+const clock = @import("clock.zig");
 
 pub fn Uart(comptime index: usize, comptime pins: Pins) type {
-    const SystemUart = chip.Uart(index, pins);
+    const SystemUart = hal.Uart(index, pins);
     return struct {
         const Self = @This();
 
@@ -11,7 +11,7 @@ pub fn Uart(comptime index: usize, comptime pins: Pins) type {
 
         /// Initializes the UART with the given config and returns a handle to the uart.
         pub fn init(config: Config) InitError!Self {
-            micro.clock.ensure();
+            clock.ensure();
             return Self{
                 .internal = try SystemUart.init(config),
             };
@@ -81,9 +81,9 @@ pub const Config = struct {
 };
 
 // TODO: comptime verify that the enums are valid
-pub const DataBits = chip.uart.DataBits;
-pub const StopBits = chip.uart.StopBits;
-pub const Parity = chip.uart.Parity;
+pub const DataBits = hal.uart.DataBits;
+pub const StopBits = hal.uart.StopBits;
+pub const Parity = hal.uart.Parity;
 
 pub const InitError = error{
     UnsupportedWordSize,


### PR DESCRIPTION
Mostly changes to imports/variables that changed.

The i2c fix prevents the controller form hanging/crash when running this line
`const i2c = try interfaces.i2c.I2CController(0, .{}).init(.{ .target_speed = 400_000 });`.
I think this is caused because the struct that is returned contains just functions so it has size 0 and clangs avr code gen cant handle that properly.