### PR TITLE
Fix mmio toggle

### DIFF
--- a/core/src/mmio.zig
+++ b/core/src/mmio.zig
@@ -47,7 +47,7 @@ pub fn Mmio(comptime PackedT: type) type {
         pub inline fn toggle(addr: *volatile Self, fields: anytype) void {
             var val = read(addr);
             inline for (@typeInfo(@TypeOf(fields)).Struct.fields) |field| {
-                @field(val, @tagName(field.default_value.?)) = !@field(val, @tagName(field.default_value.?));
+                @field(val, field.name) = @field(val, field.name) ^ @field(fields, field.name);
             }
             write(addr, val);
         }

--- a/tools/regz/src/mmio.zig
+++ b/tools/regz/src/mmio.zig
@@ -41,7 +41,7 @@ pub fn Mmio(comptime size: u8, comptime PackedT: type) type {
         pub inline fn toggle(addr: *volatile Self, fields: anytype) void {
             var val = read(addr);
             inline for (@typeInfo(@TypeOf(fields)).Struct.fields) |field| {
-                @field(val, @tagName(field.default_value.?)) = !@field(val, @tagName(field.default_value.?));
+                @field(val, field.name) = @field(val, field.name) ^ @field(fields, field.name);
             }
             write(addr, val);
         }


### PR DESCRIPTION
In zig 0.11.0, struct field `default_value` always returns an opaque pointer which can't be used in `@tagName`.
I'm not entirely sure how the original API worked but this implementation allows selective toggling of bits in each field of registers via a xor mask:
```
REG.toggle(.{ .FIELD = MASK });
```