### PR TITLE
hal: stm32f407: Added stm32f407 source file to the build configuration

### DIFF
--- a/board-support/stmicro-stm32/build.zig
+++ b/board-support/stmicro-stm32/build.zig
@@ -67,6 +67,9 @@ pub const chips = struct {
                 .json = .{ .cwd_relative = build_root ++ "/src/chips/STM32F407.json" },
             },
         },
+        .hal = .{
+            .source_file = .{ .cwd_relative = build_root ++ "/src/hals/STM32F407.zig" },
+        },
     };
 
     pub const stm32f429zit6u = MicroZig.Target{


### PR DESCRIPTION
Added the STM32F407 hal source file, so that we can build a zig program targeting the F407