### PR TITLE
Change the HAL API to snake_case() from camelCase()

### DIFF
--- a/src/core/experimental/debug.zig
+++ b/src/core/experimental/debug.zig
@@ -30,7 +30,7 @@ const DebugWriter = std.io.Writer(void, DebugErr, writer_write);
 pub fn write(string: []const u8) void {
     if (!config.has_board)
         return;
-    if (!@hasDecl(board, "debugWrite"))
+    if (!@hasDecl(board, "debug_write"))
         return;
 
     board.debug_write(string);

--- a/src/core/experimental/spi.zig
+++ b/src/core/experimental/spi.zig
@@ -1,16 +1,16 @@
 const std = @import("std");
-const micro = @import("microzig");
-const chip = @import("chip");
+const hal = @import("hal");
+const clock = @import("clock.zig"); // Is there a different/better way?
 
 /// The SPI bus with the given environment-specific number.
 /// Only 'master' mode is supported currently.
 pub fn SpiBus(comptime index: usize) type {
-    const SystemSpi = chip.SpiBus(index);
+    const SystemSpi = hal.SpiBus(index);
 
     return struct {
         /// A SPI 'slave' device, selected via the given CS pin.
         /// (Default is CS=low to select.)
-        pub fn SpiDevice(comptime cs_pin: type, config: DeviceConfig) type {
+        pub fn SpiDevice(comptime cs_pin: type, comptime config: DeviceConfig) type {
             return struct {
                 const SelfSpiDevice = @This();
 
@@ -24,7 +24,7 @@ pub fn SpiBus(comptime index: usize) type {
                     device: SelfSpiDevice,
 
                     fn transceive_byte(self: *SelfTransfer, write_byte: u8, read_pointer: *u8) !void {
-                        try self.device.internal.transceiveByte(write_byte, read_pointer);
+                        try self.device.internal.transceive_byte(write_byte, read_pointer);
                     }
 
                     pub const Writer = std.io.Writer(*SelfTransfer, WriteError, write_some);
@@ -35,7 +35,7 @@ pub fn SpiBus(comptime index: usize) type {
                     }
 
                     fn write_some(self: *SelfTransfer, buffer: []const u8) WriteError!usize {
-                        try self.device.internal.writeAll(buffer);
+                        try self.device.internal.write_all(buffer);
                         return buffer.len;
                     }
 
@@ -47,40 +47,40 @@ pub fn SpiBus(comptime index: usize) type {
                     }
 
                     fn read_some(self: *SelfTransfer, buffer: []u8) ReadError!usize {
-                        try self.device.internal.readInto(buffer);
+                        try self.device.internal.read_into(buffer);
                         return buffer.len;
                     }
 
                     /// end the current transfer, releasing via the CS pin
                     pub fn end(self: *SelfTransfer) void {
-                        self.device.internal.endTransfer(cs_pin, config);
+                        self.device.internal.end_transfer(cs_pin, config);
                     }
                 };
 
                 /// start a new transfer, selecting using the CS pin
                 pub fn begin_transfer(self: SelfSpiDevice) !Transfer {
-                    self.internal.switchToDevice(cs_pin, config);
-                    self.internal.beginTransfer(cs_pin, config);
+                    self.internal.switch_to_device(cs_pin, config);
+                    self.internal.begin_transfer(cs_pin, config);
                     return Transfer{ .device = self };
                 }
 
                 pub fn transceive(self: SelfSpiDevice, write_buffer: []const u8, read_buffer: []u8) !void {
                     std.debug.assert(write_buffer.len == read_buffer.len);
-                    var transfer = try self.beginTransfer();
+                    var transfer = try self.begin_transfer();
                     defer transfer.end();
                     for (write_buffer, 0..) |_, i| {
-                        try transfer.transceiveByte(write_buffer[i], &read_buffer[i]);
+                        try transfer.transceive_byte(write_buffer[i], &read_buffer[i]);
                     }
                 }
 
                 /// Shorthand for 'register-based' devices
                 pub fn write_register(self: SelfSpiDevice, register_address: u8, byte: u8) ReadError!void {
-                    try self.writeRegisters(register_address, &.{byte});
+                    try self.write_registers(register_address, &.{byte});
                 }
 
                 /// Shorthand for 'register-based' devices
-                pub fn write_registers(self: SelfSpiDevice, register_address: u8, buffer: []u8) ReadError!void {
-                    var transfer = try self.beginTransfer();
+                pub fn write_registers(self: SelfSpiDevice, register_address: u8, buffer: []const u8) ReadError!void {
+                    var transfer = try self.begin_transfer();
                     defer transfer.end();
                     // write auto-increment, starting at given register
                     try transfer.writer().writeByte(0b01_000000 | register_address);
@@ -90,13 +90,13 @@ pub fn SpiBus(comptime index: usize) type {
                 /// Shorthand for 'register-based' devices
                 pub fn read_register(self: SelfSpiDevice, register_address: u8) ReadError!u8 {
                     var buffer: [1]u8 = undefined;
-                    try self.readRegisters(register_address, &buffer);
+                    try self.read_registers(register_address, &buffer);
                     return buffer[0];
                 }
 
                 /// Shorthand for 'register-based' devices
                 pub fn read_registers(self: SelfSpiDevice, register_address: u8, buffer: []u8) ReadError!void {
-                    var transfer = try self.beginTransfer();
+                    var transfer = try self.begin_transfer();
                     defer transfer.end();
                     // read auto-increment, starting at given register
                     try transfer.writer().writeByte(0b11_000000 | register_address);
@@ -111,7 +111,7 @@ pub fn SpiBus(comptime index: usize) type {
 
         /// Initialize this SPI bus and return a handle to it.
         pub fn init(config: BusConfig) InitError!SelfSpiBus {
-            micro.clock.ensure(); // TODO: Wat?
+            clock.ensure(); // TODO: Wat?
             return SelfSpiBus{
                 .internal = try SystemSpi.init(config),
             };

--- a/src/core/experimental/uart.zig
+++ b/src/core/experimental/uart.zig
@@ -20,21 +20,21 @@ pub fn Uart(comptime index: usize, comptime pins: Pins) type {
         /// If the UART is already initialized, try to return a handle to it,
         /// else initialize with the given config.
         pub fn get_or_init(config: Config) InitError!Self {
-            if (!@hasDecl(SystemUart, "getOrInit")) {
+            if (!@hasDecl(SystemUart, "get_or_init")) {
                 // fallback to reinitializing the UART
                 return init(config);
             }
             return Self{
-                .internal = try SystemUart.getOrInit(config),
+                .internal = try SystemUart.get_or_init(config),
             };
         }
 
         pub fn can_read(self: Self) bool {
-            return self.internal.canRead();
+            return self.internal.can_read();
         }
 
         pub fn can_write(self: Self) bool {
-            return self.internal.canWrite();
+            return self.internal.can_write();
         }
 
         pub fn reader(self: Self) Reader {


### PR DESCRIPTION
This is to follow the STM32 HAL implementations in stmicro-stm32, which were converted to snake_case() when they were extracted from the main microzig repository into their own separate repository.