### PR TITLE
Fix rp2040 gpio_clock example.

### DIFF
--- a/examples/raspberrypi/rp2040/src/gpio_clk.zig
+++ b/examples/raspberrypi/rp2040/src/gpio_clk.zig
@@ -12,5 +12,6 @@ const clock_config = clocks.GlobalConfiguration.init(.{
 
 pub fn main() !void {
     gpout0_pin.set_function(.gpck);
+    clock_config.apply();
     while (true) {}
 }


### PR DESCRIPTION
Was testing the clock and couldn’t get it working because the global config never gets applied as is.