### PR TITLE
ESP 32 blinky example - typo fix

### DIFF
--- a/examples/espressif/esp/src/blinky.zig
+++ b/examples/espressif/esp/src/blinky.zig
@@ -58,7 +58,7 @@ pub fn main() !void {
         microzig.core.experimental.debug.busy_sleep(100_000);
 
         led_r_pin.write(gpio.Level.low);
-        led_b_pin.write(gpio.Level.low);
+        led_g_pin.write(gpio.Level.low);
         led_b_pin.write(gpio.Level.high);
         uart.write(0, "B");
         microzig.core.experimental.debug.busy_sleep(100_000);


### PR DESCRIPTION
I was looking through the example for esp 32 for micro zig and I noticed a small bug/typo in setting blue led to high.