### PR TITLE
Linking and linker relaxation fixes

### DIFF
--- a/bsp/espressif/esp/src/cpus/espressif-riscv.zig
+++ b/bsp/espressif/esp/src/cpus/espressif-riscv.zig
@@ -67,7 +67,12 @@ pub const startup_logic = struct {
             :
             : [eos] "r" (@as(u32, microzig.config.end_of_stack)),
         );
-        asm volatile ("la gp, __global_pointer$");
+        asm volatile (
+            \\.option push
+            \\.option norelax
+            \\la gp, __global_pointer$
+            \\.option pop
+        );
         microzig.cpu.setStatusBit(.mtvec, microzig.config.end_of_stack);
         root.initialize_system_memories();
         microzig_main();

--- a/build/src/generate_linkerscript.zig
+++ b/build/src/generate_linkerscript.zig
@@ -138,6 +138,14 @@ pub fn main() !void {
             \\
         );
     }
+
+    switch (program_args.cpu_arch) {
+        .riscv32, .riscv64 => try writer.writeAll(
+            \\  PROVIDE(__global_pointer$ = microzig_data_start + 0x800);
+        ),
+        else => {},
+    }
+
     try writer.writeAll("}\n");
 
     // TODO: Assert that the flash can actually hold all data!

--- a/build/src/generate_linkerscript.zig
+++ b/build/src/generate_linkerscript.zig
@@ -121,8 +121,9 @@ pub fn main() !void {
             \\  .data :
             \\  {
             \\     microzig_data_start = .;
-            \\     *(.rodata*)
+            \\     *(.sdata*)
             \\     *(.data*)
+            \\     *(.rodata*)
             \\     microzig_data_end = .;
             \\  } > ram0 AT> flash0
             \\


### PR DESCRIPTION
This PR fixes the following issues:
1. Accounts for the possibility of the `.sdata*` sections being generated. These sections are created by compilers in order to optimize access for small data on some architectures. Right now this breaks the `espressif/esp` example the `.sdata` output section is being automatically placed at the wrong place, creating an incorrect and enormous binary.
2. Properly provide the `__global_pointer$` used in the RISC-V architecture CPUs to initialize the GP register. This register is then used in order to improve access times to frequently used data, as long as it is +-2048 bytes away by fitting the offset in the immideate part of the instruction.
3. Disables relaxation when initializing the GP register on `espressif-riscv`

References:
https://www.sifive.com/blog/all-aboard-part-3-linker-relaxation-in-riscv-toolchain
https://five-embeddev.com/quickref/global_pointer.html
https://d3s.mff.cuni.cz/files/teaching/nswi200/202324/doc/riscv-abi.pdf