### PR TITLE
fix regz output for sycl-badge

### DIFF
--- a/tools/regz/src/gen.zig
+++ b/tools/regz/src/gen.zig
@@ -657,10 +657,10 @@ fn write_registers_base(
         if (offset > size)
             @panic("peripheral size too small, parsing should have caught this");
 
-        //if (offset != size)
-        //    try writer.print("padding: [{}]u8,\n", .{
-        //        size - offset,
-        //    });
+        if (offset != size)
+            try writer.print("padding: [{}]u8,\n", .{
+                size - offset,
+            });
     }
 
     try out_writer.writeAll(buffer.items);


### PR DESCRIPTION
This padding is necessary for types inside arrays so that the array elements are correctly spaced.

Unblocks [sycl-badge](https://github.com/ZigEmbeddedGroup/sycl-badge)