### PR TITLE
Use app provided panic handler if it exists

### DIFF
--- a/core/src/start.zig
+++ b/core/src/start.zig
@@ -3,12 +3,7 @@ const microzig = @import("microzig");
 const app = @import("app");
 
 // Use microzig panic handler if not defined by an application
-pub usingnamespace if (!@hasDecl(app, "panic"))
-    struct {
-        pub const panic = microzig.panic;
-    }
-else
-    struct {};
+pub const panic = if (!@hasDecl(app, "panic")) microzig.panic else app.panic;
 
 pub const VectorTableOptions = if (@hasDecl(microzig.chip, "VectorTable"))
 blk: {


### PR DESCRIPTION
Before, Zig didn't find my app provided panic handler.

Also, manages to avoid the use of `usingnamespace`.