### PR TITLE
rp2040: remove redendant code in I2C.apply()

### DIFF
--- a/bsp/raspberrypi/rp2040/src/hal/i2c.zig
+++ b/bsp/raspberrypi/rp2040/src/hal/i2c.zig
@@ -79,13 +79,6 @@ pub const I2C = enum(u1) {
 
         i2c.disable();
 
-        regs.IC_ENABLE.write(.{
-            .ENABLE = .{ .value = .DISABLED },
-            .ABORT = .{ .value = .DISABLE },
-            .TX_CMD_BLOCK = .{ .value = .NOT_BLOCKED },
-            .padding = 0,
-        });
-
         // Configure as a fast-mode master with RepStart support, 7-bit addresses
         regs.IC_CON.write(.{
             .MASTER_MODE = .{ .value = .ENABLED },


### PR DESCRIPTION
A call to `i2c.disable()` was immediately followed by an inlined copy of its body. I2C is still working for me with this change.