### PR TITLE
Update gen.zig to produce just enums

### DIFF
--- a/tools/regz/src/gen.zig
+++ b/tools/regz/src/gen.zig
@@ -1113,10 +1113,7 @@ test "gen.field with named enum" {
         \\            };
         \\
         \\            TEST_REGISTER: mmio.Mmio(packed struct(u8) {
-        \\                TEST_FIELD: packed union {
-        \\                    raw: u4,
-        \\                    value: TEST_ENUM,
-        \\                },
+        \\                TEST_FIELD: TEST_ENUM,
         \\                padding: u4,
         \\            }),
         \\        };
@@ -1142,13 +1139,10 @@ test "gen.field with anonymous enum" {
         \\    pub const peripherals = struct {
         \\        pub const TEST_PERIPHERAL = extern struct {
         \\            TEST_REGISTER: mmio.Mmio(packed struct(u8) {
-        \\                TEST_FIELD: packed union {
-        \\                    raw: u4,
-        \\                    value: enum(u4) {
-        \\                        TEST_ENUM_FIELD1 = 0x0,
-        \\                        TEST_ENUM_FIELD2 = 0x1,
-        \\                        _,
-        \\                    },
+        \\                TEST_FIELD: enum(u4) {
+        \\                    TEST_ENUM_FIELD1 = 0x0,
+        \\                    TEST_ENUM_FIELD2 = 0x1,
+        \\                    _,
         \\                },
         \\                padding: u4,
         \\            }),

--- a/tools/regz/src/gen.zig
+++ b/tools/regz/src/gen.zig
@@ -824,10 +824,12 @@ fn write_fields(
         } else if (db.attrs.@"enum".get(fields[i].id)) |enum_id| {
             if (db.attrs.name.get(enum_id)) |enum_name| {
                 try writer.print(
-                    \\{}: packed union {{
-                    \\    raw: u{},
-                    \\    value: {},
-                    \\}},
+                // These were phased out in favor of using new builtins
+                //    \\{}: packed union {{
+                //    \\    raw: u{},
+                //    \\    value: {},
+                //    \\}},
+                    \\{}: {},
                     \\
                 , .{
                     std.zig.fmtId(name),
@@ -836,9 +838,10 @@ fn write_fields(
                 });
             } else {
                 try writer.print(
-                    \\{}: packed union {{
-                    \\    raw: u{},
-                    \\    value: enum(u{}) {{
+                // \\{}: packed union {{
+                // \\    raw: u{},
+                // \\    value: enum(u{}) {{
+                    \\{}: enum(u{}) {{
                     \\
                 , .{
                     std.zig.fmtId(name),

--- a/tools/regz/src/gen.zig
+++ b/tools/regz/src/gen.zig
@@ -839,7 +839,7 @@ fn write_fields(
                     next.size,
                 });
                 try write_enum_fields(db, enum_id, writer);
-                try writer.writeAll("},\n},\n");
+                try writer.writeAll("},\n");
             }
         } else {
             try writer.print("{}: u{},\n", .{ std.zig.fmtId(name), next.size });

--- a/tools/regz/src/gen.zig
+++ b/tools/regz/src/gen.zig
@@ -824,28 +824,18 @@ fn write_fields(
         } else if (db.attrs.@"enum".get(fields[i].id)) |enum_id| {
             if (db.attrs.name.get(enum_id)) |enum_name| {
                 try writer.print(
-                // These were phased out in favor of using new builtins
-                //    \\{}: packed union {{
-                //    \\    raw: u{},
-                //    \\    value: {},
-                //    \\}},
                     \\{}: {},
                     \\
                 , .{
                     std.zig.fmtId(name),
-                    next.size,
                     std.zig.fmtId(enum_name),
                 });
             } else {
                 try writer.print(
-                // \\{}: packed union {{
-                // \\    raw: u{},
-                // \\    value: enum(u{}) {{
                     \\{}: enum(u{}) {{
                     \\
                 , .{
                     std.zig.fmtId(name),
-                    next.size,
                     next.size,
                 });
                 try write_enum_fields(db, enum_id, writer);


### PR DESCRIPTION
Changed the gen.zig to produce just enums instead of packed unions.