### PR TITLE
Fix setting pull direction in pinConfig

### DIFF
--- a/bsp/raspberrypi/rp2040/src/hal/pins.zig
+++ b/bsp/raspberrypi/rp2040/src/hal/pins.zig
@@ -522,7 +522,7 @@ pub const GlobalConfiguration = struct {
                     if (comptime pin_config.get_direction() != .in)
                         @compileError("Only input pins can have pull up/down enabled");
 
-                    gpio.set_pull(gpio_num, pull);
+                    gpio.num(gpio_num).set_pull(pull);
                 };
         }
 


### PR DESCRIPTION
Was getting the error
```
error: root struct of file 'hal.gpio' has no member named 'set_pull'
                    gpio.set_pull(gpio_num, pull);
                    ~~~~^~~~~~~~~
```
I don't know if this is the best way to do this, but it seems to work.