### PR TITLE
When adding an option, set it as app module dependency

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -63,6 +63,9 @@ pub const EmbeddedExecutable = struct {
 
     pub fn addOptions(exe: *EmbeddedExecutable, module_name: []const u8, options: *std.build.OptionsStep) void {
         exe.inner.addOptions(module_name, options);
+        const app_module = exe.inner.modules.get("app").?;
+        const opt_module = exe.inner.modules.get(module_name).?;
+        app_module.dependencies.put(module_name, opt_module) catch @panic("OOM");
     }
 
     pub fn addObjectFile(exe: *EmbeddedExecutable, source_file: []const u8) void {


### PR DESCRIPTION
With new module architecture, the added option would not be visible in the app module. This fixes that.

For example here is how options works, in `build.zig`

```zig

    var buf: [100]u8 = .{0} ** 100;
    const date = std.fmt.bufPrint(
        &buf,
        "{d}",
        .{std.time.timestamp()},
    ) catch unreachable;
    const options = b.addOptions();
    options.addOption([]const u8, "date", date);
    exe.addOptions("compile_info", options);

```

Then in app main file.

```zig
const compile_info = @import("compile_info");
...
debug(compile_info.date, .{});

```