### PR TITLE
Use root build for chips, hals, and boards

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -495,7 +495,7 @@ pub fn addFirmware(
     };
     errdefer fw.output_files.deinit();
 
-    fw.modules.chip = micro_build.createModule(.{
+    fw.modules.chip = mz.b.createModule(.{
         .source_file = chip_source,
         .dependencies = &.{
             .{ .name = "microzig", .module = fw.modules.microzig },
@@ -503,7 +503,7 @@ pub fn addFirmware(
     });
     fw.modules.microzig.dependencies.put("chip", fw.modules.chip) catch @panic("out of memory");
 
-    fw.modules.cpu = micro_build.createModule(.{
+    fw.modules.cpu = mz.b.createModule(.{
         .source_file = cpu.source_file,
         .dependencies = &.{
             .{ .name = "microzig", .module = fw.modules.microzig },
@@ -512,7 +512,7 @@ pub fn addFirmware(
     fw.modules.microzig.dependencies.put("cpu", fw.modules.cpu) catch @panic("out of memory");
 
     if (maybe_hal) |hal| {
-        fw.modules.hal = micro_build.createModule(.{
+        fw.modules.hal = mz.b.createModule(.{
             .source_file = hal.source_file,
             .dependencies = &.{
                 .{ .name = "microzig", .module = fw.modules.microzig },
@@ -522,7 +522,7 @@ pub fn addFirmware(
     }
 
     if (maybe_board) |brd| {
-        fw.modules.board = micro_build.createModule(.{
+        fw.modules.board = mz.b.createModule(.{
             .source_file = brd.source_file,
             .dependencies = &.{
                 .{ .name = "microzig", .module = fw.modules.microzig },


### PR DESCRIPTION
The reason behind this change is that I'm unable to specify a chip, hal, or board definition in a local project and that's a pattern that we explicitly want to handle. This means packages must provide an absolute path to their files, which is already done throughout our small ecosystem.

In the future I'd like to change the API so package creators or those vendoring everything locally give a relative path.