### PR TITLE
Initial ESP32-C3 GPIO HAL driver

### DIFF
--- a/bsp/espressif/esp/src/example/blinky.zig
+++ b/bsp/espressif/esp/src/example/blinky.zig
@@ -1,57 +1,71 @@
 const std = @import("std");
 const microzig = @import("microzig");
 const peripherals = microzig.chip.peripherals;
+const gpio = microzig.hal.gpio;
+const uart = microzig.hal.uart;
 const TIMG0 = peripherals.TIMG0;
 const RTC_CNTL = peripherals.RTC_CNTL;
 const INTERRUPT_CORE0 = peripherals.INTERRUPT_CORE0;
-const GPIO = peripherals.GPIO;
 
 const dogfood: u32 = 0x50D83AA1;
 const super_dogfood: u32 = 0x8F1D312A;
 
+const LED_R_PIN = 3; // GPIO
+const LED_G_PIN = 4; // GPIO
+const LED_B_PIN = 8; // GPIO
+
+const led_pins = [_]u32{
+    LED_R_PIN,
+    LED_G_PIN,
+    LED_B_PIN,
+};
+
 pub fn main() !void {
+    // Feed and disable watchdog 0
     TIMG0.WDTWPROTECT.raw = dogfood;
     TIMG0.WDTCONFIG0.raw = 0;
     TIMG0.WDTWPROTECT.raw = 0;
 
+    // Feed and disable rtc watchdog
     RTC_CNTL.WDTWPROTECT.raw = dogfood;
     RTC_CNTL.WDTCONFIG0.raw = 0;
     RTC_CNTL.WDTWPROTECT.raw = 0;
 
+    // Feed and disable rtc super watchdog
     RTC_CNTL.SWD_WPROTECT.raw = super_dogfood;
     RTC_CNTL.SWD_CONF.modify(.{ .SWD_DISABLE = 1 });
     RTC_CNTL.SWD_WPROTECT.raw = 0;
 
+    // Disable all interrupts
     INTERRUPT_CORE0.CPU_INT_ENABLE.raw = 0;
 
-    microzig.hal.gpio.init(LED_R_PIN, .{
-        .direction = .output,
-        .direct_io = true,
-    });
-    microzig.hal.gpio.init(LED_G_PIN, .{
-        .direction = .output,
-        .direct_io = true,
-    });
-    microzig.hal.gpio.init(LED_B_PIN, .{
-        .direction = .output,
-        .direct_io = true,
-    });
+    var pin_config = gpio.Pin.default_config;
+    pin_config.output_enable = true;
+    pin_config.drive_strength = gpio.DriveStrength.@"40mA";
 
-    microzig.hal.uart.write(0, "Hello from Zig!\r\n");
+    var led_r_pin = gpio.Pin.init(LED_R_PIN, pin_config);
+    var led_g_pin = gpio.Pin.init(LED_G_PIN, pin_config);
+    var led_b_pin = gpio.Pin.init(LED_B_PIN, pin_config);
+
+    uart.write(0, "Hello from Zig!\r\n");
 
     while (true) {
-        GPIO.OUT.modify(.{ .DATA_ORIG = (1 << LED_R_PIN) });
-        microzig.hal.uart.write(0, "R");
+        led_r_pin.write(gpio.Level.high);
+        led_g_pin.write(gpio.Level.low);
+        led_b_pin.write(gpio.Level.low);
+        uart.write(0, "R");
         microzig.core.experimental.debug.busy_sleep(100_000);
-        GPIO.OUT.modify(.{ .DATA_ORIG = (1 << LED_G_PIN) });
-        microzig.hal.uart.write(0, "G");
+
+        led_r_pin.write(gpio.Level.low);
+        led_g_pin.write(gpio.Level.high);
+        led_b_pin.write(gpio.Level.low);
+        uart.write(0, "G");
         microzig.core.experimental.debug.busy_sleep(100_000);
-        GPIO.OUT.modify(.{ .DATA_ORIG = (1 << LED_B_PIN) });
-        microzig.hal.uart.write(0, "B");
+
+        led_r_pin.write(gpio.Level.low);
+        led_b_pin.write(gpio.Level.low);
+        led_b_pin.write(gpio.Level.high);
+        uart.write(0, "B");
         microzig.core.experimental.debug.busy_sleep(100_000);
     }
 }
-
-const LED_R_PIN = 3; // GPIO
-const LED_G_PIN = 16; // GPIO
-const LED_B_PIN = 17; // GPIO

--- a/bsp/espressif/esp/src/example/blinky.zig
+++ b/bsp/espressif/esp/src/example/blinky.zig
@@ -10,16 +10,6 @@ const INTERRUPT_CORE0 = peripherals.INTERRUPT_CORE0;
 const dogfood: u32 = 0x50D83AA1;
 const super_dogfood: u32 = 0x8F1D312A;
 
-const LED_R_PIN = 3; // GPIO
-const LED_G_PIN = 4; // GPIO
-const LED_B_PIN = 8; // GPIO
-
-const led_pins = [_]u32{
-    LED_R_PIN,
-    LED_G_PIN,
-    LED_B_PIN,
-};
-
 pub fn main() !void {
     // Feed and disable watchdog 0
     TIMG0.WDTWPROTECT.raw = dogfood;
@@ -39,13 +29,18 @@ pub fn main() !void {
     // Disable all interrupts
     INTERRUPT_CORE0.CPU_INT_ENABLE.raw = 0;
 
-    var pin_config = gpio.Pin.default_config;
-    pin_config.output_enable = true;
-    pin_config.drive_strength = gpio.DriveStrength.@"40mA";
+    const pin_config = gpio.Pin.Config{
+        .output_enable = true,
+        .drive_strength = gpio.DriveStrength.@"40mA",
+    };
 
-    var led_r_pin = gpio.Pin.init(LED_R_PIN, pin_config);
-    var led_g_pin = gpio.Pin.init(LED_G_PIN, pin_config);
-    var led_b_pin = gpio.Pin.init(LED_B_PIN, pin_config);
+    const led_r_pin = gpio.instance.GPIO3;
+    const led_g_pin = gpio.instance.GPIO4;
+    const led_b_pin = gpio.instance.GPIO5;
+
+    led_r_pin.apply(pin_config);
+    led_g_pin.apply(pin_config);
+    led_b_pin.apply(pin_config);
 
     uart.write(0, "Hello from Zig!\r\n");
 

--- a/bsp/espressif/esp/src/hals/ESP32_C3.zig
+++ b/bsp/espressif/esp/src/hals/ESP32_C3.zig
@@ -1,47 +1,5 @@
 const std = @import("std");
 const microzig = @import("microzig");
-const peripherals = microzig.chip.peripherals;
-const GPIO = peripherals.GPIO;
 
-pub const gpio = struct {
-    fn assertRange(comptime p: comptime_int) void {
-        if (p < 0 or p >= 21)
-            @compileError(std.fmt.comptimePrint("GPIO {} does not exist. GPIO pins can be between 0 and 21", .{p}));
-    }
-
-    pub const Config = struct {
-        function: u8 = 0x80,
-        invert_function: bool = false,
-        direction: microzig.core.experimental.gpio.Direction,
-        direct_io: bool = false,
-        invert_direct_io: bool = false,
-    };
-
-    pub fn init(comptime pin: comptime_int, comptime config: Config) void {
-        assertRange(pin);
-        GPIO.FUNC_OUT_SEL_CFG[pin].modify(.{
-            .OUT_SEL = config.function,
-            .INV_SEL = @intFromBool(config.invert_function),
-            .OEN_SEL = @intFromBool(config.direct_io),
-            .OEN_INV_SEL = @intFromBool(config.invert_direct_io),
-        });
-        switch (config.direction) {
-            .input => GPIO.ENABLE.raw &= ~(@as(u32, 1) << pin),
-            .output => GPIO.ENABLE.raw |= (@as(u32, 1) << pin),
-        }
-    }
-};
-
-pub const uart = struct {
-    fn reg(comptime index: comptime_int) @TypeOf(@field(peripherals, std.fmt.comptimePrint("UART{}", .{index}))) {
-        return @field(peripherals, std.fmt.comptimePrint("UART{}", .{index}));
-    }
-
-    pub fn write(comptime index: comptime_int, slice: []const u8) void {
-        const r = reg(index);
-        for (slice) |c| {
-            while (r.STATUS.read().TXFIFO_CNT > 8) {}
-            r.FIFO.raw = c;
-        }
-    }
-};
+pub const gpio = @import("esp32-c3/gpio.zig");
+pub const uart = @import("esp32-c3/uart.zig");

--- a/bsp/espressif/esp/src/hals/esp32-c3/gpio.zig
+++ b/bsp/espressif/esp/src/hals/esp32-c3/gpio.zig
@@ -1,0 +1,147 @@
+const std = @import("std");
+const microzig = @import("microzig");
+const peripherals = microzig.chip.peripherals;
+const IO_MUX = peripherals.IO_MUX;
+const GPIO = peripherals.GPIO;
+
+pub const Level = enum(u1) {
+    low = 0,
+    high = 1,
+};
+
+pub const DriveStrength = enum(u2) {
+    @"5mA" = 0,
+    @"10mA" = 1,
+    @"20mA" = 2,
+    @"40mA" = 3,
+};
+
+pub const Pin = struct {
+    number: u5,
+
+    pub const Config = struct {
+        input_enable: bool,
+        output_enable: bool,
+        open_drain: bool,
+        pullup_enable: bool,
+        pulldown_enable: bool,
+        input_filter_enable: bool,
+        output_invert: bool,
+        drive_strength: DriveStrength,
+    };
+
+    pub const default_config = Config{
+        .input_enable = false,
+        .output_enable = false,
+        .open_drain = false,
+        .pullup_enable = false,
+        .pulldown_enable = false,
+        .input_filter_enable = false,
+        .output_invert = false,
+        .drive_strength = DriveStrength.@"5mA",
+    };
+
+    pub fn init(number: u5, config: Config) Pin {
+        std.debug.assert(number < 21);
+
+        IO_MUX.GPIO[number].modify(.{
+            .SLP_SEL = 0,
+            .FUN_WPD = @intFromBool(config.pulldown_enable),
+            .FUN_WPU = @intFromBool(config.pullup_enable),
+            .FUN_DRV = @intFromEnum(config.drive_strength),
+            .FILTER_EN = @intFromBool(config.input_filter_enable),
+            .FUN_IE = @intFromBool(config.input_enable),
+            .MCU_SEL = 1,
+        });
+
+        GPIO.FUNC_OUT_SEL_CFG[number].write(.{
+            .OUT_SEL = 0x80,
+            .OEN_SEL = @intFromBool(config.output_enable),
+            .INV_SEL = @intFromBool(config.output_invert),
+            .OEN_INV_SEL = 0,
+            .padding = 0,
+        });
+
+        GPIO.PIN[number].modify(.{
+            .PIN_PAD_DRIVER = @intFromBool(config.open_drain),
+        });
+
+        GPIO.ENABLE_W1TS.write(.{ .ENABLE_W1TS = @as(u17, 1) << number, .padding = 0 });
+
+        return Pin{
+            .number = number,
+        };
+    }
+
+    pub fn deinit(self: Pin) void {
+        IO_MUX.GPIO[self.number].write_raw(0x00);
+        GPIO.FUNC_OUT_SEL_CFG[self.number].write_raw(0x00);
+        GPIO.PIN[self.number].write_raw(0x00);
+        GPIO.ENABLE_W1TC.write(.{ .ENABLE_W1TC = @as(u17, 1) << self.number, .padding = 0 });
+    }
+
+    pub fn set_output_enable(self: Pin, enable: bool) void {
+        GPIO.FUNC_OUT_SEL_CFG[self.number].modify(.{
+            .OEN_SEL = @intFromBool(enable),
+        });
+    }
+
+    pub fn set_open_drain(self: Pin, enable: bool) void {
+        GPIO.PIN[self.number].modify(.{
+            .PIN_PAD_DRIVER = @intFromBool(enable),
+        });
+    }
+
+    pub fn set_pullup(self: Pin, enable: bool) void {
+        IO_MUX.GPIO[self.number].modify(.{
+            .MCU_WPU = @intFromBool(enable),
+        });
+    }
+
+    pub fn set_pulldown(self: Pin, enable: bool) void {
+        IO_MUX.GPIO[self.number].modify(.{
+            .MCU_WPD = @intFromBool(enable),
+        });
+    }
+
+    pub fn set_output_invert(self: Pin, enable: bool) void {
+        GPIO.FUNC_OUT_SEL_CFG[self.number].modify(.{
+            .OEN_INV_SEL = enable,
+        });
+    }
+
+    pub fn set_output_drive_strength(self: Pin, strength: DriveStrength) void {
+        IO_MUX.GPIO[self.number].modify(.{
+            .FUN_DRV = @intFromEnum(strength),
+        });
+    }
+
+    pub fn set_input_filter(self: Pin, enable: bool) void {
+        IO_MUX.GPIO[self.number].modify(.{
+            .FILTER_EN = @intFromBool(enable),
+        });
+    }
+
+    pub fn write(self: Pin, level: Level) void {
+        std.debug.assert(GPIO.FUNC_OUT_SEL_CFG[self.number].read().OEN_SEL == 1);
+
+        switch (level) {
+            Level.low => GPIO.OUT_W1TC.write(.{ .OUT_W1TC = @as(u17, 1) << self.number, .padding = 0 }),
+            Level.high => GPIO.OUT_W1TS.write(.{ .OUT_W1TS = @as(u17, 1) << self.number, .padding = 0 }),
+        }
+    }
+
+    pub fn read(self: Pin) Level {
+        std.debug.assert(IO_MUX.GPIO[self.number].FUN_IE == 1);
+
+        return @enumFromInt(GPIO.IN.raw >> self.number & 0x01);
+    }
+
+    pub fn toggle(self: Pin) void {
+        if ((GPIO.OUT.raw >> self.number & 0x01) == 0) {
+            write(self, Level.high);
+        } else {
+            write(self, Level.low);
+        }
+    }
+};

--- a/bsp/espressif/esp/src/hals/esp32-c3/gpio.zig
+++ b/bsp/espressif/esp/src/hals/esp32-c3/gpio.zig
@@ -131,6 +131,12 @@ pub const Pin = struct {
         }
     }
 
+    pub fn get_output_state(self: Pin) Level {
+        std.debug.assert(GPIO.FUNC_OUT_SEL_CFG[self.number].read().OEN_SEL == 1);
+
+        return @enumFromInt((GPIO.OUT.raw >> self.number & 0x01));
+    }
+
     pub fn read(self: Pin) Level {
         std.debug.assert(IO_MUX.GPIO[self.number].FUN_IE == 1);
 
@@ -138,10 +144,9 @@ pub const Pin = struct {
     }
 
     pub fn toggle(self: Pin) void {
-        if ((GPIO.OUT.raw >> self.number & 0x01) == 0) {
-            write(self, Level.high);
-        } else {
-            write(self, Level.low);
+        switch (get_output_state(self)) {
+            Level.low => write(self, Level.high),
+            Level.high => write(self, Level.low),
         }
     }
 };

--- a/bsp/espressif/esp/src/hals/esp32-c3/gpio.zig
+++ b/bsp/espressif/esp/src/hals/esp32-c3/gpio.zig
@@ -66,6 +66,13 @@ pub const Pin = struct {
             .PIN_PAD_DRIVER = @intFromBool(config.open_drain),
         });
 
+        // NOTE: Assert that the USB_SERIAL_JTAG peripheral which uses pins GPIO18 and GPIO19
+        //       is disabled and USB pullup/down resistors are disabled.
+        if (number == 18 or number == 19) {
+            const usb_conf0 = peripherals.USB_DEVICE.CONF0.read();
+            std.debug.assert(usb_conf0.USB_PAD_ENABLE == 0 and usb_conf0.DP_PULLUP == 0 and usb_conf0.DP_PULLDOWN == 0 and usb_conf0.DM_PULLUP == 0 and usb_conf0.DM_PULLDOWN == 0);
+        }
+
         GPIO.ENABLE_W1TS.write(.{ .ENABLE_W1TS = @as(u17, 1) << number, .padding = 0 });
 
         return Pin{

--- a/bsp/espressif/esp/src/hals/esp32-c3/gpio.zig
+++ b/bsp/espressif/esp/src/hals/esp32-c3/gpio.zig
@@ -20,25 +20,14 @@ pub const Pin = struct {
     number: u5,
 
     pub const Config = struct {
-        input_enable: bool,
-        output_enable: bool,
-        open_drain: bool,
-        pullup_enable: bool,
-        pulldown_enable: bool,
-        input_filter_enable: bool,
-        output_invert: bool,
-        drive_strength: DriveStrength,
-    };
-
-    pub const default_config = Config{
-        .input_enable = false,
-        .output_enable = false,
-        .open_drain = false,
-        .pullup_enable = false,
-        .pulldown_enable = false,
-        .input_filter_enable = false,
-        .output_invert = false,
-        .drive_strength = DriveStrength.@"5mA",
+        input_enable: bool = false,
+        output_enable: bool = false,
+        open_drain: bool = false,
+        pullup_enable: bool = false,
+        pulldown_enable: bool = false,
+        input_filter_enable: bool = false,
+        output_invert: bool = false,
+        drive_strength: DriveStrength = DriveStrength.@"5mA",
     };
 
     pub fn init(number: u5, config: Config) Pin {

--- a/bsp/espressif/esp/src/hals/esp32-c3/uart.zig
+++ b/bsp/espressif/esp/src/hals/esp32-c3/uart.zig
@@ -1,0 +1,17 @@
+const std = @import("std");
+const microzig = @import("microzig");
+const peripherals = microzig.chip.peripherals;
+
+const UART = peripherals.UART;
+
+fn reg(comptime index: comptime_int) @TypeOf(@field(peripherals, std.fmt.comptimePrint("UART{}", .{index}))) {
+    return @field(peripherals, std.fmt.comptimePrint("UART{}", .{index}));
+}
+
+pub fn write(comptime index: comptime_int, slice: []const u8) void {
+    const r = reg(index);
+    for (slice) |c| {
+        while (r.STATUS.read().TXFIFO_CNT > 8) {}
+        r.FIFO.raw = c;
+    }
+}

--- a/examples/espressif/esp/src/blinky.zig
+++ b/examples/espressif/esp/src/blinky.zig
@@ -10,16 +10,6 @@ const INTERRUPT_CORE0 = peripherals.INTERRUPT_CORE0;
 const dogfood: u32 = 0x50D83AA1;
 const super_dogfood: u32 = 0x8F1D312A;
 
-const LED_R_PIN = 3; // GPIO
-const LED_G_PIN = 4; // GPIO
-const LED_B_PIN = 5; // GPIO
-
-const led_pins = [_]u32{
-    LED_R_PIN,
-    LED_G_PIN,
-    LED_B_PIN,
-};
-
 pub fn main() !void {
     // Feed and disable watchdog 0
     TIMG0.WDTWPROTECT.raw = dogfood;
@@ -44,9 +34,13 @@ pub fn main() !void {
         .drive_strength = gpio.DriveStrength.@"40mA",
     };
 
-    var led_r_pin = gpio.Pin.init(LED_R_PIN, pin_config);
-    var led_g_pin = gpio.Pin.init(LED_G_PIN, pin_config);
-    var led_b_pin = gpio.Pin.init(LED_B_PIN, pin_config);
+    const led_r_pin = gpio.instance.GPIO3;
+    const led_g_pin = gpio.instance.GPIO4;
+    const led_b_pin = gpio.instance.GPIO5;
+
+    led_r_pin.apply(pin_config);
+    led_g_pin.apply(pin_config);
+    led_b_pin.apply(pin_config);
 
     uart.write(0, "Hello from Zig!\r\n");
 

--- a/examples/espressif/esp/src/blinky.zig
+++ b/examples/espressif/esp/src/blinky.zig
@@ -39,9 +39,10 @@ pub fn main() !void {
     // Disable all interrupts
     INTERRUPT_CORE0.CPU_INT_ENABLE.raw = 0;
 
-    var pin_config = gpio.Pin.default_config;
-    pin_config.output_enable = true;
-    pin_config.drive_strength = gpio.DriveStrength.@"40mA";
+    const pin_config = gpio.Pin.Config{
+        .output_enable = true,
+        .drive_strength = gpio.DriveStrength.@"40mA",
+    };
 
     var led_r_pin = gpio.Pin.init(LED_R_PIN, pin_config);
     var led_g_pin = gpio.Pin.init(LED_G_PIN, pin_config);


### PR DESCRIPTION
This adds a first iteration of the `ESP32-C3` (later to be universal) GPIO HAL driver, and factors it out into its own file.