### PR TITLE
fix(rp2040) apply broken codegen workaround to both busy loop

### DIFF
--- a/bsp/raspberrypi/rp2040/src/hal/hw.zig
+++ b/bsp/raspberrypi/rp2040/src/hal/hw.zig
@@ -20,27 +20,27 @@ const set_bits = @as(u32, 0x2) << 12;
 const clear_bits = @as(u32, 0x3) << 12;
 
 pub fn clear_alias_raw(ptr: anytype) *volatile u32 {
-    return @as(*volatile u32, @ptrFromInt(@intFromPtr(ptr) | clear_bits));
+    return @ptrFromInt(@intFromPtr(ptr) | clear_bits);
 }
 
 pub fn set_alias_raw(ptr: anytype) *volatile u32 {
-    return @as(*volatile u32, @ptrFromInt(@intFromPtr(ptr) | set_bits));
+    return @ptrFromInt(@intFromPtr(ptr) | set_bits);
 }
 
 pub fn xor_alias_raw(ptr: anytype) *volatile u32 {
-    return @as(*volatile u32, @ptrFromInt(@intFromPtr(ptr) | xor_bits));
+    return @ptrFromInt(@intFromPtr(ptr) | xor_bits);
 }
 
 pub fn clear_alias(ptr: anytype) @TypeOf(ptr) {
-    return @as(@TypeOf(ptr), @ptrFromInt(@intFromPtr(ptr) | clear_bits));
+    return @ptrFromInt(@intFromPtr(ptr) | clear_bits);
 }
 
 pub fn set_alias(ptr: anytype) @TypeOf(ptr) {
-    return @as(@TypeOf(ptr), @ptrFromInt(@intFromPtr(ptr) | set_bits));
+    return @ptrFromInt(@intFromPtr(ptr) | set_bits);
 }
 
 pub fn xor_alias(ptr: anytype) @TypeOf(ptr) {
-    return @as(@TypeOf(ptr), @ptrFromInt(@intFromPtr(ptr) | xor_bits));
+    return @ptrFromInt(@intFromPtr(ptr) | xor_bits);
 }
 
 pub inline fn tight_loop_contents() void {


### PR DESCRIPTION
And also remove couple of redundant `@as` usages.

Partially fixes #214 