### PR TITLE
Properly export startup logic for espressif-riscv

### DIFF
--- a/bsp/espressif/esp/src/cpus/espressif-riscv.zig
+++ b/bsp/espressif/esp/src/cpus/espressif-riscv.zig
@@ -61,7 +61,7 @@ pub const startup_logic = struct {
 
     extern fn microzig_main() noreturn;
 
-    export fn _start() linksection("microzig_flash_start") callconv(.C) noreturn {
+    pub fn _start() linksection("microzig_flash_start") callconv(.C) noreturn {
         microzig.cpu.disable_interrupts();
         asm volatile ("mv sp, %[eos]"
             :
@@ -103,5 +103,7 @@ pub const startup_logic = struct {
 };
 
 pub fn export_startup_logic() void {
-    // no op as it's already being exported
+    @export(startup_logic._start, .{
+        .name = "_start",
+    });
 }


### PR DESCRIPTION
This fixes an issue where startup logic was not properly exported for the espressif-riscv CPU, leading to failed builds at first and lack of direct boot bytes on second and further builds.

The issue can be reproduced by building the `espressif/esp` example with Zig `0.12`.

First output:
```bash
install
└─ install generated to esp32-c3_blinky.bin
   └─ objcopy generated
      └─ zig build-exe esp32-c3_blinky Debug riscv32-freestanding-eabi failure
error: warning(link): unexpected LLD stderr:
ld.lld: warning: cannot find entry symbol _start; not setting start address
```