### PR TITLE
Fixing issues in Build to achieve v0.11.0 compatibility

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -3,10 +3,10 @@
 //! This means we need to use addExecutable() instead of using
 
 const std = @import("std");
-const LibExeObjStep = std.build.LibExeObjStep;
-const Module = std.build.Module;
-const LazyPath = std.build.LazyPath;
-const OptionsStep = std.build.OptionsStep;
+const LibExeObjStep = std.Build.LibExeObjStep;
+const Module = std.Build.Module;
+const LazyPath = std.Build.LazyPath;
+const OptionsStep = std.Build.OptionsStep;
 const Build = std.Build;
 
 // alias for packages
@@ -50,16 +50,16 @@ pub const EmbeddedExecutable = struct {
         b.installArtifact(exe.inner);
     }
 
-    pub fn addIncludePath(exe: *EmbeddedExecutable, path: []const u8) void {
+    pub fn addIncludePath(exe: *EmbeddedExecutable, path: LazyPath) void {
         exe.inner.addIncludePath(path);
     }
 
-    pub fn addSystemIncludePath(exe: *EmbeddedExecutable, path: []const u8) void {
+    pub fn addSystemIncludePath(exe: *EmbeddedExecutable, path: LazyPath) void {
         return exe.inner.addSystemIncludePath(path);
     }
 
-    pub fn addCSourceFile(exe: *EmbeddedExecutable, file: []const u8, flags: []const []const u8) void {
-        exe.inner.addCSourceFile(file, flags);
+    pub fn addCSourceFile(exe: *EmbeddedExecutable, source: Build.Step.Compile.CSourceFile) void {
+        exe.inner.addCSourceFile(source);
     }
 
     pub fn addOptions(exe: *EmbeddedExecutable, module_name: []const u8, options: *OptionsStep) void {
@@ -69,8 +69,8 @@ pub const EmbeddedExecutable = struct {
         app_module.dependencies.put(module_name, opt_module) catch @panic("OOM");
     }
 
-    pub fn addObjectFile(exe: *EmbeddedExecutable, source_file: []const u8) void {
-        exe.inner.addObjectFile(source_file);
+    pub fn addObjectFile(exe: *EmbeddedExecutable, source: LazyPath) void {
+        exe.inner.addObjectFile(source);
     }
 };
 


### PR DESCRIPTION
Hi Team Microzig!
I have updated my microzig fork to use the LazyPaths and CSourceFiles used in the v0.11.0 compilation. 

This fixes my personal project  (https://github.com/FranciscoLlobet/efm32-freertos-zig)

Thanks in advance and Best Regards
Francisco