### PR TITLE
RP2040 Uart Refactor

### DIFF
--- a/bsp/raspberrypi/rp2040/src/hal.zig
+++ b/bsp/raspberrypi/rp2040/src/hal.zig
@@ -60,4 +60,5 @@ test "hal tests" {
     _ = pio;
     _ = usb;
     _ = i2c;
+    _ = uart;
 }

--- a/bsp/raspberrypi/rp2040/src/hal/uart.zig
+++ b/bsp/raspberrypi/rp2040/src/hal/uart.zig
@@ -1,16 +1,14 @@
 const std = @import("std");
 const microzig = @import("microzig");
 const peripherals = microzig.chip.peripherals;
-const UART0 = peripherals.UART0;
-const UART1 = peripherals.UART1;
+const UART0_reg = peripherals.UART0;
+const UART1_reg = peripherals.UART1;
 
 const gpio = @import("gpio.zig");
 const clocks = @import("clocks.zig");
 const resets = @import("resets.zig");
 const time = @import("time.zig");
 const dma = @import("dma.zig");
-
-const assert = std.debug.assert;
 
 const UartRegs = microzig.chip.types.peripherals.UART0;
 
@@ -32,27 +30,107 @@ pub const Parity = enum {
     odd,
 };
 
+pub const ConfigError = error{
+    UnsupportedBaudRate,
+};
+
 pub const Config = struct {
     clock_config: clocks.GlobalConfiguration,
-    tx_pin: ?gpio.Pin = null,
-    rx_pin: ?gpio.Pin = null,
     baud_rate: u32,
     word_bits: WordBits = .eight,
     stop_bits: StopBits = .one,
     parity: Parity = .none,
 };
 
-pub fn num(n: u1) UART {
-    return @as(UART, @enumFromInt(n));
+pub const TransactionError = error{
+    OverrunError,
+    BreakError,
+    ParityError,
+    FramingError,
+    Timeout,
+};
+
+pub const ErrorStates = packed struct(u4) {
+    overrun_error: bool = false,
+    break_error: bool = false,
+    parity_error: bool = false,
+    framing_error: bool = false,
+};
+
+fn comptime_fail_or_error(msg: []const u8, fmt_args: anytype, err: ConfigError) ConfigError {
+    if (@inComptime()) {
+        @compileError(std.fmt.comptimePrint(msg, fmt_args));
+    } else {
+        return err;
+    }
 }
 
+/// Checks against datasheet settings for invalid baud rates.
+///
+/// Returns an error at runtime, and raises a compile error at comptime.
+fn validate_baudrate(baud_rate: u32, peri_freq: u32) ConfigError!void {
+    if (peri_freq < 16 * baud_rate) {
+        return comptime_fail_or_error(
+            "Peripheral clock: {d} too low for baudrate: {d}",
+            .{ peri_freq, baud_rate },
+            ConfigError.UnsupportedBaudRate,
+        );
+    } else if ((peri_freq / 65535) > 16 * baud_rate) {
+        return comptime_fail_or_error(
+            "Peripheral clock: {d} too high for baudrate: {d}",
+            .{ peri_freq, baud_rate },
+            ConfigError.UnsupportedBaudRate,
+        );
+    }
+}
+
+test "uart.validate_baudrate" {
+    const peripheral_clk = 125_000_000;
+    inline for (&.{
+        4800,
+        9600,
+        19200,
+        38400,
+        57600,
+        115200,
+        230400,
+        460800,
+        921600,
+    }) |baud_rate| {
+        try std.testing.expectEqual(validate_baudrate(baud_rate, peripheral_clk), {});
+    }
+    inline for (&.{
+        0,
+        peripheral_clk,
+        peripheral_clk / 2,
+        peripheral_clk / 4,
+        peripheral_clk / 8,
+    }) |baud_rate| {
+        try std.testing.expectError(ConfigError.UnsupportedBaudRate, validate_baudrate(baud_rate, peripheral_clk));
+    }
+}
+
+pub const instance = struct {
+    pub const UART0: UART = @enumFromInt(0);
+    pub const UART1: UART = @enumFromInt(1);
+    pub fn num(n: u1) UART {
+        return @enumFromInt(n);
+    }
+};
+
+/// An API for interacting with the RP2040's UART driver.
+///
+/// Note: Assumes proper GPIO configuration, does NOT configure GPIO pins.
+///
+/// Features of the peripheral that are explicitly NOT supported by this API are:
+/// - CTS/RTS Hardware flow control
+/// - Interrupt Driven/Asynchronous writes/reads
+/// - DMA based writes/reads
 pub const UART = enum(u1) {
     _,
 
-    const WriteError = error{};
-    const ReadError = error{};
-    pub const Writer = std.io.Writer(UART, WriteError, write);
-    pub const Reader = std.io.Reader(UART, ReadError, read);
+    pub const Writer = std.io.GenericWriter(UART, TransactionError, generic_writer_fn);
+    pub const Reader = std.io.GenericReader(UART, TransactionError, generic_reader_fn);
 
     pub fn writer(uart: UART) Writer {
         return .{ .context = uart };
@@ -64,63 +142,107 @@ pub const UART = enum(u1) {
 
     fn get_regs(uart: UART) *volatile UartRegs {
         return switch (@intFromEnum(uart)) {
-            0 => UART0,
-            1 => UART1,
+            0 => UART0_reg,
+            1 => UART1_reg,
         };
     }
 
-    pub fn apply(uart: UART, comptime config: Config) void {
-        assert(config.baud_rate > 0);
-
+    fn apply_internal(uart: UART, config: Config) void {
         const uart_regs = uart.get_regs();
         const peri_freq = config.clock_config.peri.?.output_freq;
         uart.set_baudrate(config.baud_rate, peri_freq);
         uart.set_format(config.word_bits, config.stop_bits, config.parity);
+        uart_regs.UARTLCR_H.modify(.{ .FEN = 1 });
+
+        // always enable DREQ signals -- no harm if dma isn't listening
+        uart_regs.UARTDMACR.modify(.{
+            .TXDMAE = 1,
+            .RXDMAE = 1,
+        });
 
         uart_regs.UARTCR.modify(.{
             .UARTEN = 1,
             .TXE = 1,
             .RXE = 1,
         });
-
-        uart_regs.UARTLCR_H.modify(.{ .FEN = 1 });
-
-        // - always enable DREQ signals -- no harm if dma isn't listening
-        uart_regs.UARTDMACR.modify(.{
-            .TXDMAE = 1,
-            .RXDMAE = 1,
-        });
-
-        // TODO comptime assertions
-        if (config.tx_pin) |tx_pin| tx_pin.set_function(.uart);
-        if (config.rx_pin) |rx_pin| rx_pin.set_function(.uart);
     }
 
-    pub fn is_readable(uart: UART) bool {
+    /// Apply a configuration to the UART peripheral, takes in a comptime known config to enable
+    /// validation of parameters at compile time. See apply_runtime() if configuration using
+    /// parameters known ONLY at runtime is needed.
+    pub fn apply(uart: UART, comptime config: Config) void {
+        const peri_freq = config.clock_config.peri.?.output_freq;
+        comptime validate_baudrate(config.baud_rate, peri_freq) catch unreachable;
+        uart.apply_internal(config);
+    }
+
+    /// Same as apply(), but due to parameters being runtime known, returns an error on invalid
+    /// configurations.
+    pub fn apply_runtime(uart: UART, config: Config) ConfigError!void {
+        const peri_freq = config.clock_config.peri.?.output_freq;
+        try validate_baudrate(config.baud_rate, peri_freq);
+        uart.apply_internal(config);
+    }
+
+    /// Disable Uart transmission, pre-fill the TX FIFO as much as possible, and then re-enable to start transmission.
+    fn prime_tx_fifo(uart: UART, src: []const u8) usize {
+        const uart_regs = uart.get_regs();
+        uart_regs.UARTCR.modify(.{
+            .TXE = 0,
+        });
+        var tx_remaining = src.len;
+        while (tx_remaining > 0 and uart.is_writeable()) {
+            uart_regs.UARTDR.write_raw(src[src.len - tx_remaining]);
+            tx_remaining -= 1;
+        }
+        uart_regs.UARTCR.modify(.{
+            .TXE = 1,
+        });
+        return src.len - tx_remaining;
+    }
+
+    pub inline fn is_readable(uart: UART) bool {
         return (0 == uart.get_regs().UARTFR.read().RXFE);
     }
 
-    pub fn is_writeable(uart: UART) bool {
+    pub inline fn is_writeable(uart: UART) bool {
         return (0 == uart.get_regs().UARTFR.read().TXFF);
     }
 
-    // TODO: implement tx fifo
-    pub fn write(uart: UART, payload: []const u8) WriteError!usize {
-        const uart_regs = uart.get_regs();
-        for (payload) |byte| {
-            while (!uart.is_writeable()) {}
+    pub inline fn is_busy(uart: UART) bool {
+        return (1 == uart.get_regs().UARTFR.read().BUSY);
+    }
 
-            uart_regs.UARTDR.raw = byte;
+    /// Write bytes to uart TX line and block until transaction is complete.
+    ///
+    /// Note that this does NOT disable reception while this is happening,
+    /// so if this takes too long the RX FIFO can potentially overflow.
+    pub fn write_blocking(uart: UART, payload: []const u8, timeout: ?time.Duration) TransactionError!void {
+        var tx_remaining = payload.len - uart.prime_tx_fifo(payload);
+        const uart_regs = uart.get_regs();
+
+        const deadline_maybe: ?time.Absolute = if (timeout) |v| time.make_timeout_us(v.to_us()) else null;
+
+        while (tx_remaining > 0) {
+            while (!uart.is_writeable()) {
+                if (deadline_maybe) |deadline| if (deadline.is_reached()) return TransactionError.Timeout;
+            }
+            uart_regs.UARTDR.write_raw(payload[payload.len - tx_remaining]);
+            tx_remaining -= 1;
         }
 
-        return payload.len;
+        while (uart.is_busy()) {
+            if (deadline_maybe) |deadline| if (deadline.is_reached()) return TransactionError.Timeout;
+        }
     }
 
-    pub fn tx_fifo(uart: UART) *volatile u32 {
-        const regs = uart.get_regs();
-        return @as(*volatile u32, @ptrCast(&regs.UARTDR));
+    /// Wraps write_blocking() for use as a GenericWriter
+    fn generic_writer_fn(uart: UART, buffer: []const u8) TransactionError!usize {
+        try uart.write_blocking(buffer, null);
+        return buffer.len;
     }
 
+    // TODO: Will potentially be modified in a future DMA overhaul
     pub fn dreq_tx(uart: UART) dma.Dreq {
         return switch (@intFromEnum(uart)) {
             0 => .uart0_tx,
@@ -128,23 +250,73 @@ pub const UART = enum(u1) {
         };
     }
 
-    pub fn read(uart: UART, buffer: []u8) ReadError!usize {
+    /// Returns a struct with the current status of UART errors.
+    pub fn get_errors(uart: UART) ErrorStates {
         const uart_regs = uart.get_regs();
-        for (buffer) |*byte| {
-            while (!uart.is_readable()) {}
-
-            // TODO: error checking
-            byte.* = uart_regs.UARTDR.read().DATA;
-        }
-        return buffer.len;
+        const read_val = uart_regs.UARTRSR.read();
+        return .{
+            .overrun_error = read_val.OE == 1,
+            .break_error = read_val.BE == 1,
+            .parity_error = read_val.PE == 1,
+            .framing_error = read_val.FE == 1,
+        };
     }
 
-    pub fn read_word(uart: UART) u8 {
+    /// Clears all UART errors
+    pub inline fn clear_errors(uart: UART) void {
         const uart_regs = uart.get_regs();
-        while (!uart.is_readable()) {}
+        uart_regs.UARTRSR.write(.{
+            .OE = 1,
+            .BE = 1,
+            .PE = 1,
+            .FE = 1,
+            .padding = 0,
+        });
+    }
 
-        // TODO: error checking
-        return uart_regs.UARTDR.read().DATA;
+    /// Returns the first active error encountered while reading a byte from the RX FIFO.
+    fn read_rx_fifo_with_error_check(uart: UART) TransactionError!u8 {
+        const uart_regs = uart.get_regs();
+        const read_val = uart_regs.UARTDR.read();
+
+        if (read_val.OE == 1) {
+            return TransactionError.OverrunError;
+        } else if (read_val.BE == 1) {
+            return TransactionError.BreakError;
+        } else if (read_val.PE == 1) {
+            return TransactionError.ParityError;
+        } else if (read_val.FE == 1) {
+            return TransactionError.FramingError;
+        }
+        return read_val.DATA;
+    }
+
+    /// Read bytes from uart RX line and block until transaction is complete.
+    ///
+    /// Returns a transaction error immediately if it occurs and doesn't
+    /// complete the transaction. Errors are preserved for further inspection,
+    /// so must be cleared with clear_errors() before another transaction is attempted.
+    pub fn read_blocking(uart: UART, buffer: []u8, timeout: ?time.Duration) TransactionError!void {
+        const deadline_maybe: ?time.Absolute = if (timeout) |v| time.make_timeout_us(v.to_us()) else null;
+        for (buffer) |*byte| {
+            while (!uart.is_readable()) {
+                if (deadline_maybe) |deadline| if (deadline.is_reached()) return TransactionError.Timeout;
+            }
+            byte.* = try uart.read_rx_fifo_with_error_check();
+        }
+    }
+
+    /// Convenience function for waiting for a single byte to come across the RX line.
+    pub fn read_word(uart: UART, timeout: ?time.Duration) TransactionError!u8 {
+        var byte: [1]u8 = undefined;
+        try uart.read_blocking(&byte, timeout);
+        return byte[0];
+    }
+
+    /// Wraps read_blocking() for use as a GenericReader
+    fn generic_reader_fn(uart: UART, buffer: []u8) TransactionError!usize {
+        try uart.read_blocking(buffer, null);
+        return buffer.len;
     }
 
     pub fn set_format(
@@ -176,8 +348,7 @@ pub const UART = enum(u1) {
         });
     }
 
-    fn set_baudrate(uart: UART, baud_rate: u32, peri_freq: u32) void {
-        assert(baud_rate > 0);
+    pub fn set_baudrate(uart: UART, baud_rate: u32, peri_freq: u32) void {
         const uart_regs = uart.get_regs();
         const baud_rate_div = (8 * peri_freq / baud_rate);
         var baud_ibrd = @as(u16, @intCast(baud_rate_div >> 7));
@@ -193,19 +364,31 @@ pub const UART = enum(u1) {
         uart_regs.UARTIBRD.write(.{ .BAUD_DIVINT = baud_ibrd, .padding = 0 });
         uart_regs.UARTFBRD.write(.{ .BAUD_DIVFRAC = baud_fbrd, .padding = 0 });
 
-        // just want a write, don't want to change these values
+        // PL011 needs a (dummy) LCR_H write to latch in the divisors.
+        // We don't want to actually change LCR_H contents here.
         uart_regs.UARTLCR_H.modify(.{});
     }
 };
 
 var uart_logger: ?UART.Writer = null;
 
+/// Set a specific uart instance to be used for logging.
+///
+/// Allows system logging over uart via:
+/// pub const microzig_options = .{
+///     .logFn = rp2040.uart.logFn,
+/// };
 pub fn init_logger(uart: UART) void {
     uart_logger = uart.writer();
     uart_logger.?.writeAll("\r\n================ STARTING NEW LOGGER ================\r\n") catch {};
 }
 
-pub fn log(
+/// Disables logging via the uart instance.
+pub fn deinit_logger() void {
+    uart_logger = null;
+}
+
+pub fn logFn(
     comptime level: std.log.Level,
     comptime scope: @TypeOf(.EnumLiteral),
     comptime format: []const u8,

--- a/examples/raspberrypi/rp2040/src/adc.zig
+++ b/examples/raspberrypi/rp2040/src/adc.zig
@@ -7,13 +7,13 @@ const gpio = rp2040.gpio;
 const adc = rp2040.adc;
 const time = rp2040.time;
 
-const uart = rp2040.uart.num(0);
+const uart = rp2040.uart.instance.num(0);
 const baud_rate = 115200;
 const uart_tx_pin = gpio.num(0);
 const uart_rx_pin = gpio.num(1);
 
 pub const microzig_options = .{
-    .logFn = rp2040.uart.log,
+    .logFn = rp2040.uart.logFn,
 };
 
 pub fn main() void {
@@ -21,10 +21,12 @@ pub fn main() void {
         .temp_sensor_enabled = true,
     });
 
+    inline for (&.{ uart_tx_pin, uart_rx_pin }) |pin| {
+        pin.set_function(.uart);
+    }
+
     uart.apply(.{
         .baud_rate = baud_rate,
-        .tx_pin = uart_tx_pin,
-        .rx_pin = uart_rx_pin,
         .clock_config = rp2040.clock_config,
     });
 

--- a/examples/raspberrypi/rp2040/src/flash_id.zig
+++ b/examples/raspberrypi/rp2040/src/flash_id.zig
@@ -6,7 +6,7 @@ const time = rp2040.time;
 const gpio = rp2040.gpio;
 const flash = rp2040.flash;
 
-const uart = rp2040.uart.num(0);
+const uart = rp2040.uart.instance.num(0);
 const baud_rate = 115200;
 const uart_tx_pin = gpio.num(0);
 const uart_rx_pin = gpio.num(1);
@@ -19,14 +19,16 @@ pub fn panic(message: []const u8, _: ?*std.builtin.StackTrace, _: ?usize) noretu
 
 pub const std_options = struct {
     pub const log_level = .debug;
-    pub const logFn = rp2040.uart.log;
+    pub const logFn = rp2040.uart.logFn;
 };
 
 pub fn main() !void {
+    inline for (&.{ uart_tx_pin, uart_rx_pin }) |pin| {
+        pin.set_function(.uart);
+    }
+
     uart.apply(.{
         .baud_rate = baud_rate,
-        .tx_pin = uart_tx_pin,
-        .rx_pin = uart_rx_pin,
         .clock_config = rp2040.clock_config,
     });
 

--- a/examples/raspberrypi/rp2040/src/flash_program.zig
+++ b/examples/raspberrypi/rp2040/src/flash_program.zig
@@ -8,7 +8,7 @@ const gpio = rp2040.gpio;
 const clocks = rp2040.clocks;
 
 const led = gpio.num(25);
-const uart = rp2040.uart.num(0);
+const uart = rp2040.uart.instance.num(0);
 const baud_rate = 115200;
 const uart_tx_pin = gpio.num(0);
 const uart_rx_pin = gpio.num(1);
@@ -24,7 +24,7 @@ pub fn panic(message: []const u8, _: ?*std.builtin.StackTrace, _: ?usize) noretu
 
 pub const microzig_options = .{
     .log_level = .debug,
-    .logFn = rp2040.uart.log,
+    .logFn = rp2040.uart.logFn,
 };
 
 pub fn main() !void {
@@ -32,10 +32,12 @@ pub fn main() !void {
     led.set_direction(.out);
     led.put(1);
 
+    inline for (&.{ uart_tx_pin, uart_rx_pin }) |pin| {
+        pin.set_function(.uart);
+    }
+
     uart.apply(.{
         .baud_rate = baud_rate,
-        .tx_pin = uart_tx_pin,
-        .rx_pin = uart_rx_pin,
         .clock_config = rp2040.clock_config,
     });
 

--- a/examples/raspberrypi/rp2040/src/i2c_bus_scan.zig
+++ b/examples/raspberrypi/rp2040/src/i2c_bus_scan.zig
@@ -8,17 +8,19 @@ const peripherals = microzig.chip.peripherals;
 
 pub const microzig_options = .{
     .log_level = .info,
-    .logFn = rp2040.uart.log,
+    .logFn = rp2040.uart.logFn,
 };
 
-const uart = rp2040.uart.num(0);
+const uart = rp2040.uart.instance.num(0);
 const i2c0 = i2c.instance.num(0);
 
 pub fn main() !void {
+    inline for (&.{ gpio.num(0), gpio.num(1) }) |pin| {
+        pin.set_function(.uart);
+    }
+
     uart.apply(.{
         .baud_rate = 115200,
-        .tx_pin = gpio.num(0),
-        .rx_pin = gpio.num(1),
         .clock_config = rp2040.clock_config,
     });
     rp2040.uart.init_logger(uart);

--- a/examples/raspberrypi/rp2040/src/random.zig
+++ b/examples/raspberrypi/rp2040/src/random.zig
@@ -11,7 +11,7 @@ const clocks = rp2040.clocks;
 const rand = rp2040.rand;
 
 const led = gpio.num(25);
-const uart = rp2040.uart.num(0);
+const uart = rp2040.uart.instance.num(0);
 const baud_rate = 115200;
 const uart_tx_pin = gpio.num(0);
 const uart_rx_pin = gpio.num(1);
@@ -24,7 +24,7 @@ pub fn panic(message: []const u8, _: ?*std.builtin.StackTrace, _: ?usize) noretu
 
 pub const microzig_options = .{
     .log_level = .debug,
-    .logFn = rp2040.uart.log,
+    .logFn = rp2040.uart.logFn,
 };
 
 pub fn main() !void {
@@ -32,10 +32,12 @@ pub fn main() !void {
     led.set_direction(.out);
     led.put(1);
 
+    inline for (&.{ uart_tx_pin, uart_rx_pin }) |pin| {
+        pin.set_function(.uart);
+    }
+
     uart.apply(.{
         .baud_rate = baud_rate,
-        .tx_pin = uart_tx_pin,
-        .rx_pin = uart_rx_pin,
         .clock_config = rp2040.clock_config,
     });
 

--- a/examples/raspberrypi/rp2040/src/uart.zig
+++ b/examples/raspberrypi/rp2040/src/uart.zig
@@ -7,7 +7,7 @@ const gpio = rp2040.gpio;
 const clocks = rp2040.clocks;
 
 const led = gpio.num(25);
-const uart = rp2040.uart.num(0);
+const uart = rp2040.uart.instance.num(0);
 const baud_rate = 115200;
 const uart_tx_pin = gpio.num(0);
 const uart_rx_pin = gpio.num(1);
@@ -20,7 +20,7 @@ pub fn panic(message: []const u8, _: ?*std.builtin.StackTrace, _: ?usize) noretu
 
 pub const microzig_options = .{
     .log_level = .debug,
-    .logFn = rp2040.uart.log,
+    .logFn = rp2040.uart.logFn,
 };
 
 pub fn main() !void {
@@ -28,10 +28,12 @@ pub fn main() !void {
     led.set_direction(.out);
     led.put(1);
 
+    inline for (&.{ uart_tx_pin, uart_rx_pin }) |pin| {
+        pin.set_function(.uart);
+    }
+
     uart.apply(.{
         .baud_rate = baud_rate,
-        .tx_pin = uart_tx_pin,
-        .rx_pin = uart_rx_pin,
         .clock_config = rp2040.clock_config,
     });
 

--- a/examples/raspberrypi/rp2040/src/usb_hid.zig
+++ b/examples/raspberrypi/rp2040/src/usb_hid.zig
@@ -9,7 +9,7 @@ const clocks = rp2040.clocks;
 const usb = rp2040.usb;
 
 const led = gpio.num(25);
-const uart = rp2040.uart.num(0);
+const uart = rp2040.uart.instance.num(0);
 const baud_rate = 115200;
 const uart_tx_pin = gpio.num(0);
 const uart_rx_pin = gpio.num(1);
@@ -60,7 +60,7 @@ pub fn panic(message: []const u8, _: ?*std.builtin.StackTrace, _: ?usize) noretu
 
 pub const microzig_options = .{
     .log_level = .debug,
-    .logFn = rp2040.uart.log,
+    .logFn = rp2040.uart.logFn,
 };
 
 pub fn main() !void {
@@ -68,10 +68,12 @@ pub fn main() !void {
     led.set_direction(.out);
     led.put(1);
 
+    inline for (&.{ uart_tx_pin, uart_rx_pin }) |pin| {
+        pin.set_function(.uart);
+    }
+
     uart.apply(.{
         .baud_rate = baud_rate,
-        .tx_pin = uart_tx_pin,
-        .rx_pin = uart_rx_pin,
         .clock_config = rp2040.clock_config,
     });
 


### PR DESCRIPTION
Should start looking pretty familiar to the other PRs!

The highlights:
- Removed configuration of GPIO pins by driver
- Added full transaction error handling
- Consolidated to new "uart.instance.[]" design pattern
- Added new "apply()" and "apply_runtime()" pattern for dual comptime/runtime error checking
- Added querying of current active UART errors
- Tweaked + renamed to write_blocking() and read_blocking() and added a timeout to match other APIs
- Tweaked syntax for using the UART as a logger + added ability to remove uart as logger