### PR TITLE
Generated STM32 targets with FPU

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -97,6 +97,9 @@ fn generate_parts_db(b: *Build) !Build.LazyPath {
     inline for (ports) |port| {
         const chips_start_idx = chips.items.len;
         inline for (@typeInfo(@field(port[1], "chips")).Struct.decls) |decl| {
+            if (@typeInfo(@TypeOf(@field(@field(port[1], "chips"), decl.name))) != .Struct)
+                continue;
+
             const target = @field(@field(port[1], "chips"), decl.name);
             try chips.append(.{
                 .identifier = decl.name,

--- a/core/build.zig
+++ b/core/build.zig
@@ -79,6 +79,18 @@ pub const cpus = struct {
         },
     };
 
+    pub const cortex_m33f = MicroZig.Cpu{
+        .name = "ARM Cortex-M33F",
+        .root_source_file = .{ .cwd_relative = build_root ++ "/src/cpus/cortex_m.zig" },
+        .target = std.Target.Query{
+            .cpu_arch = .thumb,
+            .cpu_model = .{ .explicit = &std.Target.arm.cpu.cortex_m33 },
+            .cpu_features_add = std.Target.arm.featureSet(&.{.vfp4d16sp}),
+            .os_tag = .freestanding,
+            .abi = .eabihf,
+        },
+    };
+
     pub const cortex_m4 = MicroZig.Cpu{
         .name = "ARM Cortex-M4",
         .root_source_file = .{ .cwd_relative = build_root ++ "/src/cpus/cortex_m.zig" },
@@ -109,10 +121,20 @@ pub const cpus = struct {
             .cpu_arch = .thumb,
             .cpu_model = .{ .explicit = &std.Target.arm.cpu.cortex_m7 },
             .os_tag = .freestanding,
+            .abi = .eabi,
+        },
+    };
+    pub const cortex_m7f = MicroZig.Cpu{
+        .name = "ARM Cortex-M7F",
+        .root_source_file = .{ .cwd_relative = build_root ++ "/src/cpus/cortex_m.zig" },
+        .target = std.zig.CrossTarget{
+            .cpu_arch = .thumb,
+            .cpu_model = .{ .explicit = &std.Target.arm.cpu.cortex_m7 },
+            .cpu_features_add = std.Target.arm.featureSet(&.{.fp_armv8d16sp}),
+            .os_tag = .freestanding,
             .abi = .eabihf,
         },
     };
-
     pub const riscv32_imac = MicroZig.Cpu{
         .name = "RISC-V 32-bit",
         .root_source_file = .{ .cwd_relative = build_root ++ "/src/cpus/riscv32.zig" },

--- a/port/stmicro/stm32/src/chips.zig
+++ b/port/stmicro/stm32/src/chips.zig
@@ -5,7 +5,7 @@ fn root() []const u8 {
     return comptime (std.fs.path.dirname(@src().file) orelse ".");
 }
 const build_root = root();
-const register_definition_path = build_root ++ "/chips/all.zig";
+pub const register_definition_path = build_root ++ "/chips/all.zig";
 
 pub const STM32C011D6 = MicroZig.Target{
     .preferred_format = .elf,
@@ -3507,7 +3507,7 @@ pub const STM32F301C6 = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32F301C6",
-        .cpu = MicroZig.cpus.cortex_m4,
+        .cpu = MicroZig.cpus.cortex_m4f,
         .memory_regions = &.{
             .{ .offset = 0x8000000, .length = 0x8000, .kind = .flash },
             .{ .offset = 0x20000000, .length = 0x4000, .kind = .ram },
@@ -3522,7 +3522,7 @@ pub const STM32F301C8 = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32F301C8",
-        .cpu = MicroZig.cpus.cortex_m4,
+        .cpu = MicroZig.cpus.cortex_m4f,
         .memory_regions = &.{
             .{ .offset = 0x8000000, .length = 0x10000, .kind = .flash },
             .{ .offset = 0x20000000, .length = 0x4000, .kind = .ram },
@@ -3537,7 +3537,7 @@ pub const STM32F301K6 = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32F301K6",
-        .cpu = MicroZig.cpus.cortex_m4,
+        .cpu = MicroZig.cpus.cortex_m4f,
         .memory_regions = &.{
             .{ .offset = 0x8000000, .length = 0x8000, .kind = .flash },
             .{ .offset = 0x20000000, .length = 0x4000, .kind = .ram },
@@ -3552,7 +3552,7 @@ pub const STM32F301K8 = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32F301K8",
-        .cpu = MicroZig.cpus.cortex_m4,
+        .cpu = MicroZig.cpus.cortex_m4f,
         .memory_regions = &.{
             .{ .offset = 0x8000000, .length = 0x10000, .kind = .flash },
             .{ .offset = 0x20000000, .length = 0x4000, .kind = .ram },
@@ -3567,7 +3567,7 @@ pub const STM32F301R6 = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32F301R6",
-        .cpu = MicroZig.cpus.cortex_m4,
+        .cpu = MicroZig.cpus.cortex_m4f,
         .memory_regions = &.{
             .{ .offset = 0x8000000, .length = 0x8000, .kind = .flash },
             .{ .offset = 0x20000000, .length = 0x4000, .kind = .ram },
@@ -3582,7 +3582,7 @@ pub const STM32F301R8 = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32F301R8",
-        .cpu = MicroZig.cpus.cortex_m4,
+        .cpu = MicroZig.cpus.cortex_m4f,
         .memory_regions = &.{
             .{ .offset = 0x8000000, .length = 0x10000, .kind = .flash },
             .{ .offset = 0x20000000, .length = 0x4000, .kind = .ram },
@@ -3597,7 +3597,7 @@ pub const STM32F302C6 = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32F302C6",
-        .cpu = MicroZig.cpus.cortex_m4,
+        .cpu = MicroZig.cpus.cortex_m4f,
         .memory_regions = &.{
             .{ .offset = 0x8000000, .length = 0x8000, .kind = .flash },
             .{ .offset = 0x20000000, .length = 0x4000, .kind = .ram },
@@ -3612,7 +3612,7 @@ pub const STM32F302C8 = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32F302C8",
-        .cpu = MicroZig.cpus.cortex_m4,
+        .cpu = MicroZig.cpus.cortex_m4f,
         .memory_regions = &.{
             .{ .offset = 0x8000000, .length = 0x10000, .kind = .flash },
             .{ .offset = 0x20000000, .length = 0x4000, .kind = .ram },
@@ -3627,7 +3627,7 @@ pub const STM32F302CB = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32F302CB",
-        .cpu = MicroZig.cpus.cortex_m4,
+        .cpu = MicroZig.cpus.cortex_m4f,
         .memory_regions = &.{
             .{ .offset = 0x8000000, .length = 0x20000, .kind = .flash },
             .{ .offset = 0x20000000, .length = 0x8000, .kind = .ram },
@@ -3642,7 +3642,7 @@ pub const STM32F302CC = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32F302CC",
-        .cpu = MicroZig.cpus.cortex_m4,
+        .cpu = MicroZig.cpus.cortex_m4f,
         .memory_regions = &.{
             .{ .offset = 0x8000000, .length = 0x40000, .kind = .flash },
             .{ .offset = 0x20000000, .length = 0xA000, .kind = .ram },
@@ -3657,7 +3657,7 @@ pub const STM32F302K6 = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32F302K6",
-        .cpu = MicroZig.cpus.cortex_m4,
+        .cpu = MicroZig.cpus.cortex_m4f,
         .memory_regions = &.{
             .{ .offset = 0x8000000, .length = 0x8000, .kind = .flash },
             .{ .offset = 0x20000000, .length = 0x4000, .kind = .ram },
@@ -3672,7 +3672,7 @@ pub const STM32F302K8 = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32F302K8",
-        .cpu = MicroZig.cpus.cortex_m4,
+        .cpu = MicroZig.cpus.cortex_m4f,
         .memory_regions = &.{
             .{ .offset = 0x8000000, .length = 0x10000, .kind = .flash },
             .{ .offset = 0x20000000, .length = 0x4000, .kind = .ram },
@@ -3687,7 +3687,7 @@ pub const STM32F302R6 = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32F302R6",
-        .cpu = MicroZig.cpus.cortex_m4,
+        .cpu = MicroZig.cpus.cortex_m4f,
         .memory_regions = &.{
             .{ .offset = 0x8000000, .length = 0x8000, .kind = .flash },
             .{ .offset = 0x20000000, .length = 0x4000, .kind = .ram },
@@ -3702,7 +3702,7 @@ pub const STM32F302R8 = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32F302R8",
-        .cpu = MicroZig.cpus.cortex_m4,
+        .cpu = MicroZig.cpus.cortex_m4f,
         .memory_regions = &.{
             .{ .offset = 0x8000000, .length = 0x10000, .kind = .flash },
             .{ .offset = 0x20000000, .length = 0x4000, .kind = .ram },
@@ -3717,7 +3717,7 @@ pub const STM32F302RB = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32F302RB",
-        .cpu = MicroZig.cpus.cortex_m4,
+        .cpu = MicroZig.cpus.cortex_m4f,
         .memory_regions = &.{
             .{ .offset = 0x8000000, .length = 0x20000, .kind = .flash },
             .{ .offset = 0x20000000, .length = 0x8000, .kind = .ram },
@@ -3732,7 +3732,7 @@ pub const STM32F302RC = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32F302RC",
-        .cpu = MicroZig.cpus.cortex_m4,
+        .cpu = MicroZig.cpus.cortex_m4f,
         .memory_regions = &.{
             .{ .offset = 0x8000000, .length = 0x40000, .kind = .flash },
             .{ .offset = 0x20000000, .length = 0xA000, .kind = .ram },
@@ -3747,7 +3747,7 @@ pub const STM32F302RD = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32F302RD",
-        .cpu = MicroZig.cpus.cortex_m4,
+        .cpu = MicroZig.cpus.cortex_m4f,
         .memory_regions = &.{
             .{ .offset = 0x8000000, .length = 0x60000, .kind = .flash },
             .{ .offset = 0x20000000, .length = 0x10000, .kind = .ram },
@@ -3762,7 +3762,7 @@ pub const STM32F302RE = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32F302RE",
-        .cpu = MicroZig.cpus.cortex_m4,
+        .cpu = MicroZig.cpus.cortex_m4f,
         .memory_regions = &.{
             .{ .offset = 0x8000000, .length = 0x80000, .kind = .flash },
             .{ .offset = 0x20000000, .length = 0x10000, .kind = .ram },
@@ -3777,7 +3777,7 @@ pub const STM32F302VB = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32F302VB",
-        .cpu = MicroZig.cpus.cortex_m4,
+        .cpu = MicroZig.cpus.cortex_m4f,
         .memory_regions = &.{
             .{ .offset = 0x8000000, .length = 0x20000, .kind = .flash },
             .{ .offset = 0x20000000, .length = 0x8000, .kind = .ram },
@@ -3792,7 +3792,7 @@ pub const STM32F302VC = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32F302VC",
-        .cpu = MicroZig.cpus.cortex_m4,
+        .cpu = MicroZig.cpus.cortex_m4f,
         .memory_regions = &.{
             .{ .offset = 0x8000000, .length = 0x40000, .kind = .flash },
             .{ .offset = 0x20000000, .length = 0xA000, .kind = .ram },
@@ -3807,7 +3807,7 @@ pub const STM32F302VD = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32F302VD",
-        .cpu = MicroZig.cpus.cortex_m4,
+        .cpu = MicroZig.cpus.cortex_m4f,
         .memory_regions = &.{
             .{ .offset = 0x8000000, .length = 0x60000, .kind = .flash },
             .{ .offset = 0x20000000, .length = 0x10000, .kind = .ram },
@@ -3822,7 +3822,7 @@ pub const STM32F302VE = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32F302VE",
-        .cpu = MicroZig.cpus.cortex_m4,
+        .cpu = MicroZig.cpus.cortex_m4f,
         .memory_regions = &.{
             .{ .offset = 0x8000000, .length = 0x80000, .kind = .flash },
             .{ .offset = 0x20000000, .length = 0x10000, .kind = .ram },
@@ -3837,7 +3837,7 @@ pub const STM32F302ZD = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32F302ZD",
-        .cpu = MicroZig.cpus.cortex_m4,
+        .cpu = MicroZig.cpus.cortex_m4f,
         .memory_regions = &.{
             .{ .offset = 0x8000000, .length = 0x60000, .kind = .flash },
             .{ .offset = 0x20000000, .length = 0x10000, .kind = .ram },
@@ -3852,7 +3852,7 @@ pub const STM32F302ZE = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32F302ZE",
-        .cpu = MicroZig.cpus.cortex_m4,
+        .cpu = MicroZig.cpus.cortex_m4f,
         .memory_regions = &.{
             .{ .offset = 0x8000000, .length = 0x80000, .kind = .flash },
             .{ .offset = 0x20000000, .length = 0x10000, .kind = .ram },
@@ -3867,7 +3867,7 @@ pub const STM32F303C6 = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32F303C6",
-        .cpu = MicroZig.cpus.cortex_m4,
+        .cpu = MicroZig.cpus.cortex_m4f,
         .memory_regions = &.{
             .{ .offset = 0x8000000, .length = 0x8000, .kind = .flash },
             .{ .offset = 0x10000000, .length = 0x1000, .kind = .ram },
@@ -3883,7 +3883,7 @@ pub const STM32F303C8 = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32F303C8",
-        .cpu = MicroZig.cpus.cortex_m4,
+        .cpu = MicroZig.cpus.cortex_m4f,
         .memory_regions = &.{
             .{ .offset = 0x8000000, .length = 0x10000, .kind = .flash },
             .{ .offset = 0x10000000, .length = 0x1000, .kind = .ram },
@@ -3899,7 +3899,7 @@ pub const STM32F303CB = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32F303CB",
-        .cpu = MicroZig.cpus.cortex_m4,
+        .cpu = MicroZig.cpus.cortex_m4f,
         .memory_regions = &.{
             .{ .offset = 0x8000000, .length = 0x20000, .kind = .flash },
             .{ .offset = 0x10000000, .length = 0x2000, .kind = .ram },
@@ -3915,7 +3915,7 @@ pub const STM32F303CC = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32F303CC",
-        .cpu = MicroZig.cpus.cortex_m4,
+        .cpu = MicroZig.cpus.cortex_m4f,
         .memory_regions = &.{
             .{ .offset = 0x8000000, .length = 0x40000, .kind = .flash },
             .{ .offset = 0x10000000, .length = 0x2000, .kind = .ram },
@@ -3931,7 +3931,7 @@ pub const STM32F303K6 = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32F303K6",
-        .cpu = MicroZig.cpus.cortex_m4,
+        .cpu = MicroZig.cpus.cortex_m4f,
         .memory_regions = &.{
             .{ .offset = 0x8000000, .length = 0x8000, .kind = .flash },
             .{ .offset = 0x10000000, .length = 0x1000, .kind = .ram },
@@ -3947,7 +3947,7 @@ pub const STM32F303K8 = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32F303K8",
-        .cpu = MicroZig.cpus.cortex_m4,
+        .cpu = MicroZig.cpus.cortex_m4f,
         .memory_regions = &.{
             .{ .offset = 0x8000000, .length = 0x10000, .kind = .flash },
             .{ .offset = 0x10000000, .length = 0x1000, .kind = .ram },
@@ -3963,7 +3963,7 @@ pub const STM32F303R6 = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32F303R6",
-        .cpu = MicroZig.cpus.cortex_m4,
+        .cpu = MicroZig.cpus.cortex_m4f,
         .memory_regions = &.{
             .{ .offset = 0x8000000, .length = 0x8000, .kind = .flash },
             .{ .offset = 0x10000000, .length = 0x1000, .kind = .ram },
@@ -3979,7 +3979,7 @@ pub const STM32F303R8 = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32F303R8",
-        .cpu = MicroZig.cpus.cortex_m4,
+        .cpu = MicroZig.cpus.cortex_m4f,
         .memory_regions = &.{
             .{ .offset = 0x8000000, .length = 0x10000, .kind = .flash },
             .{ .offset = 0x10000000, .length = 0x1000, .kind = .ram },
@@ -3995,7 +3995,7 @@ pub const STM32F303RB = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32F303RB",
-        .cpu = MicroZig.cpus.cortex_m4,
+        .cpu = MicroZig.cpus.cortex_m4f,
         .memory_regions = &.{
             .{ .offset = 0x8000000, .length = 0x20000, .kind = .flash },
             .{ .offset = 0x10000000, .length = 0x2000, .kind = .ram },
@@ -4011,7 +4011,7 @@ pub const STM32F303RC = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32F303RC",
-        .cpu = MicroZig.cpus.cortex_m4,
+        .cpu = MicroZig.cpus.cortex_m4f,
         .memory_regions = &.{
             .{ .offset = 0x8000000, .length = 0x40000, .kind = .flash },
             .{ .offset = 0x10000000, .length = 0x2000, .kind = .ram },
@@ -4027,7 +4027,7 @@ pub const STM32F303RD = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32F303RD",
-        .cpu = MicroZig.cpus.cortex_m4,
+        .cpu = MicroZig.cpus.cortex_m4f,
         .memory_regions = &.{
             .{ .offset = 0x8000000, .length = 0x60000, .kind = .flash },
             .{ .offset = 0x10000000, .length = 0x4000, .kind = .ram },
@@ -4043,7 +4043,7 @@ pub const STM32F303RE = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32F303RE",
-        .cpu = MicroZig.cpus.cortex_m4,
+        .cpu = MicroZig.cpus.cortex_m4f,
         .memory_regions = &.{
             .{ .offset = 0x8000000, .length = 0x80000, .kind = .flash },
             .{ .offset = 0x10000000, .length = 0x4000, .kind = .ram },
@@ -4059,7 +4059,7 @@ pub const STM32F303VB = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32F303VB",
-        .cpu = MicroZig.cpus.cortex_m4,
+        .cpu = MicroZig.cpus.cortex_m4f,
         .memory_regions = &.{
             .{ .offset = 0x8000000, .length = 0x20000, .kind = .flash },
             .{ .offset = 0x10000000, .length = 0x2000, .kind = .ram },
@@ -4075,7 +4075,7 @@ pub const STM32F303VC = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32F303VC",
-        .cpu = MicroZig.cpus.cortex_m4,
+        .cpu = MicroZig.cpus.cortex_m4f,
         .memory_regions = &.{
             .{ .offset = 0x8000000, .length = 0x40000, .kind = .flash },
             .{ .offset = 0x10000000, .length = 0x2000, .kind = .ram },
@@ -4091,7 +4091,7 @@ pub const STM32F303VD = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32F303VD",
-        .cpu = MicroZig.cpus.cortex_m4,
+        .cpu = MicroZig.cpus.cortex_m4f,
         .memory_regions = &.{
             .{ .offset = 0x8000000, .length = 0x60000, .kind = .flash },
             .{ .offset = 0x10000000, .length = 0x4000, .kind = .ram },
@@ -4107,7 +4107,7 @@ pub const STM32F303VE = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32F303VE",
-        .cpu = MicroZig.cpus.cortex_m4,
+        .cpu = MicroZig.cpus.cortex_m4f,
         .memory_regions = &.{
             .{ .offset = 0x8000000, .length = 0x80000, .kind = .flash },
             .{ .offset = 0x10000000, .length = 0x4000, .kind = .ram },
@@ -4123,7 +4123,7 @@ pub const STM32F303ZD = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32F303ZD",
-        .cpu = MicroZig.cpus.cortex_m4,
+        .cpu = MicroZig.cpus.cortex_m4f,
         .memory_regions = &.{
             .{ .offset = 0x8000000, .length = 0x60000, .kind = .flash },
             .{ .offset = 0x10000000, .length = 0x4000, .kind = .ram },
@@ -4139,7 +4139,7 @@ pub const STM32F303ZE = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32F303ZE",
-        .cpu = MicroZig.cpus.cortex_m4,
+        .cpu = MicroZig.cpus.cortex_m4f,
         .memory_regions = &.{
             .{ .offset = 0x8000000, .length = 0x80000, .kind = .flash },
             .{ .offset = 0x10000000, .length = 0x4000, .kind = .ram },
@@ -4155,7 +4155,7 @@ pub const STM32F318C8 = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32F318C8",
-        .cpu = MicroZig.cpus.cortex_m4,
+        .cpu = MicroZig.cpus.cortex_m4f,
         .memory_regions = &.{
             .{ .offset = 0x8000000, .length = 0x10000, .kind = .flash },
             .{ .offset = 0x20000000, .length = 0x4000, .kind = .ram },
@@ -4170,7 +4170,7 @@ pub const STM32F318K8 = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32F318K8",
-        .cpu = MicroZig.cpus.cortex_m4,
+        .cpu = MicroZig.cpus.cortex_m4f,
         .memory_regions = &.{
             .{ .offset = 0x8000000, .length = 0x10000, .kind = .flash },
             .{ .offset = 0x20000000, .length = 0x4000, .kind = .ram },
@@ -4185,7 +4185,7 @@ pub const STM32F328C8 = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32F328C8",
-        .cpu = MicroZig.cpus.cortex_m4,
+        .cpu = MicroZig.cpus.cortex_m4f,
         .memory_regions = &.{
             .{ .offset = 0x8000000, .length = 0x10000, .kind = .flash },
             .{ .offset = 0x10000000, .length = 0x1000, .kind = .ram },
@@ -4201,7 +4201,7 @@ pub const STM32F334C4 = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32F334C4",
-        .cpu = MicroZig.cpus.cortex_m4,
+        .cpu = MicroZig.cpus.cortex_m4f,
         .memory_regions = &.{
             .{ .offset = 0x8000000, .length = 0x4000, .kind = .flash },
             .{ .offset = 0x10000000, .length = 0x1000, .kind = .ram },
@@ -4217,7 +4217,7 @@ pub const STM32F334C6 = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32F334C6",
-        .cpu = MicroZig.cpus.cortex_m4,
+        .cpu = MicroZig.cpus.cortex_m4f,
         .memory_regions = &.{
             .{ .offset = 0x8000000, .length = 0x8000, .kind = .flash },
             .{ .offset = 0x10000000, .length = 0x1000, .kind = .ram },
@@ -4233,7 +4233,7 @@ pub const STM32F334C8 = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32F334C8",
-        .cpu = MicroZig.cpus.cortex_m4,
+        .cpu = MicroZig.cpus.cortex_m4f,
         .memory_regions = &.{
             .{ .offset = 0x8000000, .length = 0x10000, .kind = .flash },
             .{ .offset = 0x10000000, .length = 0x1000, .kind = .ram },
@@ -4249,7 +4249,7 @@ pub const STM32F334K4 = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32F334K4",
-        .cpu = MicroZig.cpus.cortex_m4,
+        .cpu = MicroZig.cpus.cortex_m4f,
         .memory_regions = &.{
             .{ .offset = 0x8000000, .length = 0x4000, .kind = .flash },
             .{ .offset = 0x10000000, .length = 0x1000, .kind = .ram },
@@ -4265,7 +4265,7 @@ pub const STM32F334K6 = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32F334K6",
-        .cpu = MicroZig.cpus.cortex_m4,
+        .cpu = MicroZig.cpus.cortex_m4f,
         .memory_regions = &.{
             .{ .offset = 0x8000000, .length = 0x8000, .kind = .flash },
             .{ .offset = 0x10000000, .length = 0x1000, .kind = .ram },
@@ -4281,7 +4281,7 @@ pub const STM32F334K8 = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32F334K8",
-        .cpu = MicroZig.cpus.cortex_m4,
+        .cpu = MicroZig.cpus.cortex_m4f,
         .memory_regions = &.{
             .{ .offset = 0x8000000, .length = 0x10000, .kind = .flash },
             .{ .offset = 0x10000000, .length = 0x1000, .kind = .ram },
@@ -4297,7 +4297,7 @@ pub const STM32F334R6 = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32F334R6",
-        .cpu = MicroZig.cpus.cortex_m4,
+        .cpu = MicroZig.cpus.cortex_m4f,
         .memory_regions = &.{
             .{ .offset = 0x8000000, .length = 0x8000, .kind = .flash },
             .{ .offset = 0x10000000, .length = 0x1000, .kind = .ram },
@@ -4313,7 +4313,7 @@ pub const STM32F334R8 = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32F334R8",
-        .cpu = MicroZig.cpus.cortex_m4,
+        .cpu = MicroZig.cpus.cortex_m4f,
         .memory_regions = &.{
             .{ .offset = 0x8000000, .length = 0x10000, .kind = .flash },
             .{ .offset = 0x10000000, .length = 0x1000, .kind = .ram },
@@ -4329,7 +4329,7 @@ pub const STM32F358CC = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32F358CC",
-        .cpu = MicroZig.cpus.cortex_m4,
+        .cpu = MicroZig.cpus.cortex_m4f,
         .memory_regions = &.{
             .{ .offset = 0x8000000, .length = 0x40000, .kind = .flash },
             .{ .offset = 0x10000000, .length = 0x2000, .kind = .ram },
@@ -4345,7 +4345,7 @@ pub const STM32F358RC = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32F358RC",
-        .cpu = MicroZig.cpus.cortex_m4,
+        .cpu = MicroZig.cpus.cortex_m4f,
         .memory_regions = &.{
             .{ .offset = 0x8000000, .length = 0x40000, .kind = .flash },
             .{ .offset = 0x10000000, .length = 0x2000, .kind = .ram },
@@ -4361,7 +4361,7 @@ pub const STM32F358VC = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32F358VC",
-        .cpu = MicroZig.cpus.cortex_m4,
+        .cpu = MicroZig.cpus.cortex_m4f,
         .memory_regions = &.{
             .{ .offset = 0x8000000, .length = 0x40000, .kind = .flash },
             .{ .offset = 0x10000000, .length = 0x2000, .kind = .ram },
@@ -4377,7 +4377,7 @@ pub const STM32F373C8 = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32F373C8",
-        .cpu = MicroZig.cpus.cortex_m4,
+        .cpu = MicroZig.cpus.cortex_m4f,
         .memory_regions = &.{
             .{ .offset = 0x8000000, .length = 0x10000, .kind = .flash },
             .{ .offset = 0x20000000, .length = 0x4000, .kind = .ram },
@@ -4392,7 +4392,7 @@ pub const STM32F373CB = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32F373CB",
-        .cpu = MicroZig.cpus.cortex_m4,
+        .cpu = MicroZig.cpus.cortex_m4f,
         .memory_regions = &.{
             .{ .offset = 0x8000000, .length = 0x20000, .kind = .flash },
             .{ .offset = 0x20000000, .length = 0x6000, .kind = .ram },
@@ -4407,7 +4407,7 @@ pub const STM32F373CC = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32F373CC",
-        .cpu = MicroZig.cpus.cortex_m4,
+        .cpu = MicroZig.cpus.cortex_m4f,
         .memory_regions = &.{
             .{ .offset = 0x8000000, .length = 0x40000, .kind = .flash },
             .{ .offset = 0x20000000, .length = 0x8000, .kind = .ram },
@@ -4422,7 +4422,7 @@ pub const STM32F373R8 = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32F373R8",
-        .cpu = MicroZig.cpus.cortex_m4,
+        .cpu = MicroZig.cpus.cortex_m4f,
         .memory_regions = &.{
             .{ .offset = 0x8000000, .length = 0x10000, .kind = .flash },
             .{ .offset = 0x20000000, .length = 0x4000, .kind = .ram },
@@ -4437,7 +4437,7 @@ pub const STM32F373RB = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32F373RB",
-        .cpu = MicroZig.cpus.cortex_m4,
+        .cpu = MicroZig.cpus.cortex_m4f,
         .memory_regions = &.{
             .{ .offset = 0x8000000, .length = 0x20000, .kind = .flash },
             .{ .offset = 0x20000000, .length = 0x6000, .kind = .ram },
@@ -4452,7 +4452,7 @@ pub const STM32F373RC = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32F373RC",
-        .cpu = MicroZig.cpus.cortex_m4,
+        .cpu = MicroZig.cpus.cortex_m4f,
         .memory_regions = &.{
             .{ .offset = 0x8000000, .length = 0x40000, .kind = .flash },
             .{ .offset = 0x20000000, .length = 0x8000, .kind = .ram },
@@ -4467,7 +4467,7 @@ pub const STM32F373V8 = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32F373V8",
-        .cpu = MicroZig.cpus.cortex_m4,
+        .cpu = MicroZig.cpus.cortex_m4f,
         .memory_regions = &.{
             .{ .offset = 0x8000000, .length = 0x10000, .kind = .flash },
             .{ .offset = 0x20000000, .length = 0x4000, .kind = .ram },
@@ -4482,7 +4482,7 @@ pub const STM32F373VB = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32F373VB",
-        .cpu = MicroZig.cpus.cortex_m4,
+        .cpu = MicroZig.cpus.cortex_m4f,
         .memory_regions = &.{
             .{ .offset = 0x8000000, .length = 0x20000, .kind = .flash },
             .{ .offset = 0x20000000, .length = 0x6000, .kind = .ram },
@@ -4497,7 +4497,7 @@ pub const STM32F373VC = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32F373VC",
-        .cpu = MicroZig.cpus.cortex_m4,
+        .cpu = MicroZig.cpus.cortex_m4f,
         .memory_regions = &.{
             .{ .offset = 0x8000000, .length = 0x40000, .kind = .flash },
             .{ .offset = 0x20000000, .length = 0x8000, .kind = .ram },
@@ -4512,7 +4512,7 @@ pub const STM32F378CC = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32F378CC",
-        .cpu = MicroZig.cpus.cortex_m4,
+        .cpu = MicroZig.cpus.cortex_m4f,
         .memory_regions = &.{
             .{ .offset = 0x8000000, .length = 0x40000, .kind = .flash },
             .{ .offset = 0x20000000, .length = 0x8000, .kind = .ram },
@@ -4527,7 +4527,7 @@ pub const STM32F378RC = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32F378RC",
-        .cpu = MicroZig.cpus.cortex_m4,
+        .cpu = MicroZig.cpus.cortex_m4f,
         .memory_regions = &.{
             .{ .offset = 0x8000000, .length = 0x40000, .kind = .flash },
             .{ .offset = 0x20000000, .length = 0x8000, .kind = .ram },
@@ -4542,7 +4542,7 @@ pub const STM32F378VC = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32F378VC",
-        .cpu = MicroZig.cpus.cortex_m4,
+        .cpu = MicroZig.cpus.cortex_m4f,
         .memory_regions = &.{
             .{ .offset = 0x8000000, .length = 0x40000, .kind = .flash },
             .{ .offset = 0x20000000, .length = 0x8000, .kind = .ram },
@@ -4557,7 +4557,7 @@ pub const STM32F398VE = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32F398VE",
-        .cpu = MicroZig.cpus.cortex_m4,
+        .cpu = MicroZig.cpus.cortex_m4f,
         .memory_regions = &.{
             .{ .offset = 0x8000000, .length = 0x80000, .kind = .flash },
             .{ .offset = 0x10000000, .length = 0x4000, .kind = .ram },
@@ -4573,7 +4573,7 @@ pub const STM32F401CB = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32F401CB",
-        .cpu = MicroZig.cpus.cortex_m4,
+        .cpu = MicroZig.cpus.cortex_m4f,
         .memory_regions = &.{
             .{ .offset = 0x8000000, .length = 0x10000, .kind = .flash },
             .{ .offset = 0x8010000, .length = 0x10000, .kind = .flash },
@@ -4589,7 +4589,7 @@ pub const STM32F401CC = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32F401CC",
-        .cpu = MicroZig.cpus.cortex_m4,
+        .cpu = MicroZig.cpus.cortex_m4f,
         .memory_regions = &.{
             .{ .offset = 0x8000000, .length = 0x10000, .kind = .flash },
             .{ .offset = 0x8010000, .length = 0x10000, .kind = .flash },
@@ -4606,7 +4606,7 @@ pub const STM32F401CD = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32F401CD",
-        .cpu = MicroZig.cpus.cortex_m4,
+        .cpu = MicroZig.cpus.cortex_m4f,
         .memory_regions = &.{
             .{ .offset = 0x8000000, .length = 0x10000, .kind = .flash },
             .{ .offset = 0x8010000, .length = 0x10000, .kind = .flash },
@@ -4623,7 +4623,7 @@ pub const STM32F401CE = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32F401CE",
-        .cpu = MicroZig.cpus.cortex_m4,
+        .cpu = MicroZig.cpus.cortex_m4f,
         .memory_regions = &.{
             .{ .offset = 0x8000000, .length = 0x10000, .kind = .flash },
             .{ .offset = 0x8010000, .length = 0x10000, .kind = .flash },
@@ -4640,7 +4640,7 @@ pub const STM32F401RB = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32F401RB",
-        .cpu = MicroZig.cpus.cortex_m4,
+        .cpu = MicroZig.cpus.cortex_m4f,
         .memory_regions = &.{
             .{ .offset = 0x8000000, .length = 0x10000, .kind = .flash },
             .{ .offset = 0x8010000, .length = 0x10000, .kind = .flash },
@@ -4656,7 +4656,7 @@ pub const STM32F401RC = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32F401RC",
-        .cpu = MicroZig.cpus.cortex_m4,
+        .cpu = MicroZig.cpus.cortex_m4f,
         .memory_regions = &.{
             .{ .offset = 0x8000000, .length = 0x10000, .kind = .flash },
             .{ .offset = 0x8010000, .length = 0x10000, .kind = .flash },
@@ -4673,7 +4673,7 @@ pub const STM32F401RD = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32F401RD",
-        .cpu = MicroZig.cpus.cortex_m4,
+        .cpu = MicroZig.cpus.cortex_m4f,
         .memory_regions = &.{
             .{ .offset = 0x8000000, .length = 0x10000, .kind = .flash },
             .{ .offset = 0x8010000, .length = 0x10000, .kind = .flash },
@@ -4690,7 +4690,7 @@ pub const STM32F401RE = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32F401RE",
-        .cpu = MicroZig.cpus.cortex_m4,
+        .cpu = MicroZig.cpus.cortex_m4f,
         .memory_regions = &.{
             .{ .offset = 0x8000000, .length = 0x10000, .kind = .flash },
             .{ .offset = 0x8010000, .length = 0x10000, .kind = .flash },
@@ -4707,7 +4707,7 @@ pub const STM32F401VB = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32F401VB",
-        .cpu = MicroZig.cpus.cortex_m4,
+        .cpu = MicroZig.cpus.cortex_m4f,
         .memory_regions = &.{
             .{ .offset = 0x8000000, .length = 0x10000, .kind = .flash },
             .{ .offset = 0x8010000, .length = 0x10000, .kind = .flash },
@@ -4723,7 +4723,7 @@ pub const STM32F401VC = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32F401VC",
-        .cpu = MicroZig.cpus.cortex_m4,
+        .cpu = MicroZig.cpus.cortex_m4f,
         .memory_regions = &.{
             .{ .offset = 0x8000000, .length = 0x10000, .kind = .flash },
             .{ .offset = 0x8010000, .length = 0x10000, .kind = .flash },
@@ -4740,7 +4740,7 @@ pub const STM32F401VD = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32F401VD",
-        .cpu = MicroZig.cpus.cortex_m4,
+        .cpu = MicroZig.cpus.cortex_m4f,
         .memory_regions = &.{
             .{ .offset = 0x8000000, .length = 0x10000, .kind = .flash },
             .{ .offset = 0x8010000, .length = 0x10000, .kind = .flash },
@@ -4757,7 +4757,7 @@ pub const STM32F401VE = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32F401VE",
-        .cpu = MicroZig.cpus.cortex_m4,
+        .cpu = MicroZig.cpus.cortex_m4f,
         .memory_regions = &.{
             .{ .offset = 0x8000000, .length = 0x10000, .kind = .flash },
             .{ .offset = 0x8010000, .length = 0x10000, .kind = .flash },
@@ -4774,7 +4774,7 @@ pub const STM32F405OE = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32F405OE",
-        .cpu = MicroZig.cpus.cortex_m4,
+        .cpu = MicroZig.cpus.cortex_m4f,
         .memory_regions = &.{
             .{ .offset = 0x8000000, .length = 0x10000, .kind = .flash },
             .{ .offset = 0x8010000, .length = 0x10000, .kind = .flash },
@@ -4793,7 +4793,7 @@ pub const STM32F405OG = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32F405OG",
-        .cpu = MicroZig.cpus.cortex_m4,
+        .cpu = MicroZig.cpus.cortex_m4f,
         .memory_regions = &.{
             .{ .offset = 0x8000000, .length = 0x10000, .kind = .flash },
             .{ .offset = 0x8010000, .length = 0x10000, .kind = .flash },
@@ -4812,7 +4812,7 @@ pub const STM32F405RG = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32F405RG",
-        .cpu = MicroZig.cpus.cortex_m4,
+        .cpu = MicroZig.cpus.cortex_m4f,
         .memory_regions = &.{
             .{ .offset = 0x8000000, .length = 0x10000, .kind = .flash },
             .{ .offset = 0x8010000, .length = 0x10000, .kind = .flash },
@@ -4831,7 +4831,7 @@ pub const STM32F405VG = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32F405VG",
-        .cpu = MicroZig.cpus.cortex_m4,
+        .cpu = MicroZig.cpus.cortex_m4f,
         .memory_regions = &.{
             .{ .offset = 0x8000000, .length = 0x10000, .kind = .flash },
             .{ .offset = 0x8010000, .length = 0x10000, .kind = .flash },
@@ -4850,7 +4850,7 @@ pub const STM32F405ZG = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32F405ZG",
-        .cpu = MicroZig.cpus.cortex_m4,
+        .cpu = MicroZig.cpus.cortex_m4f,
         .memory_regions = &.{
             .{ .offset = 0x8000000, .length = 0x10000, .kind = .flash },
             .{ .offset = 0x8010000, .length = 0x10000, .kind = .flash },
@@ -4869,7 +4869,7 @@ pub const STM32F407IE = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32F407IE",
-        .cpu = MicroZig.cpus.cortex_m4,
+        .cpu = MicroZig.cpus.cortex_m4f,
         .memory_regions = &.{
             .{ .offset = 0x8000000, .length = 0x10000, .kind = .flash },
             .{ .offset = 0x8010000, .length = 0x10000, .kind = .flash },
@@ -4888,7 +4888,7 @@ pub const STM32F407IG = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32F407IG",
-        .cpu = MicroZig.cpus.cortex_m4,
+        .cpu = MicroZig.cpus.cortex_m4f,
         .memory_regions = &.{
             .{ .offset = 0x8000000, .length = 0x10000, .kind = .flash },
             .{ .offset = 0x8010000, .length = 0x10000, .kind = .flash },
@@ -4907,7 +4907,7 @@ pub const STM32F407VE = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32F407VE",
-        .cpu = MicroZig.cpus.cortex_m4,
+        .cpu = MicroZig.cpus.cortex_m4f,
         .memory_regions = &.{
             .{ .offset = 0x8000000, .length = 0x10000, .kind = .flash },
             .{ .offset = 0x8010000, .length = 0x10000, .kind = .flash },
@@ -4926,7 +4926,7 @@ pub const STM32F407VG = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32F407VG",
-        .cpu = MicroZig.cpus.cortex_m4,
+        .cpu = MicroZig.cpus.cortex_m4f,
         .memory_regions = &.{
             .{ .offset = 0x8000000, .length = 0x10000, .kind = .flash },
             .{ .offset = 0x8010000, .length = 0x10000, .kind = .flash },
@@ -4945,7 +4945,7 @@ pub const STM32F407ZE = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32F407ZE",
-        .cpu = MicroZig.cpus.cortex_m4,
+        .cpu = MicroZig.cpus.cortex_m4f,
         .memory_regions = &.{
             .{ .offset = 0x8000000, .length = 0x10000, .kind = .flash },
             .{ .offset = 0x8010000, .length = 0x10000, .kind = .flash },
@@ -4964,7 +4964,7 @@ pub const STM32F407ZG = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32F407ZG",
-        .cpu = MicroZig.cpus.cortex_m4,
+        .cpu = MicroZig.cpus.cortex_m4f,
         .memory_regions = &.{
             .{ .offset = 0x8000000, .length = 0x10000, .kind = .flash },
             .{ .offset = 0x8010000, .length = 0x10000, .kind = .flash },
@@ -4983,7 +4983,7 @@ pub const STM32F410C8 = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32F410C8",
-        .cpu = MicroZig.cpus.cortex_m4,
+        .cpu = MicroZig.cpus.cortex_m4f,
         .memory_regions = &.{
             .{ .offset = 0x8000000, .length = 0x10000, .kind = .flash },
             .{ .offset = 0x20000000, .length = 0x8000, .kind = .ram },
@@ -4998,7 +4998,7 @@ pub const STM32F410CB = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32F410CB",
-        .cpu = MicroZig.cpus.cortex_m4,
+        .cpu = MicroZig.cpus.cortex_m4f,
         .memory_regions = &.{
             .{ .offset = 0x8000000, .length = 0x10000, .kind = .flash },
             .{ .offset = 0x8010000, .length = 0x10000, .kind = .flash },
@@ -5014,7 +5014,7 @@ pub const STM32F410R8 = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32F410R8",
-        .cpu = MicroZig.cpus.cortex_m4,
+        .cpu = MicroZig.cpus.cortex_m4f,
         .memory_regions = &.{
             .{ .offset = 0x8000000, .length = 0x10000, .kind = .flash },
             .{ .offset = 0x20000000, .length = 0x8000, .kind = .ram },
@@ -5029,7 +5029,7 @@ pub const STM32F410RB = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32F410RB",
-        .cpu = MicroZig.cpus.cortex_m4,
+        .cpu = MicroZig.cpus.cortex_m4f,
         .memory_regions = &.{
             .{ .offset = 0x8000000, .length = 0x10000, .kind = .flash },
             .{ .offset = 0x8010000, .length = 0x10000, .kind = .flash },
@@ -5045,7 +5045,7 @@ pub const STM32F410T8 = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32F410T8",
-        .cpu = MicroZig.cpus.cortex_m4,
+        .cpu = MicroZig.cpus.cortex_m4f,
         .memory_regions = &.{
             .{ .offset = 0x8000000, .length = 0x10000, .kind = .flash },
             .{ .offset = 0x20000000, .length = 0x8000, .kind = .ram },
@@ -5060,7 +5060,7 @@ pub const STM32F410TB = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32F410TB",
-        .cpu = MicroZig.cpus.cortex_m4,
+        .cpu = MicroZig.cpus.cortex_m4f,
         .memory_regions = &.{
             .{ .offset = 0x8000000, .length = 0x10000, .kind = .flash },
             .{ .offset = 0x8010000, .length = 0x10000, .kind = .flash },
@@ -5076,7 +5076,7 @@ pub const STM32F411CC = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32F411CC",
-        .cpu = MicroZig.cpus.cortex_m4,
+        .cpu = MicroZig.cpus.cortex_m4f,
         .memory_regions = &.{
             .{ .offset = 0x8000000, .length = 0x10000, .kind = .flash },
             .{ .offset = 0x8010000, .length = 0x10000, .kind = .flash },
@@ -5093,7 +5093,7 @@ pub const STM32F411CE = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32F411CE",
-        .cpu = MicroZig.cpus.cortex_m4,
+        .cpu = MicroZig.cpus.cortex_m4f,
         .memory_regions = &.{
             .{ .offset = 0x8000000, .length = 0x10000, .kind = .flash },
             .{ .offset = 0x8010000, .length = 0x10000, .kind = .flash },
@@ -5110,7 +5110,7 @@ pub const STM32F411RC = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32F411RC",
-        .cpu = MicroZig.cpus.cortex_m4,
+        .cpu = MicroZig.cpus.cortex_m4f,
         .memory_regions = &.{
             .{ .offset = 0x8000000, .length = 0x10000, .kind = .flash },
             .{ .offset = 0x8010000, .length = 0x10000, .kind = .flash },
@@ -5127,7 +5127,7 @@ pub const STM32F411RE = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32F411RE",
-        .cpu = MicroZig.cpus.cortex_m4,
+        .cpu = MicroZig.cpus.cortex_m4f,
         .memory_regions = &.{
             .{ .offset = 0x8000000, .length = 0x10000, .kind = .flash },
             .{ .offset = 0x8010000, .length = 0x10000, .kind = .flash },
@@ -5144,7 +5144,7 @@ pub const STM32F411VC = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32F411VC",
-        .cpu = MicroZig.cpus.cortex_m4,
+        .cpu = MicroZig.cpus.cortex_m4f,
         .memory_regions = &.{
             .{ .offset = 0x8000000, .length = 0x10000, .kind = .flash },
             .{ .offset = 0x8010000, .length = 0x10000, .kind = .flash },
@@ -5161,7 +5161,7 @@ pub const STM32F411VE = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32F411VE",
-        .cpu = MicroZig.cpus.cortex_m4,
+        .cpu = MicroZig.cpus.cortex_m4f,
         .memory_regions = &.{
             .{ .offset = 0x8000000, .length = 0x10000, .kind = .flash },
             .{ .offset = 0x8010000, .length = 0x10000, .kind = .flash },
@@ -5178,7 +5178,7 @@ pub const STM32F412CE = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32F412CE",
-        .cpu = MicroZig.cpus.cortex_m4,
+        .cpu = MicroZig.cpus.cortex_m4f,
         .memory_regions = &.{
             .{ .offset = 0x8000000, .length = 0x10000, .kind = .flash },
             .{ .offset = 0x8010000, .length = 0x10000, .kind = .flash },
@@ -5195,7 +5195,7 @@ pub const STM32F412CG = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32F412CG",
-        .cpu = MicroZig.cpus.cortex_m4,
+        .cpu = MicroZig.cpus.cortex_m4f,
         .memory_regions = &.{
             .{ .offset = 0x8000000, .length = 0x10000, .kind = .flash },
             .{ .offset = 0x8010000, .length = 0x10000, .kind = .flash },
@@ -5212,7 +5212,7 @@ pub const STM32F412RE = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32F412RE",
-        .cpu = MicroZig.cpus.cortex_m4,
+        .cpu = MicroZig.cpus.cortex_m4f,
         .memory_regions = &.{
             .{ .offset = 0x8000000, .length = 0x10000, .kind = .flash },
             .{ .offset = 0x8010000, .length = 0x10000, .kind = .flash },
@@ -5229,7 +5229,7 @@ pub const STM32F412RG = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32F412RG",
-        .cpu = MicroZig.cpus.cortex_m4,
+        .cpu = MicroZig.cpus.cortex_m4f,
         .memory_regions = &.{
             .{ .offset = 0x8000000, .length = 0x10000, .kind = .flash },
             .{ .offset = 0x8010000, .length = 0x10000, .kind = .flash },
@@ -5246,7 +5246,7 @@ pub const STM32F412VE = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32F412VE",
-        .cpu = MicroZig.cpus.cortex_m4,
+        .cpu = MicroZig.cpus.cortex_m4f,
         .memory_regions = &.{
             .{ .offset = 0x8000000, .length = 0x10000, .kind = .flash },
             .{ .offset = 0x8010000, .length = 0x10000, .kind = .flash },
@@ -5263,7 +5263,7 @@ pub const STM32F412VG = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32F412VG",
-        .cpu = MicroZig.cpus.cortex_m4,
+        .cpu = MicroZig.cpus.cortex_m4f,
         .memory_regions = &.{
             .{ .offset = 0x8000000, .length = 0x10000, .kind = .flash },
             .{ .offset = 0x8010000, .length = 0x10000, .kind = .flash },
@@ -5280,7 +5280,7 @@ pub const STM32F412ZE = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32F412ZE",
-        .cpu = MicroZig.cpus.cortex_m4,
+        .cpu = MicroZig.cpus.cortex_m4f,
         .memory_regions = &.{
             .{ .offset = 0x8000000, .length = 0x10000, .kind = .flash },
             .{ .offset = 0x8010000, .length = 0x10000, .kind = .flash },
@@ -5297,7 +5297,7 @@ pub const STM32F412ZG = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32F412ZG",
-        .cpu = MicroZig.cpus.cortex_m4,
+        .cpu = MicroZig.cpus.cortex_m4f,
         .memory_regions = &.{
             .{ .offset = 0x8000000, .length = 0x10000, .kind = .flash },
             .{ .offset = 0x8010000, .length = 0x10000, .kind = .flash },
@@ -5314,7 +5314,7 @@ pub const STM32F413CG = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32F413CG",
-        .cpu = MicroZig.cpus.cortex_m4,
+        .cpu = MicroZig.cpus.cortex_m4f,
         .memory_regions = &.{
             .{ .offset = 0x8000000, .length = 0x10000, .kind = .flash },
             .{ .offset = 0x8010000, .length = 0x10000, .kind = .flash },
@@ -5331,7 +5331,7 @@ pub const STM32F413CH = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32F413CH",
-        .cpu = MicroZig.cpus.cortex_m4,
+        .cpu = MicroZig.cpus.cortex_m4f,
         .memory_regions = &.{
             .{ .offset = 0x8000000, .length = 0x10000, .kind = .flash },
             .{ .offset = 0x8010000, .length = 0x10000, .kind = .flash },
@@ -5348,7 +5348,7 @@ pub const STM32F413MG = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32F413MG",
-        .cpu = MicroZig.cpus.cortex_m4,
+        .cpu = MicroZig.cpus.cortex_m4f,
         .memory_regions = &.{
             .{ .offset = 0x8000000, .length = 0x10000, .kind = .flash },
             .{ .offset = 0x8010000, .length = 0x10000, .kind = .flash },
@@ -5365,7 +5365,7 @@ pub const STM32F413MH = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32F413MH",
-        .cpu = MicroZig.cpus.cortex_m4,
+        .cpu = MicroZig.cpus.cortex_m4f,
         .memory_regions = &.{
             .{ .offset = 0x8000000, .length = 0x10000, .kind = .flash },
             .{ .offset = 0x8010000, .length = 0x10000, .kind = .flash },
@@ -5382,7 +5382,7 @@ pub const STM32F413RG = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32F413RG",
-        .cpu = MicroZig.cpus.cortex_m4,
+        .cpu = MicroZig.cpus.cortex_m4f,
         .memory_regions = &.{
             .{ .offset = 0x8000000, .length = 0x10000, .kind = .flash },
             .{ .offset = 0x8010000, .length = 0x10000, .kind = .flash },
@@ -5399,7 +5399,7 @@ pub const STM32F413RH = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32F413RH",
-        .cpu = MicroZig.cpus.cortex_m4,
+        .cpu = MicroZig.cpus.cortex_m4f,
         .memory_regions = &.{
             .{ .offset = 0x8000000, .length = 0x10000, .kind = .flash },
             .{ .offset = 0x8010000, .length = 0x10000, .kind = .flash },
@@ -5416,7 +5416,7 @@ pub const STM32F413VG = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32F413VG",
-        .cpu = MicroZig.cpus.cortex_m4,
+        .cpu = MicroZig.cpus.cortex_m4f,
         .memory_regions = &.{
             .{ .offset = 0x8000000, .length = 0x10000, .kind = .flash },
             .{ .offset = 0x8010000, .length = 0x10000, .kind = .flash },
@@ -5433,7 +5433,7 @@ pub const STM32F413VH = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32F413VH",
-        .cpu = MicroZig.cpus.cortex_m4,
+        .cpu = MicroZig.cpus.cortex_m4f,
         .memory_regions = &.{
             .{ .offset = 0x8000000, .length = 0x10000, .kind = .flash },
             .{ .offset = 0x8010000, .length = 0x10000, .kind = .flash },
@@ -5450,7 +5450,7 @@ pub const STM32F413ZG = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32F413ZG",
-        .cpu = MicroZig.cpus.cortex_m4,
+        .cpu = MicroZig.cpus.cortex_m4f,
         .memory_regions = &.{
             .{ .offset = 0x8000000, .length = 0x10000, .kind = .flash },
             .{ .offset = 0x8010000, .length = 0x10000, .kind = .flash },
@@ -5467,7 +5467,7 @@ pub const STM32F413ZH = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32F413ZH",
-        .cpu = MicroZig.cpus.cortex_m4,
+        .cpu = MicroZig.cpus.cortex_m4f,
         .memory_regions = &.{
             .{ .offset = 0x8000000, .length = 0x10000, .kind = .flash },
             .{ .offset = 0x8010000, .length = 0x10000, .kind = .flash },
@@ -5484,7 +5484,7 @@ pub const STM32F415OG = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32F415OG",
-        .cpu = MicroZig.cpus.cortex_m4,
+        .cpu = MicroZig.cpus.cortex_m4f,
         .memory_regions = &.{
             .{ .offset = 0x8000000, .length = 0x10000, .kind = .flash },
             .{ .offset = 0x8010000, .length = 0x10000, .kind = .flash },
@@ -5502,7 +5502,7 @@ pub const STM32F415RG = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32F415RG",
-        .cpu = MicroZig.cpus.cortex_m4,
+        .cpu = MicroZig.cpus.cortex_m4f,
         .memory_regions = &.{
             .{ .offset = 0x8000000, .length = 0x10000, .kind = .flash },
             .{ .offset = 0x8010000, .length = 0x10000, .kind = .flash },
@@ -5520,7 +5520,7 @@ pub const STM32F415VG = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32F415VG",
-        .cpu = MicroZig.cpus.cortex_m4,
+        .cpu = MicroZig.cpus.cortex_m4f,
         .memory_regions = &.{
             .{ .offset = 0x8000000, .length = 0x10000, .kind = .flash },
             .{ .offset = 0x8010000, .length = 0x10000, .kind = .flash },
@@ -5538,7 +5538,7 @@ pub const STM32F415ZG = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32F415ZG",
-        .cpu = MicroZig.cpus.cortex_m4,
+        .cpu = MicroZig.cpus.cortex_m4f,
         .memory_regions = &.{
             .{ .offset = 0x8000000, .length = 0x10000, .kind = .flash },
             .{ .offset = 0x8010000, .length = 0x10000, .kind = .flash },
@@ -5556,7 +5556,7 @@ pub const STM32F417IE = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32F417IE",
-        .cpu = MicroZig.cpus.cortex_m4,
+        .cpu = MicroZig.cpus.cortex_m4f,
         .memory_regions = &.{
             .{ .offset = 0x8000000, .length = 0x10000, .kind = .flash },
             .{ .offset = 0x8010000, .length = 0x10000, .kind = .flash },
@@ -5574,7 +5574,7 @@ pub const STM32F417IG = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32F417IG",
-        .cpu = MicroZig.cpus.cortex_m4,
+        .cpu = MicroZig.cpus.cortex_m4f,
         .memory_regions = &.{
             .{ .offset = 0x8000000, .length = 0x10000, .kind = .flash },
             .{ .offset = 0x8010000, .length = 0x10000, .kind = .flash },
@@ -5592,7 +5592,7 @@ pub const STM32F417VE = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32F417VE",
-        .cpu = MicroZig.cpus.cortex_m4,
+        .cpu = MicroZig.cpus.cortex_m4f,
         .memory_regions = &.{
             .{ .offset = 0x8000000, .length = 0x10000, .kind = .flash },
             .{ .offset = 0x8010000, .length = 0x10000, .kind = .flash },
@@ -5610,7 +5610,7 @@ pub const STM32F417VG = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32F417VG",
-        .cpu = MicroZig.cpus.cortex_m4,
+        .cpu = MicroZig.cpus.cortex_m4f,
         .memory_regions = &.{
             .{ .offset = 0x8000000, .length = 0x10000, .kind = .flash },
             .{ .offset = 0x8010000, .length = 0x10000, .kind = .flash },
@@ -5628,7 +5628,7 @@ pub const STM32F417ZE = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32F417ZE",
-        .cpu = MicroZig.cpus.cortex_m4,
+        .cpu = MicroZig.cpus.cortex_m4f,
         .memory_regions = &.{
             .{ .offset = 0x8000000, .length = 0x10000, .kind = .flash },
             .{ .offset = 0x8010000, .length = 0x10000, .kind = .flash },
@@ -5646,7 +5646,7 @@ pub const STM32F417ZG = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32F417ZG",
-        .cpu = MicroZig.cpus.cortex_m4,
+        .cpu = MicroZig.cpus.cortex_m4f,
         .memory_regions = &.{
             .{ .offset = 0x8000000, .length = 0x10000, .kind = .flash },
             .{ .offset = 0x8010000, .length = 0x10000, .kind = .flash },
@@ -5664,7 +5664,7 @@ pub const STM32F423CH = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32F423CH",
-        .cpu = MicroZig.cpus.cortex_m4,
+        .cpu = MicroZig.cpus.cortex_m4f,
         .memory_regions = &.{
             .{ .offset = 0x8000000, .length = 0x10000, .kind = .flash },
             .{ .offset = 0x8010000, .length = 0x10000, .kind = .flash },
@@ -5681,7 +5681,7 @@ pub const STM32F423MH = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32F423MH",
-        .cpu = MicroZig.cpus.cortex_m4,
+        .cpu = MicroZig.cpus.cortex_m4f,
         .memory_regions = &.{
             .{ .offset = 0x8000000, .length = 0x10000, .kind = .flash },
             .{ .offset = 0x8010000, .length = 0x10000, .kind = .flash },
@@ -5698,7 +5698,7 @@ pub const STM32F423RH = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32F423RH",
-        .cpu = MicroZig.cpus.cortex_m4,
+        .cpu = MicroZig.cpus.cortex_m4f,
         .memory_regions = &.{
             .{ .offset = 0x8000000, .length = 0x10000, .kind = .flash },
             .{ .offset = 0x8010000, .length = 0x10000, .kind = .flash },
@@ -5715,7 +5715,7 @@ pub const STM32F423VH = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32F423VH",
-        .cpu = MicroZig.cpus.cortex_m4,
+        .cpu = MicroZig.cpus.cortex_m4f,
         .memory_regions = &.{
             .{ .offset = 0x8000000, .length = 0x10000, .kind = .flash },
             .{ .offset = 0x8010000, .length = 0x10000, .kind = .flash },
@@ -5732,7 +5732,7 @@ pub const STM32F423ZH = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32F423ZH",
-        .cpu = MicroZig.cpus.cortex_m4,
+        .cpu = MicroZig.cpus.cortex_m4f,
         .memory_regions = &.{
             .{ .offset = 0x8000000, .length = 0x10000, .kind = .flash },
             .{ .offset = 0x8010000, .length = 0x10000, .kind = .flash },
@@ -5749,7 +5749,7 @@ pub const STM32F427AG = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32F427AG",
-        .cpu = MicroZig.cpus.cortex_m4,
+        .cpu = MicroZig.cpus.cortex_m4f,
         .memory_regions = &.{
             .{ .offset = 0x8000000, .length = 0x10000, .kind = .flash },
             .{ .offset = 0x8010000, .length = 0x10000, .kind = .flash },
@@ -5767,7 +5767,7 @@ pub const STM32F427AI = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32F427AI",
-        .cpu = MicroZig.cpus.cortex_m4,
+        .cpu = MicroZig.cpus.cortex_m4f,
         .memory_regions = &.{
             .{ .offset = 0x8000000, .length = 0x10000, .kind = .flash },
             .{ .offset = 0x8010000, .length = 0x10000, .kind = .flash },
@@ -5788,7 +5788,7 @@ pub const STM32F427IG = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32F427IG",
-        .cpu = MicroZig.cpus.cortex_m4,
+        .cpu = MicroZig.cpus.cortex_m4f,
         .memory_regions = &.{
             .{ .offset = 0x8000000, .length = 0x10000, .kind = .flash },
             .{ .offset = 0x8010000, .length = 0x10000, .kind = .flash },
@@ -5806,7 +5806,7 @@ pub const STM32F427II = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32F427II",
-        .cpu = MicroZig.cpus.cortex_m4,
+        .cpu = MicroZig.cpus.cortex_m4f,
         .memory_regions = &.{
             .{ .offset = 0x8000000, .length = 0x10000, .kind = .flash },
             .{ .offset = 0x8010000, .length = 0x10000, .kind = .flash },
@@ -5827,7 +5827,7 @@ pub const STM32F427VG = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32F427VG",
-        .cpu = MicroZig.cpus.cortex_m4,
+        .cpu = MicroZig.cpus.cortex_m4f,
         .memory_regions = &.{
             .{ .offset = 0x8000000, .length = 0x10000, .kind = .flash },
             .{ .offset = 0x8010000, .length = 0x10000, .kind = .flash },
@@ -5845,7 +5845,7 @@ pub const STM32F427VI = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32F427VI",
-        .cpu = MicroZig.cpus.cortex_m4,
+        .cpu = MicroZig.cpus.cortex_m4f,
         .memory_regions = &.{
             .{ .offset = 0x8000000, .length = 0x10000, .kind = .flash },
             .{ .offset = 0x8010000, .length = 0x10000, .kind = .flash },
@@ -5866,7 +5866,7 @@ pub const STM32F427ZG = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32F427ZG",
-        .cpu = MicroZig.cpus.cortex_m4,
+        .cpu = MicroZig.cpus.cortex_m4f,
         .memory_regions = &.{
             .{ .offset = 0x8000000, .length = 0x10000, .kind = .flash },
             .{ .offset = 0x8010000, .length = 0x10000, .kind = .flash },
@@ -5884,7 +5884,7 @@ pub const STM32F427ZI = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32F427ZI",
-        .cpu = MicroZig.cpus.cortex_m4,
+        .cpu = MicroZig.cpus.cortex_m4f,
         .memory_regions = &.{
             .{ .offset = 0x8000000, .length = 0x10000, .kind = .flash },
             .{ .offset = 0x8010000, .length = 0x10000, .kind = .flash },
@@ -5905,7 +5905,7 @@ pub const STM32F429AG = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32F429AG",
-        .cpu = MicroZig.cpus.cortex_m4,
+        .cpu = MicroZig.cpus.cortex_m4f,
         .memory_regions = &.{
             .{ .offset = 0x8000000, .length = 0x10000, .kind = .flash },
             .{ .offset = 0x8010000, .length = 0x10000, .kind = .flash },
@@ -5923,7 +5923,7 @@ pub const STM32F429AI = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32F429AI",
-        .cpu = MicroZig.cpus.cortex_m4,
+        .cpu = MicroZig.cpus.cortex_m4f,
         .memory_regions = &.{
             .{ .offset = 0x8000000, .length = 0x10000, .kind = .flash },
             .{ .offset = 0x8010000, .length = 0x10000, .kind = .flash },
@@ -5944,7 +5944,7 @@ pub const STM32F429BE = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32F429BE",
-        .cpu = MicroZig.cpus.cortex_m4,
+        .cpu = MicroZig.cpus.cortex_m4f,
         .memory_regions = &.{
             .{ .offset = 0x8000000, .length = 0x10000, .kind = .flash },
             .{ .offset = 0x8010000, .length = 0x10000, .kind = .flash },
@@ -5962,7 +5962,7 @@ pub const STM32F429BG = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32F429BG",
-        .cpu = MicroZig.cpus.cortex_m4,
+        .cpu = MicroZig.cpus.cortex_m4f,
         .memory_regions = &.{
             .{ .offset = 0x8000000, .length = 0x10000, .kind = .flash },
             .{ .offset = 0x8010000, .length = 0x10000, .kind = .flash },
@@ -5980,7 +5980,7 @@ pub const STM32F429BI = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32F429BI",
-        .cpu = MicroZig.cpus.cortex_m4,
+        .cpu = MicroZig.cpus.cortex_m4f,
         .memory_regions = &.{
             .{ .offset = 0x8000000, .length = 0x10000, .kind = .flash },
             .{ .offset = 0x8010000, .length = 0x10000, .kind = .flash },
@@ -6001,7 +6001,7 @@ pub const STM32F429IE = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32F429IE",
-        .cpu = MicroZig.cpus.cortex_m4,
+        .cpu = MicroZig.cpus.cortex_m4f,
         .memory_regions = &.{
             .{ .offset = 0x8000000, .length = 0x10000, .kind = .flash },
             .{ .offset = 0x8010000, .length = 0x10000, .kind = .flash },
@@ -6019,7 +6019,7 @@ pub const STM32F429IG = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32F429IG",
-        .cpu = MicroZig.cpus.cortex_m4,
+        .cpu = MicroZig.cpus.cortex_m4f,
         .memory_regions = &.{
             .{ .offset = 0x8000000, .length = 0x10000, .kind = .flash },
             .{ .offset = 0x8010000, .length = 0x10000, .kind = .flash },
@@ -6037,7 +6037,7 @@ pub const STM32F429II = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32F429II",
-        .cpu = MicroZig.cpus.cortex_m4,
+        .cpu = MicroZig.cpus.cortex_m4f,
         .memory_regions = &.{
             .{ .offset = 0x8000000, .length = 0x10000, .kind = .flash },
             .{ .offset = 0x8010000, .length = 0x10000, .kind = .flash },
@@ -6058,7 +6058,7 @@ pub const STM32F429NE = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32F429NE",
-        .cpu = MicroZig.cpus.cortex_m4,
+        .cpu = MicroZig.cpus.cortex_m4f,
         .memory_regions = &.{
             .{ .offset = 0x8000000, .length = 0x10000, .kind = .flash },
             .{ .offset = 0x8010000, .length = 0x10000, .kind = .flash },
@@ -6076,7 +6076,7 @@ pub const STM32F429NG = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32F429NG",
-        .cpu = MicroZig.cpus.cortex_m4,
+        .cpu = MicroZig.cpus.cortex_m4f,
         .memory_regions = &.{
             .{ .offset = 0x8000000, .length = 0x10000, .kind = .flash },
             .{ .offset = 0x8010000, .length = 0x10000, .kind = .flash },
@@ -6094,7 +6094,7 @@ pub const STM32F429NI = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32F429NI",
-        .cpu = MicroZig.cpus.cortex_m4,
+        .cpu = MicroZig.cpus.cortex_m4f,
         .memory_regions = &.{
             .{ .offset = 0x8000000, .length = 0x10000, .kind = .flash },
             .{ .offset = 0x8010000, .length = 0x10000, .kind = .flash },
@@ -6115,7 +6115,7 @@ pub const STM32F429VE = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32F429VE",
-        .cpu = MicroZig.cpus.cortex_m4,
+        .cpu = MicroZig.cpus.cortex_m4f,
         .memory_regions = &.{
             .{ .offset = 0x8000000, .length = 0x10000, .kind = .flash },
             .{ .offset = 0x8010000, .length = 0x10000, .kind = .flash },
@@ -6133,7 +6133,7 @@ pub const STM32F429VG = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32F429VG",
-        .cpu = MicroZig.cpus.cortex_m4,
+        .cpu = MicroZig.cpus.cortex_m4f,
         .memory_regions = &.{
             .{ .offset = 0x8000000, .length = 0x10000, .kind = .flash },
             .{ .offset = 0x8010000, .length = 0x10000, .kind = .flash },
@@ -6151,7 +6151,7 @@ pub const STM32F429VI = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32F429VI",
-        .cpu = MicroZig.cpus.cortex_m4,
+        .cpu = MicroZig.cpus.cortex_m4f,
         .memory_regions = &.{
             .{ .offset = 0x8000000, .length = 0x10000, .kind = .flash },
             .{ .offset = 0x8010000, .length = 0x10000, .kind = .flash },
@@ -6172,7 +6172,7 @@ pub const STM32F429ZE = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32F429ZE",
-        .cpu = MicroZig.cpus.cortex_m4,
+        .cpu = MicroZig.cpus.cortex_m4f,
         .memory_regions = &.{
             .{ .offset = 0x8000000, .length = 0x10000, .kind = .flash },
             .{ .offset = 0x8010000, .length = 0x10000, .kind = .flash },
@@ -6190,7 +6190,7 @@ pub const STM32F429ZG = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32F429ZG",
-        .cpu = MicroZig.cpus.cortex_m4,
+        .cpu = MicroZig.cpus.cortex_m4f,
         .memory_regions = &.{
             .{ .offset = 0x8000000, .length = 0x10000, .kind = .flash },
             .{ .offset = 0x8010000, .length = 0x10000, .kind = .flash },
@@ -6208,7 +6208,7 @@ pub const STM32F429ZI = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32F429ZI",
-        .cpu = MicroZig.cpus.cortex_m4,
+        .cpu = MicroZig.cpus.cortex_m4f,
         .memory_regions = &.{
             .{ .offset = 0x8000000, .length = 0x10000, .kind = .flash },
             .{ .offset = 0x8010000, .length = 0x10000, .kind = .flash },
@@ -6229,7 +6229,7 @@ pub const STM32F437AI = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32F437AI",
-        .cpu = MicroZig.cpus.cortex_m4,
+        .cpu = MicroZig.cpus.cortex_m4f,
         .memory_regions = &.{
             .{ .offset = 0x8000000, .length = 0x10000, .kind = .flash },
             .{ .offset = 0x8010000, .length = 0x10000, .kind = .flash },
@@ -6250,7 +6250,7 @@ pub const STM32F437IG = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32F437IG",
-        .cpu = MicroZig.cpus.cortex_m4,
+        .cpu = MicroZig.cpus.cortex_m4f,
         .memory_regions = &.{
             .{ .offset = 0x8000000, .length = 0x10000, .kind = .flash },
             .{ .offset = 0x8010000, .length = 0x10000, .kind = .flash },
@@ -6268,7 +6268,7 @@ pub const STM32F437II = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32F437II",
-        .cpu = MicroZig.cpus.cortex_m4,
+        .cpu = MicroZig.cpus.cortex_m4f,
         .memory_regions = &.{
             .{ .offset = 0x8000000, .length = 0x10000, .kind = .flash },
             .{ .offset = 0x8010000, .length = 0x10000, .kind = .flash },
@@ -6289,7 +6289,7 @@ pub const STM32F437VG = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32F437VG",
-        .cpu = MicroZig.cpus.cortex_m4,
+        .cpu = MicroZig.cpus.cortex_m4f,
         .memory_regions = &.{
             .{ .offset = 0x8000000, .length = 0x10000, .kind = .flash },
             .{ .offset = 0x8010000, .length = 0x10000, .kind = .flash },
@@ -6307,7 +6307,7 @@ pub const STM32F437VI = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32F437VI",
-        .cpu = MicroZig.cpus.cortex_m4,
+        .cpu = MicroZig.cpus.cortex_m4f,
         .memory_regions = &.{
             .{ .offset = 0x8000000, .length = 0x10000, .kind = .flash },
             .{ .offset = 0x8010000, .length = 0x10000, .kind = .flash },
@@ -6328,7 +6328,7 @@ pub const STM32F437ZG = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32F437ZG",
-        .cpu = MicroZig.cpus.cortex_m4,
+        .cpu = MicroZig.cpus.cortex_m4f,
         .memory_regions = &.{
             .{ .offset = 0x8000000, .length = 0x10000, .kind = .flash },
             .{ .offset = 0x8010000, .length = 0x10000, .kind = .flash },
@@ -6346,7 +6346,7 @@ pub const STM32F437ZI = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32F437ZI",
-        .cpu = MicroZig.cpus.cortex_m4,
+        .cpu = MicroZig.cpus.cortex_m4f,
         .memory_regions = &.{
             .{ .offset = 0x8000000, .length = 0x10000, .kind = .flash },
             .{ .offset = 0x8010000, .length = 0x10000, .kind = .flash },
@@ -6367,7 +6367,7 @@ pub const STM32F439AI = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32F439AI",
-        .cpu = MicroZig.cpus.cortex_m4,
+        .cpu = MicroZig.cpus.cortex_m4f,
         .memory_regions = &.{
             .{ .offset = 0x8000000, .length = 0x10000, .kind = .flash },
             .{ .offset = 0x8010000, .length = 0x10000, .kind = .flash },
@@ -6388,7 +6388,7 @@ pub const STM32F439BG = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32F439BG",
-        .cpu = MicroZig.cpus.cortex_m4,
+        .cpu = MicroZig.cpus.cortex_m4f,
         .memory_regions = &.{
             .{ .offset = 0x8000000, .length = 0x10000, .kind = .flash },
             .{ .offset = 0x8010000, .length = 0x10000, .kind = .flash },
@@ -6406,7 +6406,7 @@ pub const STM32F439BI = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32F439BI",
-        .cpu = MicroZig.cpus.cortex_m4,
+        .cpu = MicroZig.cpus.cortex_m4f,
         .memory_regions = &.{
             .{ .offset = 0x8000000, .length = 0x10000, .kind = .flash },
             .{ .offset = 0x8010000, .length = 0x10000, .kind = .flash },
@@ -6427,7 +6427,7 @@ pub const STM32F439IG = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32F439IG",
-        .cpu = MicroZig.cpus.cortex_m4,
+        .cpu = MicroZig.cpus.cortex_m4f,
         .memory_regions = &.{
             .{ .offset = 0x8000000, .length = 0x10000, .kind = .flash },
             .{ .offset = 0x8010000, .length = 0x10000, .kind = .flash },
@@ -6445,7 +6445,7 @@ pub const STM32F439II = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32F439II",
-        .cpu = MicroZig.cpus.cortex_m4,
+        .cpu = MicroZig.cpus.cortex_m4f,
         .memory_regions = &.{
             .{ .offset = 0x8000000, .length = 0x10000, .kind = .flash },
             .{ .offset = 0x8010000, .length = 0x10000, .kind = .flash },
@@ -6466,7 +6466,7 @@ pub const STM32F439NG = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32F439NG",
-        .cpu = MicroZig.cpus.cortex_m4,
+        .cpu = MicroZig.cpus.cortex_m4f,
         .memory_regions = &.{
             .{ .offset = 0x8000000, .length = 0x10000, .kind = .flash },
             .{ .offset = 0x8010000, .length = 0x10000, .kind = .flash },
@@ -6484,7 +6484,7 @@ pub const STM32F439NI = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32F439NI",
-        .cpu = MicroZig.cpus.cortex_m4,
+        .cpu = MicroZig.cpus.cortex_m4f,
         .memory_regions = &.{
             .{ .offset = 0x8000000, .length = 0x10000, .kind = .flash },
             .{ .offset = 0x8010000, .length = 0x10000, .kind = .flash },
@@ -6505,7 +6505,7 @@ pub const STM32F439VG = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32F439VG",
-        .cpu = MicroZig.cpus.cortex_m4,
+        .cpu = MicroZig.cpus.cortex_m4f,
         .memory_regions = &.{
             .{ .offset = 0x8000000, .length = 0x10000, .kind = .flash },
             .{ .offset = 0x8010000, .length = 0x10000, .kind = .flash },
@@ -6523,7 +6523,7 @@ pub const STM32F439VI = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32F439VI",
-        .cpu = MicroZig.cpus.cortex_m4,
+        .cpu = MicroZig.cpus.cortex_m4f,
         .memory_regions = &.{
             .{ .offset = 0x8000000, .length = 0x10000, .kind = .flash },
             .{ .offset = 0x8010000, .length = 0x10000, .kind = .flash },
@@ -6544,7 +6544,7 @@ pub const STM32F439ZG = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32F439ZG",
-        .cpu = MicroZig.cpus.cortex_m4,
+        .cpu = MicroZig.cpus.cortex_m4f,
         .memory_regions = &.{
             .{ .offset = 0x8000000, .length = 0x10000, .kind = .flash },
             .{ .offset = 0x8010000, .length = 0x10000, .kind = .flash },
@@ -6562,7 +6562,7 @@ pub const STM32F439ZI = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32F439ZI",
-        .cpu = MicroZig.cpus.cortex_m4,
+        .cpu = MicroZig.cpus.cortex_m4f,
         .memory_regions = &.{
             .{ .offset = 0x8000000, .length = 0x10000, .kind = .flash },
             .{ .offset = 0x8010000, .length = 0x10000, .kind = .flash },
@@ -6583,7 +6583,7 @@ pub const STM32F446MC = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32F446MC",
-        .cpu = MicroZig.cpus.cortex_m4,
+        .cpu = MicroZig.cpus.cortex_m4f,
         .memory_regions = &.{
             .{ .offset = 0x8000000, .length = 0x10000, .kind = .flash },
             .{ .offset = 0x8010000, .length = 0x10000, .kind = .flash },
@@ -6600,7 +6600,7 @@ pub const STM32F446ME = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32F446ME",
-        .cpu = MicroZig.cpus.cortex_m4,
+        .cpu = MicroZig.cpus.cortex_m4f,
         .memory_regions = &.{
             .{ .offset = 0x8000000, .length = 0x10000, .kind = .flash },
             .{ .offset = 0x8010000, .length = 0x10000, .kind = .flash },
@@ -6617,7 +6617,7 @@ pub const STM32F446RC = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32F446RC",
-        .cpu = MicroZig.cpus.cortex_m4,
+        .cpu = MicroZig.cpus.cortex_m4f,
         .memory_regions = &.{
             .{ .offset = 0x8000000, .length = 0x10000, .kind = .flash },
             .{ .offset = 0x8010000, .length = 0x10000, .kind = .flash },
@@ -6634,7 +6634,7 @@ pub const STM32F446RE = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32F446RE",
-        .cpu = MicroZig.cpus.cortex_m4,
+        .cpu = MicroZig.cpus.cortex_m4f,
         .memory_regions = &.{
             .{ .offset = 0x8000000, .length = 0x10000, .kind = .flash },
             .{ .offset = 0x8010000, .length = 0x10000, .kind = .flash },
@@ -6651,7 +6651,7 @@ pub const STM32F446VC = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32F446VC",
-        .cpu = MicroZig.cpus.cortex_m4,
+        .cpu = MicroZig.cpus.cortex_m4f,
         .memory_regions = &.{
             .{ .offset = 0x8000000, .length = 0x10000, .kind = .flash },
             .{ .offset = 0x8010000, .length = 0x10000, .kind = .flash },
@@ -6668,7 +6668,7 @@ pub const STM32F446VE = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32F446VE",
-        .cpu = MicroZig.cpus.cortex_m4,
+        .cpu = MicroZig.cpus.cortex_m4f,
         .memory_regions = &.{
             .{ .offset = 0x8000000, .length = 0x10000, .kind = .flash },
             .{ .offset = 0x8010000, .length = 0x10000, .kind = .flash },
@@ -6685,7 +6685,7 @@ pub const STM32F446ZC = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32F446ZC",
-        .cpu = MicroZig.cpus.cortex_m4,
+        .cpu = MicroZig.cpus.cortex_m4f,
         .memory_regions = &.{
             .{ .offset = 0x8000000, .length = 0x10000, .kind = .flash },
             .{ .offset = 0x8010000, .length = 0x10000, .kind = .flash },
@@ -6702,7 +6702,7 @@ pub const STM32F446ZE = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32F446ZE",
-        .cpu = MicroZig.cpus.cortex_m4,
+        .cpu = MicroZig.cpus.cortex_m4f,
         .memory_regions = &.{
             .{ .offset = 0x8000000, .length = 0x10000, .kind = .flash },
             .{ .offset = 0x8010000, .length = 0x10000, .kind = .flash },
@@ -6719,7 +6719,7 @@ pub const STM32F469AE = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32F469AE",
-        .cpu = MicroZig.cpus.cortex_m4,
+        .cpu = MicroZig.cpus.cortex_m4f,
         .memory_regions = &.{
             .{ .offset = 0x8000000, .length = 0x10000, .kind = .flash },
             .{ .offset = 0x8010000, .length = 0x10000, .kind = .flash },
@@ -6737,7 +6737,7 @@ pub const STM32F469AG = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32F469AG",
-        .cpu = MicroZig.cpus.cortex_m4,
+        .cpu = MicroZig.cpus.cortex_m4f,
         .memory_regions = &.{
             .{ .offset = 0x8000000, .length = 0x10000, .kind = .flash },
             .{ .offset = 0x8010000, .length = 0x10000, .kind = .flash },
@@ -6755,7 +6755,7 @@ pub const STM32F469AI = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32F469AI",
-        .cpu = MicroZig.cpus.cortex_m4,
+        .cpu = MicroZig.cpus.cortex_m4f,
         .memory_regions = &.{
             .{ .offset = 0x8000000, .length = 0x10000, .kind = .flash },
             .{ .offset = 0x8010000, .length = 0x10000, .kind = .flash },
@@ -6776,7 +6776,7 @@ pub const STM32F469BE = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32F469BE",
-        .cpu = MicroZig.cpus.cortex_m4,
+        .cpu = MicroZig.cpus.cortex_m4f,
         .memory_regions = &.{
             .{ .offset = 0x8000000, .length = 0x10000, .kind = .flash },
             .{ .offset = 0x8010000, .length = 0x10000, .kind = .flash },
@@ -6794,7 +6794,7 @@ pub const STM32F469BG = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32F469BG",
-        .cpu = MicroZig.cpus.cortex_m4,
+        .cpu = MicroZig.cpus.cortex_m4f,
         .memory_regions = &.{
             .{ .offset = 0x8000000, .length = 0x10000, .kind = .flash },
             .{ .offset = 0x8010000, .length = 0x10000, .kind = .flash },
@@ -6812,7 +6812,7 @@ pub const STM32F469BI = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32F469BI",
-        .cpu = MicroZig.cpus.cortex_m4,
+        .cpu = MicroZig.cpus.cortex_m4f,
         .memory_regions = &.{
             .{ .offset = 0x8000000, .length = 0x10000, .kind = .flash },
             .{ .offset = 0x8010000, .length = 0x10000, .kind = .flash },
@@ -6833,7 +6833,7 @@ pub const STM32F469IE = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32F469IE",
-        .cpu = MicroZig.cpus.cortex_m4,
+        .cpu = MicroZig.cpus.cortex_m4f,
         .memory_regions = &.{
             .{ .offset = 0x8000000, .length = 0x10000, .kind = .flash },
             .{ .offset = 0x8010000, .length = 0x10000, .kind = .flash },
@@ -6851,7 +6851,7 @@ pub const STM32F469IG = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32F469IG",
-        .cpu = MicroZig.cpus.cortex_m4,
+        .cpu = MicroZig.cpus.cortex_m4f,
         .memory_regions = &.{
             .{ .offset = 0x8000000, .length = 0x10000, .kind = .flash },
             .{ .offset = 0x8010000, .length = 0x10000, .kind = .flash },
@@ -6869,7 +6869,7 @@ pub const STM32F469II = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32F469II",
-        .cpu = MicroZig.cpus.cortex_m4,
+        .cpu = MicroZig.cpus.cortex_m4f,
         .memory_regions = &.{
             .{ .offset = 0x8000000, .length = 0x10000, .kind = .flash },
             .{ .offset = 0x8010000, .length = 0x10000, .kind = .flash },
@@ -6890,7 +6890,7 @@ pub const STM32F469NE = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32F469NE",
-        .cpu = MicroZig.cpus.cortex_m4,
+        .cpu = MicroZig.cpus.cortex_m4f,
         .memory_regions = &.{
             .{ .offset = 0x8000000, .length = 0x10000, .kind = .flash },
             .{ .offset = 0x8010000, .length = 0x10000, .kind = .flash },
@@ -6908,7 +6908,7 @@ pub const STM32F469NG = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32F469NG",
-        .cpu = MicroZig.cpus.cortex_m4,
+        .cpu = MicroZig.cpus.cortex_m4f,
         .memory_regions = &.{
             .{ .offset = 0x8000000, .length = 0x10000, .kind = .flash },
             .{ .offset = 0x8010000, .length = 0x10000, .kind = .flash },
@@ -6926,7 +6926,7 @@ pub const STM32F469NI = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32F469NI",
-        .cpu = MicroZig.cpus.cortex_m4,
+        .cpu = MicroZig.cpus.cortex_m4f,
         .memory_regions = &.{
             .{ .offset = 0x8000000, .length = 0x10000, .kind = .flash },
             .{ .offset = 0x8010000, .length = 0x10000, .kind = .flash },
@@ -6947,7 +6947,7 @@ pub const STM32F469VE = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32F469VE",
-        .cpu = MicroZig.cpus.cortex_m4,
+        .cpu = MicroZig.cpus.cortex_m4f,
         .memory_regions = &.{
             .{ .offset = 0x8000000, .length = 0x10000, .kind = .flash },
             .{ .offset = 0x8010000, .length = 0x10000, .kind = .flash },
@@ -6965,7 +6965,7 @@ pub const STM32F469VG = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32F469VG",
-        .cpu = MicroZig.cpus.cortex_m4,
+        .cpu = MicroZig.cpus.cortex_m4f,
         .memory_regions = &.{
             .{ .offset = 0x8000000, .length = 0x10000, .kind = .flash },
             .{ .offset = 0x8010000, .length = 0x10000, .kind = .flash },
@@ -6983,7 +6983,7 @@ pub const STM32F469VI = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32F469VI",
-        .cpu = MicroZig.cpus.cortex_m4,
+        .cpu = MicroZig.cpus.cortex_m4f,
         .memory_regions = &.{
             .{ .offset = 0x8000000, .length = 0x10000, .kind = .flash },
             .{ .offset = 0x8010000, .length = 0x10000, .kind = .flash },
@@ -7004,7 +7004,7 @@ pub const STM32F469ZE = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32F469ZE",
-        .cpu = MicroZig.cpus.cortex_m4,
+        .cpu = MicroZig.cpus.cortex_m4f,
         .memory_regions = &.{
             .{ .offset = 0x8000000, .length = 0x10000, .kind = .flash },
             .{ .offset = 0x8010000, .length = 0x10000, .kind = .flash },
@@ -7022,7 +7022,7 @@ pub const STM32F469ZG = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32F469ZG",
-        .cpu = MicroZig.cpus.cortex_m4,
+        .cpu = MicroZig.cpus.cortex_m4f,
         .memory_regions = &.{
             .{ .offset = 0x8000000, .length = 0x10000, .kind = .flash },
             .{ .offset = 0x8010000, .length = 0x10000, .kind = .flash },
@@ -7040,7 +7040,7 @@ pub const STM32F469ZI = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32F469ZI",
-        .cpu = MicroZig.cpus.cortex_m4,
+        .cpu = MicroZig.cpus.cortex_m4f,
         .memory_regions = &.{
             .{ .offset = 0x8000000, .length = 0x10000, .kind = .flash },
             .{ .offset = 0x8010000, .length = 0x10000, .kind = .flash },
@@ -7061,7 +7061,7 @@ pub const STM32F479AG = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32F479AG",
-        .cpu = MicroZig.cpus.cortex_m4,
+        .cpu = MicroZig.cpus.cortex_m4f,
         .memory_regions = &.{
             .{ .offset = 0x8000000, .length = 0x10000, .kind = .flash },
             .{ .offset = 0x8010000, .length = 0x10000, .kind = .flash },
@@ -7079,7 +7079,7 @@ pub const STM32F479AI = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32F479AI",
-        .cpu = MicroZig.cpus.cortex_m4,
+        .cpu = MicroZig.cpus.cortex_m4f,
         .memory_regions = &.{
             .{ .offset = 0x8000000, .length = 0x10000, .kind = .flash },
             .{ .offset = 0x8010000, .length = 0x10000, .kind = .flash },
@@ -7100,7 +7100,7 @@ pub const STM32F479BG = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32F479BG",
-        .cpu = MicroZig.cpus.cortex_m4,
+        .cpu = MicroZig.cpus.cortex_m4f,
         .memory_regions = &.{
             .{ .offset = 0x8000000, .length = 0x10000, .kind = .flash },
             .{ .offset = 0x8010000, .length = 0x10000, .kind = .flash },
@@ -7118,7 +7118,7 @@ pub const STM32F479BI = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32F479BI",
-        .cpu = MicroZig.cpus.cortex_m4,
+        .cpu = MicroZig.cpus.cortex_m4f,
         .memory_regions = &.{
             .{ .offset = 0x8000000, .length = 0x10000, .kind = .flash },
             .{ .offset = 0x8010000, .length = 0x10000, .kind = .flash },
@@ -7139,7 +7139,7 @@ pub const STM32F479IG = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32F479IG",
-        .cpu = MicroZig.cpus.cortex_m4,
+        .cpu = MicroZig.cpus.cortex_m4f,
         .memory_regions = &.{
             .{ .offset = 0x8000000, .length = 0x10000, .kind = .flash },
             .{ .offset = 0x8010000, .length = 0x10000, .kind = .flash },
@@ -7157,7 +7157,7 @@ pub const STM32F479II = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32F479II",
-        .cpu = MicroZig.cpus.cortex_m4,
+        .cpu = MicroZig.cpus.cortex_m4f,
         .memory_regions = &.{
             .{ .offset = 0x8000000, .length = 0x10000, .kind = .flash },
             .{ .offset = 0x8010000, .length = 0x10000, .kind = .flash },
@@ -7178,7 +7178,7 @@ pub const STM32F479NG = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32F479NG",
-        .cpu = MicroZig.cpus.cortex_m4,
+        .cpu = MicroZig.cpus.cortex_m4f,
         .memory_regions = &.{
             .{ .offset = 0x8000000, .length = 0x10000, .kind = .flash },
             .{ .offset = 0x8010000, .length = 0x10000, .kind = .flash },
@@ -7196,7 +7196,7 @@ pub const STM32F479NI = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32F479NI",
-        .cpu = MicroZig.cpus.cortex_m4,
+        .cpu = MicroZig.cpus.cortex_m4f,
         .memory_regions = &.{
             .{ .offset = 0x8000000, .length = 0x10000, .kind = .flash },
             .{ .offset = 0x8010000, .length = 0x10000, .kind = .flash },
@@ -7217,7 +7217,7 @@ pub const STM32F479VG = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32F479VG",
-        .cpu = MicroZig.cpus.cortex_m4,
+        .cpu = MicroZig.cpus.cortex_m4f,
         .memory_regions = &.{
             .{ .offset = 0x8000000, .length = 0x10000, .kind = .flash },
             .{ .offset = 0x8010000, .length = 0x10000, .kind = .flash },
@@ -7235,7 +7235,7 @@ pub const STM32F479VI = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32F479VI",
-        .cpu = MicroZig.cpus.cortex_m4,
+        .cpu = MicroZig.cpus.cortex_m4f,
         .memory_regions = &.{
             .{ .offset = 0x8000000, .length = 0x10000, .kind = .flash },
             .{ .offset = 0x8010000, .length = 0x10000, .kind = .flash },
@@ -7256,7 +7256,7 @@ pub const STM32F479ZG = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32F479ZG",
-        .cpu = MicroZig.cpus.cortex_m4,
+        .cpu = MicroZig.cpus.cortex_m4f,
         .memory_regions = &.{
             .{ .offset = 0x8000000, .length = 0x10000, .kind = .flash },
             .{ .offset = 0x8010000, .length = 0x10000, .kind = .flash },
@@ -7274,7 +7274,7 @@ pub const STM32F479ZI = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32F479ZI",
-        .cpu = MicroZig.cpus.cortex_m4,
+        .cpu = MicroZig.cpus.cortex_m4f,
         .memory_regions = &.{
             .{ .offset = 0x8000000, .length = 0x10000, .kind = .flash },
             .{ .offset = 0x8010000, .length = 0x10000, .kind = .flash },
@@ -7295,7 +7295,7 @@ pub const STM32F722IC = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32F722IC",
-        .cpu = MicroZig.cpus.cortex_m7,
+        .cpu = MicroZig.cpus.cortex_m7f,
         .memory_regions = &.{
             .{ .offset = 0x8000000, .length = 0x10000, .kind = .flash },
             .{ .offset = 0x8010000, .length = 0x10000, .kind = .flash },
@@ -7313,7 +7313,7 @@ pub const STM32F722IE = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32F722IE",
-        .cpu = MicroZig.cpus.cortex_m7,
+        .cpu = MicroZig.cpus.cortex_m7f,
         .memory_regions = &.{
             .{ .offset = 0x8000000, .length = 0x10000, .kind = .flash },
             .{ .offset = 0x8010000, .length = 0x10000, .kind = .flash },
@@ -7331,7 +7331,7 @@ pub const STM32F722RC = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32F722RC",
-        .cpu = MicroZig.cpus.cortex_m7,
+        .cpu = MicroZig.cpus.cortex_m7f,
         .memory_regions = &.{
             .{ .offset = 0x8000000, .length = 0x10000, .kind = .flash },
             .{ .offset = 0x8010000, .length = 0x10000, .kind = .flash },
@@ -7349,7 +7349,7 @@ pub const STM32F722RE = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32F722RE",
-        .cpu = MicroZig.cpus.cortex_m7,
+        .cpu = MicroZig.cpus.cortex_m7f,
         .memory_regions = &.{
             .{ .offset = 0x8000000, .length = 0x10000, .kind = .flash },
             .{ .offset = 0x8010000, .length = 0x10000, .kind = .flash },
@@ -7367,7 +7367,7 @@ pub const STM32F722VC = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32F722VC",
-        .cpu = MicroZig.cpus.cortex_m7,
+        .cpu = MicroZig.cpus.cortex_m7f,
         .memory_regions = &.{
             .{ .offset = 0x8000000, .length = 0x10000, .kind = .flash },
             .{ .offset = 0x8010000, .length = 0x10000, .kind = .flash },
@@ -7385,7 +7385,7 @@ pub const STM32F722VE = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32F722VE",
-        .cpu = MicroZig.cpus.cortex_m7,
+        .cpu = MicroZig.cpus.cortex_m7f,
         .memory_regions = &.{
             .{ .offset = 0x8000000, .length = 0x10000, .kind = .flash },
             .{ .offset = 0x8010000, .length = 0x10000, .kind = .flash },
@@ -7403,7 +7403,7 @@ pub const STM32F722ZC = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32F722ZC",
-        .cpu = MicroZig.cpus.cortex_m7,
+        .cpu = MicroZig.cpus.cortex_m7f,
         .memory_regions = &.{
             .{ .offset = 0x8000000, .length = 0x10000, .kind = .flash },
             .{ .offset = 0x8010000, .length = 0x10000, .kind = .flash },
@@ -7421,7 +7421,7 @@ pub const STM32F722ZE = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32F722ZE",
-        .cpu = MicroZig.cpus.cortex_m7,
+        .cpu = MicroZig.cpus.cortex_m7f,
         .memory_regions = &.{
             .{ .offset = 0x8000000, .length = 0x10000, .kind = .flash },
             .{ .offset = 0x8010000, .length = 0x10000, .kind = .flash },
@@ -7439,7 +7439,7 @@ pub const STM32F723IC = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32F723IC",
-        .cpu = MicroZig.cpus.cortex_m7,
+        .cpu = MicroZig.cpus.cortex_m7f,
         .memory_regions = &.{
             .{ .offset = 0x8000000, .length = 0x10000, .kind = .flash },
             .{ .offset = 0x8010000, .length = 0x10000, .kind = .flash },
@@ -7457,7 +7457,7 @@ pub const STM32F723IE = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32F723IE",
-        .cpu = MicroZig.cpus.cortex_m7,
+        .cpu = MicroZig.cpus.cortex_m7f,
         .memory_regions = &.{
             .{ .offset = 0x8000000, .length = 0x10000, .kind = .flash },
             .{ .offset = 0x8010000, .length = 0x10000, .kind = .flash },
@@ -7475,7 +7475,7 @@ pub const STM32F723VC = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32F723VC",
-        .cpu = MicroZig.cpus.cortex_m7,
+        .cpu = MicroZig.cpus.cortex_m7f,
         .memory_regions = &.{
             .{ .offset = 0x8000000, .length = 0x10000, .kind = .flash },
             .{ .offset = 0x8010000, .length = 0x10000, .kind = .flash },
@@ -7493,7 +7493,7 @@ pub const STM32F723VE = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32F723VE",
-        .cpu = MicroZig.cpus.cortex_m7,
+        .cpu = MicroZig.cpus.cortex_m7f,
         .memory_regions = &.{
             .{ .offset = 0x8000000, .length = 0x10000, .kind = .flash },
             .{ .offset = 0x8010000, .length = 0x10000, .kind = .flash },
@@ -7511,7 +7511,7 @@ pub const STM32F723ZC = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32F723ZC",
-        .cpu = MicroZig.cpus.cortex_m7,
+        .cpu = MicroZig.cpus.cortex_m7f,
         .memory_regions = &.{
             .{ .offset = 0x8000000, .length = 0x10000, .kind = .flash },
             .{ .offset = 0x8010000, .length = 0x10000, .kind = .flash },
@@ -7529,7 +7529,7 @@ pub const STM32F723ZE = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32F723ZE",
-        .cpu = MicroZig.cpus.cortex_m7,
+        .cpu = MicroZig.cpus.cortex_m7f,
         .memory_regions = &.{
             .{ .offset = 0x8000000, .length = 0x10000, .kind = .flash },
             .{ .offset = 0x8010000, .length = 0x10000, .kind = .flash },
@@ -7547,7 +7547,7 @@ pub const STM32F730I8 = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32F730I8",
-        .cpu = MicroZig.cpus.cortex_m7,
+        .cpu = MicroZig.cpus.cortex_m7f,
         .memory_regions = &.{
             .{ .offset = 0x8000000, .length = 0x10000, .kind = .flash },
             .{ .offset = 0x20000000, .length = 0x10000, .kind = .ram },
@@ -7563,7 +7563,7 @@ pub const STM32F730R8 = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32F730R8",
-        .cpu = MicroZig.cpus.cortex_m7,
+        .cpu = MicroZig.cpus.cortex_m7f,
         .memory_regions = &.{
             .{ .offset = 0x8000000, .length = 0x10000, .kind = .flash },
             .{ .offset = 0x20000000, .length = 0x10000, .kind = .ram },
@@ -7579,7 +7579,7 @@ pub const STM32F730V8 = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32F730V8",
-        .cpu = MicroZig.cpus.cortex_m7,
+        .cpu = MicroZig.cpus.cortex_m7f,
         .memory_regions = &.{
             .{ .offset = 0x8000000, .length = 0x10000, .kind = .flash },
             .{ .offset = 0x20000000, .length = 0x10000, .kind = .ram },
@@ -7595,7 +7595,7 @@ pub const STM32F730Z8 = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32F730Z8",
-        .cpu = MicroZig.cpus.cortex_m7,
+        .cpu = MicroZig.cpus.cortex_m7f,
         .memory_regions = &.{
             .{ .offset = 0x8000000, .length = 0x10000, .kind = .flash },
             .{ .offset = 0x20000000, .length = 0x10000, .kind = .ram },
@@ -7611,7 +7611,7 @@ pub const STM32F732IE = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32F732IE",
-        .cpu = MicroZig.cpus.cortex_m7,
+        .cpu = MicroZig.cpus.cortex_m7f,
         .memory_regions = &.{
             .{ .offset = 0x8000000, .length = 0x10000, .kind = .flash },
             .{ .offset = 0x8010000, .length = 0x10000, .kind = .flash },
@@ -7629,7 +7629,7 @@ pub const STM32F732RE = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32F732RE",
-        .cpu = MicroZig.cpus.cortex_m7,
+        .cpu = MicroZig.cpus.cortex_m7f,
         .memory_regions = &.{
             .{ .offset = 0x8000000, .length = 0x10000, .kind = .flash },
             .{ .offset = 0x8010000, .length = 0x10000, .kind = .flash },
@@ -7647,7 +7647,7 @@ pub const STM32F732VE = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32F732VE",
-        .cpu = MicroZig.cpus.cortex_m7,
+        .cpu = MicroZig.cpus.cortex_m7f,
         .memory_regions = &.{
             .{ .offset = 0x8000000, .length = 0x10000, .kind = .flash },
             .{ .offset = 0x8010000, .length = 0x10000, .kind = .flash },
@@ -7665,7 +7665,7 @@ pub const STM32F732ZE = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32F732ZE",
-        .cpu = MicroZig.cpus.cortex_m7,
+        .cpu = MicroZig.cpus.cortex_m7f,
         .memory_regions = &.{
             .{ .offset = 0x8000000, .length = 0x10000, .kind = .flash },
             .{ .offset = 0x8010000, .length = 0x10000, .kind = .flash },
@@ -7683,7 +7683,7 @@ pub const STM32F733IE = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32F733IE",
-        .cpu = MicroZig.cpus.cortex_m7,
+        .cpu = MicroZig.cpus.cortex_m7f,
         .memory_regions = &.{
             .{ .offset = 0x8000000, .length = 0x10000, .kind = .flash },
             .{ .offset = 0x8010000, .length = 0x10000, .kind = .flash },
@@ -7701,7 +7701,7 @@ pub const STM32F733VE = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32F733VE",
-        .cpu = MicroZig.cpus.cortex_m7,
+        .cpu = MicroZig.cpus.cortex_m7f,
         .memory_regions = &.{
             .{ .offset = 0x8000000, .length = 0x10000, .kind = .flash },
             .{ .offset = 0x8010000, .length = 0x10000, .kind = .flash },
@@ -7719,7 +7719,7 @@ pub const STM32F733ZE = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32F733ZE",
-        .cpu = MicroZig.cpus.cortex_m7,
+        .cpu = MicroZig.cpus.cortex_m7f,
         .memory_regions = &.{
             .{ .offset = 0x8000000, .length = 0x10000, .kind = .flash },
             .{ .offset = 0x8010000, .length = 0x10000, .kind = .flash },
@@ -7737,7 +7737,7 @@ pub const STM32F745IE = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32F745IE",
-        .cpu = MicroZig.cpus.cortex_m7,
+        .cpu = MicroZig.cpus.cortex_m7f,
         .memory_regions = &.{
             .{ .offset = 0x8000000, .length = 0x20000, .kind = .flash },
             .{ .offset = 0x8020000, .length = 0x20000, .kind = .flash },
@@ -7755,7 +7755,7 @@ pub const STM32F745IG = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32F745IG",
-        .cpu = MicroZig.cpus.cortex_m7,
+        .cpu = MicroZig.cpus.cortex_m7f,
         .memory_regions = &.{
             .{ .offset = 0x8000000, .length = 0x20000, .kind = .flash },
             .{ .offset = 0x8020000, .length = 0x20000, .kind = .flash },
@@ -7773,7 +7773,7 @@ pub const STM32F745VE = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32F745VE",
-        .cpu = MicroZig.cpus.cortex_m7,
+        .cpu = MicroZig.cpus.cortex_m7f,
         .memory_regions = &.{
             .{ .offset = 0x8000000, .length = 0x20000, .kind = .flash },
             .{ .offset = 0x8020000, .length = 0x20000, .kind = .flash },
@@ -7791,7 +7791,7 @@ pub const STM32F745VG = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32F745VG",
-        .cpu = MicroZig.cpus.cortex_m7,
+        .cpu = MicroZig.cpus.cortex_m7f,
         .memory_regions = &.{
             .{ .offset = 0x8000000, .length = 0x20000, .kind = .flash },
             .{ .offset = 0x8020000, .length = 0x20000, .kind = .flash },
@@ -7809,7 +7809,7 @@ pub const STM32F745ZE = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32F745ZE",
-        .cpu = MicroZig.cpus.cortex_m7,
+        .cpu = MicroZig.cpus.cortex_m7f,
         .memory_regions = &.{
             .{ .offset = 0x8000000, .length = 0x20000, .kind = .flash },
             .{ .offset = 0x8020000, .length = 0x20000, .kind = .flash },
@@ -7827,7 +7827,7 @@ pub const STM32F745ZG = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32F745ZG",
-        .cpu = MicroZig.cpus.cortex_m7,
+        .cpu = MicroZig.cpus.cortex_m7f,
         .memory_regions = &.{
             .{ .offset = 0x8000000, .length = 0x20000, .kind = .flash },
             .{ .offset = 0x8020000, .length = 0x20000, .kind = .flash },
@@ -7845,7 +7845,7 @@ pub const STM32F746BE = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32F746BE",
-        .cpu = MicroZig.cpus.cortex_m7,
+        .cpu = MicroZig.cpus.cortex_m7f,
         .memory_regions = &.{
             .{ .offset = 0x8000000, .length = 0x20000, .kind = .flash },
             .{ .offset = 0x8020000, .length = 0x20000, .kind = .flash },
@@ -7863,7 +7863,7 @@ pub const STM32F746BG = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32F746BG",
-        .cpu = MicroZig.cpus.cortex_m7,
+        .cpu = MicroZig.cpus.cortex_m7f,
         .memory_regions = &.{
             .{ .offset = 0x8000000, .length = 0x20000, .kind = .flash },
             .{ .offset = 0x8020000, .length = 0x20000, .kind = .flash },
@@ -7881,7 +7881,7 @@ pub const STM32F746IE = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32F746IE",
-        .cpu = MicroZig.cpus.cortex_m7,
+        .cpu = MicroZig.cpus.cortex_m7f,
         .memory_regions = &.{
             .{ .offset = 0x8000000, .length = 0x20000, .kind = .flash },
             .{ .offset = 0x8020000, .length = 0x20000, .kind = .flash },
@@ -7899,7 +7899,7 @@ pub const STM32F746IG = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32F746IG",
-        .cpu = MicroZig.cpus.cortex_m7,
+        .cpu = MicroZig.cpus.cortex_m7f,
         .memory_regions = &.{
             .{ .offset = 0x8000000, .length = 0x20000, .kind = .flash },
             .{ .offset = 0x8020000, .length = 0x20000, .kind = .flash },
@@ -7917,7 +7917,7 @@ pub const STM32F746NE = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32F746NE",
-        .cpu = MicroZig.cpus.cortex_m7,
+        .cpu = MicroZig.cpus.cortex_m7f,
         .memory_regions = &.{
             .{ .offset = 0x8000000, .length = 0x20000, .kind = .flash },
             .{ .offset = 0x8020000, .length = 0x20000, .kind = .flash },
@@ -7935,7 +7935,7 @@ pub const STM32F746NG = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32F746NG",
-        .cpu = MicroZig.cpus.cortex_m7,
+        .cpu = MicroZig.cpus.cortex_m7f,
         .memory_regions = &.{
             .{ .offset = 0x8000000, .length = 0x20000, .kind = .flash },
             .{ .offset = 0x8020000, .length = 0x20000, .kind = .flash },
@@ -7953,7 +7953,7 @@ pub const STM32F746VE = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32F746VE",
-        .cpu = MicroZig.cpus.cortex_m7,
+        .cpu = MicroZig.cpus.cortex_m7f,
         .memory_regions = &.{
             .{ .offset = 0x8000000, .length = 0x20000, .kind = .flash },
             .{ .offset = 0x8020000, .length = 0x20000, .kind = .flash },
@@ -7971,7 +7971,7 @@ pub const STM32F746VG = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32F746VG",
-        .cpu = MicroZig.cpus.cortex_m7,
+        .cpu = MicroZig.cpus.cortex_m7f,
         .memory_regions = &.{
             .{ .offset = 0x8000000, .length = 0x20000, .kind = .flash },
             .{ .offset = 0x8020000, .length = 0x20000, .kind = .flash },
@@ -7989,7 +7989,7 @@ pub const STM32F746ZE = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32F746ZE",
-        .cpu = MicroZig.cpus.cortex_m7,
+        .cpu = MicroZig.cpus.cortex_m7f,
         .memory_regions = &.{
             .{ .offset = 0x8000000, .length = 0x20000, .kind = .flash },
             .{ .offset = 0x8020000, .length = 0x20000, .kind = .flash },
@@ -8007,7 +8007,7 @@ pub const STM32F746ZG = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32F746ZG",
-        .cpu = MicroZig.cpus.cortex_m7,
+        .cpu = MicroZig.cpus.cortex_m7f,
         .memory_regions = &.{
             .{ .offset = 0x8000000, .length = 0x20000, .kind = .flash },
             .{ .offset = 0x8020000, .length = 0x20000, .kind = .flash },
@@ -8025,7 +8025,7 @@ pub const STM32F750N8 = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32F750N8",
-        .cpu = MicroZig.cpus.cortex_m7,
+        .cpu = MicroZig.cpus.cortex_m7f,
         .memory_regions = &.{
             .{ .offset = 0x8000000, .length = 0x10000, .kind = .flash },
             .{ .offset = 0x20000000, .length = 0x10000, .kind = .ram },
@@ -8041,7 +8041,7 @@ pub const STM32F750V8 = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32F750V8",
-        .cpu = MicroZig.cpus.cortex_m7,
+        .cpu = MicroZig.cpus.cortex_m7f,
         .memory_regions = &.{
             .{ .offset = 0x8000000, .length = 0x10000, .kind = .flash },
             .{ .offset = 0x20000000, .length = 0x10000, .kind = .ram },
@@ -8057,7 +8057,7 @@ pub const STM32F750Z8 = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32F750Z8",
-        .cpu = MicroZig.cpus.cortex_m7,
+        .cpu = MicroZig.cpus.cortex_m7f,
         .memory_regions = &.{
             .{ .offset = 0x8000000, .length = 0x10000, .kind = .flash },
             .{ .offset = 0x20000000, .length = 0x10000, .kind = .ram },
@@ -8073,7 +8073,7 @@ pub const STM32F756BG = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32F756BG",
-        .cpu = MicroZig.cpus.cortex_m7,
+        .cpu = MicroZig.cpus.cortex_m7f,
         .memory_regions = &.{
             .{ .offset = 0x8000000, .length = 0x20000, .kind = .flash },
             .{ .offset = 0x8020000, .length = 0x20000, .kind = .flash },
@@ -8091,7 +8091,7 @@ pub const STM32F756IG = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32F756IG",
-        .cpu = MicroZig.cpus.cortex_m7,
+        .cpu = MicroZig.cpus.cortex_m7f,
         .memory_regions = &.{
             .{ .offset = 0x8000000, .length = 0x20000, .kind = .flash },
             .{ .offset = 0x8020000, .length = 0x20000, .kind = .flash },
@@ -8109,7 +8109,7 @@ pub const STM32F756NG = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32F756NG",
-        .cpu = MicroZig.cpus.cortex_m7,
+        .cpu = MicroZig.cpus.cortex_m7f,
         .memory_regions = &.{
             .{ .offset = 0x8000000, .length = 0x20000, .kind = .flash },
             .{ .offset = 0x8020000, .length = 0x20000, .kind = .flash },
@@ -8127,7 +8127,7 @@ pub const STM32F756VG = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32F756VG",
-        .cpu = MicroZig.cpus.cortex_m7,
+        .cpu = MicroZig.cpus.cortex_m7f,
         .memory_regions = &.{
             .{ .offset = 0x8000000, .length = 0x20000, .kind = .flash },
             .{ .offset = 0x8020000, .length = 0x20000, .kind = .flash },
@@ -8145,7 +8145,7 @@ pub const STM32F756ZG = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32F756ZG",
-        .cpu = MicroZig.cpus.cortex_m7,
+        .cpu = MicroZig.cpus.cortex_m7f,
         .memory_regions = &.{
             .{ .offset = 0x8000000, .length = 0x20000, .kind = .flash },
             .{ .offset = 0x8020000, .length = 0x20000, .kind = .flash },
@@ -8163,7 +8163,7 @@ pub const STM32F765BG = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32F765BG",
-        .cpu = MicroZig.cpus.cortex_m7,
+        .cpu = MicroZig.cpus.cortex_m7f,
         .memory_regions = &.{
             .{ .offset = 0x8000000, .length = 0x20000, .kind = .flash },
             .{ .offset = 0x8020000, .length = 0x20000, .kind = .flash },
@@ -8181,7 +8181,7 @@ pub const STM32F765BI = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32F765BI",
-        .cpu = MicroZig.cpus.cortex_m7,
+        .cpu = MicroZig.cpus.cortex_m7f,
         .memory_regions = &.{
             .{ .offset = 0x8000000, .length = 0x20000, .kind = .flash },
             .{ .offset = 0x8020000, .length = 0x20000, .kind = .flash },
@@ -8199,7 +8199,7 @@ pub const STM32F765IG = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32F765IG",
-        .cpu = MicroZig.cpus.cortex_m7,
+        .cpu = MicroZig.cpus.cortex_m7f,
         .memory_regions = &.{
             .{ .offset = 0x8000000, .length = 0x20000, .kind = .flash },
             .{ .offset = 0x8020000, .length = 0x20000, .kind = .flash },
@@ -8217,7 +8217,7 @@ pub const STM32F765II = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32F765II",
-        .cpu = MicroZig.cpus.cortex_m7,
+        .cpu = MicroZig.cpus.cortex_m7f,
         .memory_regions = &.{
             .{ .offset = 0x8000000, .length = 0x20000, .kind = .flash },
             .{ .offset = 0x8020000, .length = 0x20000, .kind = .flash },
@@ -8235,7 +8235,7 @@ pub const STM32F765NG = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32F765NG",
-        .cpu = MicroZig.cpus.cortex_m7,
+        .cpu = MicroZig.cpus.cortex_m7f,
         .memory_regions = &.{
             .{ .offset = 0x8000000, .length = 0x20000, .kind = .flash },
             .{ .offset = 0x8020000, .length = 0x20000, .kind = .flash },
@@ -8253,7 +8253,7 @@ pub const STM32F765NI = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32F765NI",
-        .cpu = MicroZig.cpus.cortex_m7,
+        .cpu = MicroZig.cpus.cortex_m7f,
         .memory_regions = &.{
             .{ .offset = 0x8000000, .length = 0x20000, .kind = .flash },
             .{ .offset = 0x8020000, .length = 0x20000, .kind = .flash },
@@ -8271,7 +8271,7 @@ pub const STM32F765VG = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32F765VG",
-        .cpu = MicroZig.cpus.cortex_m7,
+        .cpu = MicroZig.cpus.cortex_m7f,
         .memory_regions = &.{
             .{ .offset = 0x8000000, .length = 0x20000, .kind = .flash },
             .{ .offset = 0x8020000, .length = 0x20000, .kind = .flash },
@@ -8289,7 +8289,7 @@ pub const STM32F765VI = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32F765VI",
-        .cpu = MicroZig.cpus.cortex_m7,
+        .cpu = MicroZig.cpus.cortex_m7f,
         .memory_regions = &.{
             .{ .offset = 0x8000000, .length = 0x20000, .kind = .flash },
             .{ .offset = 0x8020000, .length = 0x20000, .kind = .flash },
@@ -8307,7 +8307,7 @@ pub const STM32F765ZG = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32F765ZG",
-        .cpu = MicroZig.cpus.cortex_m7,
+        .cpu = MicroZig.cpus.cortex_m7f,
         .memory_regions = &.{
             .{ .offset = 0x8000000, .length = 0x20000, .kind = .flash },
             .{ .offset = 0x8020000, .length = 0x20000, .kind = .flash },
@@ -8325,7 +8325,7 @@ pub const STM32F765ZI = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32F765ZI",
-        .cpu = MicroZig.cpus.cortex_m7,
+        .cpu = MicroZig.cpus.cortex_m7f,
         .memory_regions = &.{
             .{ .offset = 0x8000000, .length = 0x20000, .kind = .flash },
             .{ .offset = 0x8020000, .length = 0x20000, .kind = .flash },
@@ -8343,7 +8343,7 @@ pub const STM32F767BG = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32F767BG",
-        .cpu = MicroZig.cpus.cortex_m7,
+        .cpu = MicroZig.cpus.cortex_m7f,
         .memory_regions = &.{
             .{ .offset = 0x8000000, .length = 0x20000, .kind = .flash },
             .{ .offset = 0x8020000, .length = 0x20000, .kind = .flash },
@@ -8361,7 +8361,7 @@ pub const STM32F767BI = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32F767BI",
-        .cpu = MicroZig.cpus.cortex_m7,
+        .cpu = MicroZig.cpus.cortex_m7f,
         .memory_regions = &.{
             .{ .offset = 0x8000000, .length = 0x20000, .kind = .flash },
             .{ .offset = 0x8020000, .length = 0x20000, .kind = .flash },
@@ -8379,7 +8379,7 @@ pub const STM32F767IG = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32F767IG",
-        .cpu = MicroZig.cpus.cortex_m7,
+        .cpu = MicroZig.cpus.cortex_m7f,
         .memory_regions = &.{
             .{ .offset = 0x8000000, .length = 0x20000, .kind = .flash },
             .{ .offset = 0x8020000, .length = 0x20000, .kind = .flash },
@@ -8397,7 +8397,7 @@ pub const STM32F767II = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32F767II",
-        .cpu = MicroZig.cpus.cortex_m7,
+        .cpu = MicroZig.cpus.cortex_m7f,
         .memory_regions = &.{
             .{ .offset = 0x8000000, .length = 0x20000, .kind = .flash },
             .{ .offset = 0x8020000, .length = 0x20000, .kind = .flash },
@@ -8415,7 +8415,7 @@ pub const STM32F767NG = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32F767NG",
-        .cpu = MicroZig.cpus.cortex_m7,
+        .cpu = MicroZig.cpus.cortex_m7f,
         .memory_regions = &.{
             .{ .offset = 0x8000000, .length = 0x20000, .kind = .flash },
             .{ .offset = 0x8020000, .length = 0x20000, .kind = .flash },
@@ -8433,7 +8433,7 @@ pub const STM32F767NI = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32F767NI",
-        .cpu = MicroZig.cpus.cortex_m7,
+        .cpu = MicroZig.cpus.cortex_m7f,
         .memory_regions = &.{
             .{ .offset = 0x8000000, .length = 0x20000, .kind = .flash },
             .{ .offset = 0x8020000, .length = 0x20000, .kind = .flash },
@@ -8451,7 +8451,7 @@ pub const STM32F767VG = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32F767VG",
-        .cpu = MicroZig.cpus.cortex_m7,
+        .cpu = MicroZig.cpus.cortex_m7f,
         .memory_regions = &.{
             .{ .offset = 0x8000000, .length = 0x20000, .kind = .flash },
             .{ .offset = 0x8020000, .length = 0x20000, .kind = .flash },
@@ -8469,7 +8469,7 @@ pub const STM32F767VI = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32F767VI",
-        .cpu = MicroZig.cpus.cortex_m7,
+        .cpu = MicroZig.cpus.cortex_m7f,
         .memory_regions = &.{
             .{ .offset = 0x8000000, .length = 0x20000, .kind = .flash },
             .{ .offset = 0x8020000, .length = 0x20000, .kind = .flash },
@@ -8487,7 +8487,7 @@ pub const STM32F767ZG = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32F767ZG",
-        .cpu = MicroZig.cpus.cortex_m7,
+        .cpu = MicroZig.cpus.cortex_m7f,
         .memory_regions = &.{
             .{ .offset = 0x8000000, .length = 0x20000, .kind = .flash },
             .{ .offset = 0x8020000, .length = 0x20000, .kind = .flash },
@@ -8505,7 +8505,7 @@ pub const STM32F767ZI = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32F767ZI",
-        .cpu = MicroZig.cpus.cortex_m7,
+        .cpu = MicroZig.cpus.cortex_m7f,
         .memory_regions = &.{
             .{ .offset = 0x8000000, .length = 0x20000, .kind = .flash },
             .{ .offset = 0x8020000, .length = 0x20000, .kind = .flash },
@@ -8523,7 +8523,7 @@ pub const STM32F768AI = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32F768AI",
-        .cpu = MicroZig.cpus.cortex_m7,
+        .cpu = MicroZig.cpus.cortex_m7f,
         .memory_regions = &.{
             .{ .offset = 0x8000000, .length = 0x20000, .kind = .flash },
             .{ .offset = 0x8020000, .length = 0x20000, .kind = .flash },
@@ -8541,7 +8541,7 @@ pub const STM32F769AG = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32F769AG",
-        .cpu = MicroZig.cpus.cortex_m7,
+        .cpu = MicroZig.cpus.cortex_m7f,
         .memory_regions = &.{
             .{ .offset = 0x8000000, .length = 0x20000, .kind = .flash },
             .{ .offset = 0x8020000, .length = 0x20000, .kind = .flash },
@@ -8559,7 +8559,7 @@ pub const STM32F769AI = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32F769AI",
-        .cpu = MicroZig.cpus.cortex_m7,
+        .cpu = MicroZig.cpus.cortex_m7f,
         .memory_regions = &.{
             .{ .offset = 0x8000000, .length = 0x20000, .kind = .flash },
             .{ .offset = 0x8020000, .length = 0x20000, .kind = .flash },
@@ -8577,7 +8577,7 @@ pub const STM32F769BG = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32F769BG",
-        .cpu = MicroZig.cpus.cortex_m7,
+        .cpu = MicroZig.cpus.cortex_m7f,
         .memory_regions = &.{
             .{ .offset = 0x8000000, .length = 0x20000, .kind = .flash },
             .{ .offset = 0x8020000, .length = 0x20000, .kind = .flash },
@@ -8595,7 +8595,7 @@ pub const STM32F769BI = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32F769BI",
-        .cpu = MicroZig.cpus.cortex_m7,
+        .cpu = MicroZig.cpus.cortex_m7f,
         .memory_regions = &.{
             .{ .offset = 0x8000000, .length = 0x20000, .kind = .flash },
             .{ .offset = 0x8020000, .length = 0x20000, .kind = .flash },
@@ -8613,7 +8613,7 @@ pub const STM32F769IG = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32F769IG",
-        .cpu = MicroZig.cpus.cortex_m7,
+        .cpu = MicroZig.cpus.cortex_m7f,
         .memory_regions = &.{
             .{ .offset = 0x8000000, .length = 0x20000, .kind = .flash },
             .{ .offset = 0x8020000, .length = 0x20000, .kind = .flash },
@@ -8631,7 +8631,7 @@ pub const STM32F769II = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32F769II",
-        .cpu = MicroZig.cpus.cortex_m7,
+        .cpu = MicroZig.cpus.cortex_m7f,
         .memory_regions = &.{
             .{ .offset = 0x8000000, .length = 0x20000, .kind = .flash },
             .{ .offset = 0x8020000, .length = 0x20000, .kind = .flash },
@@ -8649,7 +8649,7 @@ pub const STM32F769NG = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32F769NG",
-        .cpu = MicroZig.cpus.cortex_m7,
+        .cpu = MicroZig.cpus.cortex_m7f,
         .memory_regions = &.{
             .{ .offset = 0x8000000, .length = 0x20000, .kind = .flash },
             .{ .offset = 0x8020000, .length = 0x20000, .kind = .flash },
@@ -8667,7 +8667,7 @@ pub const STM32F769NI = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32F769NI",
-        .cpu = MicroZig.cpus.cortex_m7,
+        .cpu = MicroZig.cpus.cortex_m7f,
         .memory_regions = &.{
             .{ .offset = 0x8000000, .length = 0x20000, .kind = .flash },
             .{ .offset = 0x8020000, .length = 0x20000, .kind = .flash },
@@ -8685,7 +8685,7 @@ pub const STM32F777BI = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32F777BI",
-        .cpu = MicroZig.cpus.cortex_m7,
+        .cpu = MicroZig.cpus.cortex_m7f,
         .memory_regions = &.{
             .{ .offset = 0x8000000, .length = 0x20000, .kind = .flash },
             .{ .offset = 0x8020000, .length = 0x20000, .kind = .flash },
@@ -8703,7 +8703,7 @@ pub const STM32F777II = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32F777II",
-        .cpu = MicroZig.cpus.cortex_m7,
+        .cpu = MicroZig.cpus.cortex_m7f,
         .memory_regions = &.{
             .{ .offset = 0x8000000, .length = 0x20000, .kind = .flash },
             .{ .offset = 0x8020000, .length = 0x20000, .kind = .flash },
@@ -8721,7 +8721,7 @@ pub const STM32F777NI = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32F777NI",
-        .cpu = MicroZig.cpus.cortex_m7,
+        .cpu = MicroZig.cpus.cortex_m7f,
         .memory_regions = &.{
             .{ .offset = 0x8000000, .length = 0x20000, .kind = .flash },
             .{ .offset = 0x8020000, .length = 0x20000, .kind = .flash },
@@ -8739,7 +8739,7 @@ pub const STM32F777VI = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32F777VI",
-        .cpu = MicroZig.cpus.cortex_m7,
+        .cpu = MicroZig.cpus.cortex_m7f,
         .memory_regions = &.{
             .{ .offset = 0x8000000, .length = 0x20000, .kind = .flash },
             .{ .offset = 0x8020000, .length = 0x20000, .kind = .flash },
@@ -8757,7 +8757,7 @@ pub const STM32F777ZI = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32F777ZI",
-        .cpu = MicroZig.cpus.cortex_m7,
+        .cpu = MicroZig.cpus.cortex_m7f,
         .memory_regions = &.{
             .{ .offset = 0x8000000, .length = 0x20000, .kind = .flash },
             .{ .offset = 0x8020000, .length = 0x20000, .kind = .flash },
@@ -8775,7 +8775,7 @@ pub const STM32F778AI = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32F778AI",
-        .cpu = MicroZig.cpus.cortex_m7,
+        .cpu = MicroZig.cpus.cortex_m7f,
         .memory_regions = &.{
             .{ .offset = 0x8000000, .length = 0x20000, .kind = .flash },
             .{ .offset = 0x8020000, .length = 0x20000, .kind = .flash },
@@ -8793,7 +8793,7 @@ pub const STM32F779AI = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32F779AI",
-        .cpu = MicroZig.cpus.cortex_m7,
+        .cpu = MicroZig.cpus.cortex_m7f,
         .memory_regions = &.{
             .{ .offset = 0x8000000, .length = 0x20000, .kind = .flash },
             .{ .offset = 0x8020000, .length = 0x20000, .kind = .flash },
@@ -8811,7 +8811,7 @@ pub const STM32F779BI = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32F779BI",
-        .cpu = MicroZig.cpus.cortex_m7,
+        .cpu = MicroZig.cpus.cortex_m7f,
         .memory_regions = &.{
             .{ .offset = 0x8000000, .length = 0x20000, .kind = .flash },
             .{ .offset = 0x8020000, .length = 0x20000, .kind = .flash },
@@ -8829,7 +8829,7 @@ pub const STM32F779II = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32F779II",
-        .cpu = MicroZig.cpus.cortex_m7,
+        .cpu = MicroZig.cpus.cortex_m7f,
         .memory_regions = &.{
             .{ .offset = 0x8000000, .length = 0x20000, .kind = .flash },
             .{ .offset = 0x8020000, .length = 0x20000, .kind = .flash },
@@ -8847,7 +8847,7 @@ pub const STM32F779NI = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32F779NI",
-        .cpu = MicroZig.cpus.cortex_m7,
+        .cpu = MicroZig.cpus.cortex_m7f,
         .memory_regions = &.{
             .{ .offset = 0x8000000, .length = 0x20000, .kind = .flash },
             .{ .offset = 0x8020000, .length = 0x20000, .kind = .flash },
@@ -10441,7 +10441,7 @@ pub const STM32G431C6 = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32G431C6",
-        .cpu = MicroZig.cpus.cortex_m4,
+        .cpu = MicroZig.cpus.cortex_m4f,
         .memory_regions = &.{
             .{ .offset = 0x8000000, .length = 0x8000, .kind = .flash },
             .{ .offset = 0x10000000, .length = 0x2800, .kind = .ram },
@@ -10459,7 +10459,7 @@ pub const STM32G431C8 = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32G431C8",
-        .cpu = MicroZig.cpus.cortex_m4,
+        .cpu = MicroZig.cpus.cortex_m4f,
         .memory_regions = &.{
             .{ .offset = 0x8000000, .length = 0x10000, .kind = .flash },
             .{ .offset = 0x10000000, .length = 0x2800, .kind = .ram },
@@ -10477,7 +10477,7 @@ pub const STM32G431CB = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32G431CB",
-        .cpu = MicroZig.cpus.cortex_m4,
+        .cpu = MicroZig.cpus.cortex_m4f,
         .memory_regions = &.{
             .{ .offset = 0x8000000, .length = 0x20000, .kind = .flash },
             .{ .offset = 0x10000000, .length = 0x2800, .kind = .ram },
@@ -10495,7 +10495,7 @@ pub const STM32G431K6 = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32G431K6",
-        .cpu = MicroZig.cpus.cortex_m4,
+        .cpu = MicroZig.cpus.cortex_m4f,
         .memory_regions = &.{
             .{ .offset = 0x8000000, .length = 0x8000, .kind = .flash },
             .{ .offset = 0x10000000, .length = 0x2800, .kind = .ram },
@@ -10513,7 +10513,7 @@ pub const STM32G431K8 = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32G431K8",
-        .cpu = MicroZig.cpus.cortex_m4,
+        .cpu = MicroZig.cpus.cortex_m4f,
         .memory_regions = &.{
             .{ .offset = 0x8000000, .length = 0x10000, .kind = .flash },
             .{ .offset = 0x10000000, .length = 0x2800, .kind = .ram },
@@ -10531,7 +10531,7 @@ pub const STM32G431KB = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32G431KB",
-        .cpu = MicroZig.cpus.cortex_m4,
+        .cpu = MicroZig.cpus.cortex_m4f,
         .memory_regions = &.{
             .{ .offset = 0x8000000, .length = 0x20000, .kind = .flash },
             .{ .offset = 0x10000000, .length = 0x2800, .kind = .ram },
@@ -10549,7 +10549,7 @@ pub const STM32G431M6 = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32G431M6",
-        .cpu = MicroZig.cpus.cortex_m4,
+        .cpu = MicroZig.cpus.cortex_m4f,
         .memory_regions = &.{
             .{ .offset = 0x8000000, .length = 0x8000, .kind = .flash },
             .{ .offset = 0x10000000, .length = 0x2800, .kind = .ram },
@@ -10567,7 +10567,7 @@ pub const STM32G431M8 = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32G431M8",
-        .cpu = MicroZig.cpus.cortex_m4,
+        .cpu = MicroZig.cpus.cortex_m4f,
         .memory_regions = &.{
             .{ .offset = 0x8000000, .length = 0x10000, .kind = .flash },
             .{ .offset = 0x10000000, .length = 0x2800, .kind = .ram },
@@ -10585,7 +10585,7 @@ pub const STM32G431MB = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32G431MB",
-        .cpu = MicroZig.cpus.cortex_m4,
+        .cpu = MicroZig.cpus.cortex_m4f,
         .memory_regions = &.{
             .{ .offset = 0x8000000, .length = 0x20000, .kind = .flash },
             .{ .offset = 0x10000000, .length = 0x2800, .kind = .ram },
@@ -10603,7 +10603,7 @@ pub const STM32G431R6 = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32G431R6",
-        .cpu = MicroZig.cpus.cortex_m4,
+        .cpu = MicroZig.cpus.cortex_m4f,
         .memory_regions = &.{
             .{ .offset = 0x8000000, .length = 0x8000, .kind = .flash },
             .{ .offset = 0x10000000, .length = 0x2800, .kind = .ram },
@@ -10621,7 +10621,7 @@ pub const STM32G431R8 = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32G431R8",
-        .cpu = MicroZig.cpus.cortex_m4,
+        .cpu = MicroZig.cpus.cortex_m4f,
         .memory_regions = &.{
             .{ .offset = 0x8000000, .length = 0x10000, .kind = .flash },
             .{ .offset = 0x10000000, .length = 0x2800, .kind = .ram },
@@ -10639,7 +10639,7 @@ pub const STM32G431RB = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32G431RB",
-        .cpu = MicroZig.cpus.cortex_m4,
+        .cpu = MicroZig.cpus.cortex_m4f,
         .memory_regions = &.{
             .{ .offset = 0x8000000, .length = 0x20000, .kind = .flash },
             .{ .offset = 0x10000000, .length = 0x2800, .kind = .ram },
@@ -10657,7 +10657,7 @@ pub const STM32G431V6 = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32G431V6",
-        .cpu = MicroZig.cpus.cortex_m4,
+        .cpu = MicroZig.cpus.cortex_m4f,
         .memory_regions = &.{
             .{ .offset = 0x8000000, .length = 0x8000, .kind = .flash },
             .{ .offset = 0x10000000, .length = 0x2800, .kind = .ram },
@@ -10675,7 +10675,7 @@ pub const STM32G431V8 = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32G431V8",
-        .cpu = MicroZig.cpus.cortex_m4,
+        .cpu = MicroZig.cpus.cortex_m4f,
         .memory_regions = &.{
             .{ .offset = 0x8000000, .length = 0x10000, .kind = .flash },
             .{ .offset = 0x10000000, .length = 0x2800, .kind = .ram },
@@ -10693,7 +10693,7 @@ pub const STM32G431VB = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32G431VB",
-        .cpu = MicroZig.cpus.cortex_m4,
+        .cpu = MicroZig.cpus.cortex_m4f,
         .memory_regions = &.{
             .{ .offset = 0x8000000, .length = 0x20000, .kind = .flash },
             .{ .offset = 0x10000000, .length = 0x2800, .kind = .ram },
@@ -10711,7 +10711,7 @@ pub const STM32G441CB = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32G441CB",
-        .cpu = MicroZig.cpus.cortex_m4,
+        .cpu = MicroZig.cpus.cortex_m4f,
         .memory_regions = &.{
             .{ .offset = 0x8000000, .length = 0x20000, .kind = .flash },
             .{ .offset = 0x10000000, .length = 0x2800, .kind = .ram },
@@ -10729,7 +10729,7 @@ pub const STM32G441KB = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32G441KB",
-        .cpu = MicroZig.cpus.cortex_m4,
+        .cpu = MicroZig.cpus.cortex_m4f,
         .memory_regions = &.{
             .{ .offset = 0x8000000, .length = 0x20000, .kind = .flash },
             .{ .offset = 0x10000000, .length = 0x2800, .kind = .ram },
@@ -10747,7 +10747,7 @@ pub const STM32G441MB = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32G441MB",
-        .cpu = MicroZig.cpus.cortex_m4,
+        .cpu = MicroZig.cpus.cortex_m4f,
         .memory_regions = &.{
             .{ .offset = 0x8000000, .length = 0x20000, .kind = .flash },
             .{ .offset = 0x10000000, .length = 0x2800, .kind = .ram },
@@ -10765,7 +10765,7 @@ pub const STM32G441RB = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32G441RB",
-        .cpu = MicroZig.cpus.cortex_m4,
+        .cpu = MicroZig.cpus.cortex_m4f,
         .memory_regions = &.{
             .{ .offset = 0x8000000, .length = 0x20000, .kind = .flash },
             .{ .offset = 0x10000000, .length = 0x2800, .kind = .ram },
@@ -10783,7 +10783,7 @@ pub const STM32G441VB = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32G441VB",
-        .cpu = MicroZig.cpus.cortex_m4,
+        .cpu = MicroZig.cpus.cortex_m4f,
         .memory_regions = &.{
             .{ .offset = 0x8000000, .length = 0x20000, .kind = .flash },
             .{ .offset = 0x10000000, .length = 0x2800, .kind = .ram },
@@ -10801,7 +10801,7 @@ pub const STM32G471CC = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32G471CC",
-        .cpu = MicroZig.cpus.cortex_m4,
+        .cpu = MicroZig.cpus.cortex_m4f,
         .memory_regions = &.{
             .{ .offset = 0x8000000, .length = 0x40000, .kind = .flash },
             .{ .offset = 0x10000000, .length = 0x8000, .kind = .ram },
@@ -10819,7 +10819,7 @@ pub const STM32G471CE = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32G471CE",
-        .cpu = MicroZig.cpus.cortex_m4,
+        .cpu = MicroZig.cpus.cortex_m4f,
         .memory_regions = &.{
             .{ .offset = 0x8000000, .length = 0x80000, .kind = .flash },
             .{ .offset = 0x10000000, .length = 0x8000, .kind = .ram },
@@ -10837,7 +10837,7 @@ pub const STM32G471MC = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32G471MC",
-        .cpu = MicroZig.cpus.cortex_m4,
+        .cpu = MicroZig.cpus.cortex_m4f,
         .memory_regions = &.{
             .{ .offset = 0x8000000, .length = 0x40000, .kind = .flash },
             .{ .offset = 0x10000000, .length = 0x8000, .kind = .ram },
@@ -10855,7 +10855,7 @@ pub const STM32G471ME = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32G471ME",
-        .cpu = MicroZig.cpus.cortex_m4,
+        .cpu = MicroZig.cpus.cortex_m4f,
         .memory_regions = &.{
             .{ .offset = 0x8000000, .length = 0x80000, .kind = .flash },
             .{ .offset = 0x10000000, .length = 0x8000, .kind = .ram },
@@ -10873,7 +10873,7 @@ pub const STM32G471QC = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32G471QC",
-        .cpu = MicroZig.cpus.cortex_m4,
+        .cpu = MicroZig.cpus.cortex_m4f,
         .memory_regions = &.{
             .{ .offset = 0x8000000, .length = 0x40000, .kind = .flash },
             .{ .offset = 0x10000000, .length = 0x8000, .kind = .ram },
@@ -10891,7 +10891,7 @@ pub const STM32G471QE = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32G471QE",
-        .cpu = MicroZig.cpus.cortex_m4,
+        .cpu = MicroZig.cpus.cortex_m4f,
         .memory_regions = &.{
             .{ .offset = 0x8000000, .length = 0x80000, .kind = .flash },
             .{ .offset = 0x10000000, .length = 0x8000, .kind = .ram },
@@ -10909,7 +10909,7 @@ pub const STM32G471RC = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32G471RC",
-        .cpu = MicroZig.cpus.cortex_m4,
+        .cpu = MicroZig.cpus.cortex_m4f,
         .memory_regions = &.{
             .{ .offset = 0x8000000, .length = 0x40000, .kind = .flash },
             .{ .offset = 0x10000000, .length = 0x8000, .kind = .ram },
@@ -10927,7 +10927,7 @@ pub const STM32G471RE = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32G471RE",
-        .cpu = MicroZig.cpus.cortex_m4,
+        .cpu = MicroZig.cpus.cortex_m4f,
         .memory_regions = &.{
             .{ .offset = 0x8000000, .length = 0x80000, .kind = .flash },
             .{ .offset = 0x10000000, .length = 0x8000, .kind = .ram },
@@ -10945,7 +10945,7 @@ pub const STM32G471VC = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32G471VC",
-        .cpu = MicroZig.cpus.cortex_m4,
+        .cpu = MicroZig.cpus.cortex_m4f,
         .memory_regions = &.{
             .{ .offset = 0x8000000, .length = 0x40000, .kind = .flash },
             .{ .offset = 0x10000000, .length = 0x8000, .kind = .ram },
@@ -10963,7 +10963,7 @@ pub const STM32G471VE = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32G471VE",
-        .cpu = MicroZig.cpus.cortex_m4,
+        .cpu = MicroZig.cpus.cortex_m4f,
         .memory_regions = &.{
             .{ .offset = 0x8000000, .length = 0x80000, .kind = .flash },
             .{ .offset = 0x10000000, .length = 0x8000, .kind = .ram },
@@ -10981,7 +10981,7 @@ pub const STM32G473CB = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32G473CB",
-        .cpu = MicroZig.cpus.cortex_m4,
+        .cpu = MicroZig.cpus.cortex_m4f,
         .memory_regions = &.{
             .{ .offset = 0x8000000, .length = 0x20000, .kind = .flash },
             .{ .offset = 0x10000000, .length = 0x8000, .kind = .ram },
@@ -10999,7 +10999,7 @@ pub const STM32G473CC = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32G473CC",
-        .cpu = MicroZig.cpus.cortex_m4,
+        .cpu = MicroZig.cpus.cortex_m4f,
         .memory_regions = &.{
             .{ .offset = 0x8000000, .length = 0x40000, .kind = .flash },
             .{ .offset = 0x10000000, .length = 0x8000, .kind = .ram },
@@ -11017,7 +11017,7 @@ pub const STM32G473CE = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32G473CE",
-        .cpu = MicroZig.cpus.cortex_m4,
+        .cpu = MicroZig.cpus.cortex_m4f,
         .memory_regions = &.{
             .{ .offset = 0x8000000, .length = 0x80000, .kind = .flash },
             .{ .offset = 0x10000000, .length = 0x8000, .kind = .ram },
@@ -11035,7 +11035,7 @@ pub const STM32G473MB = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32G473MB",
-        .cpu = MicroZig.cpus.cortex_m4,
+        .cpu = MicroZig.cpus.cortex_m4f,
         .memory_regions = &.{
             .{ .offset = 0x8000000, .length = 0x20000, .kind = .flash },
             .{ .offset = 0x10000000, .length = 0x8000, .kind = .ram },
@@ -11053,7 +11053,7 @@ pub const STM32G473MC = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32G473MC",
-        .cpu = MicroZig.cpus.cortex_m4,
+        .cpu = MicroZig.cpus.cortex_m4f,
         .memory_regions = &.{
             .{ .offset = 0x8000000, .length = 0x40000, .kind = .flash },
             .{ .offset = 0x10000000, .length = 0x8000, .kind = .ram },
@@ -11071,7 +11071,7 @@ pub const STM32G473ME = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32G473ME",
-        .cpu = MicroZig.cpus.cortex_m4,
+        .cpu = MicroZig.cpus.cortex_m4f,
         .memory_regions = &.{
             .{ .offset = 0x8000000, .length = 0x80000, .kind = .flash },
             .{ .offset = 0x10000000, .length = 0x8000, .kind = .ram },
@@ -11089,7 +11089,7 @@ pub const STM32G473PB = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32G473PB",
-        .cpu = MicroZig.cpus.cortex_m4,
+        .cpu = MicroZig.cpus.cortex_m4f,
         .memory_regions = &.{
             .{ .offset = 0x8000000, .length = 0x20000, .kind = .flash },
             .{ .offset = 0x10000000, .length = 0x8000, .kind = .ram },
@@ -11107,7 +11107,7 @@ pub const STM32G473PC = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32G473PC",
-        .cpu = MicroZig.cpus.cortex_m4,
+        .cpu = MicroZig.cpus.cortex_m4f,
         .memory_regions = &.{
             .{ .offset = 0x8000000, .length = 0x40000, .kind = .flash },
             .{ .offset = 0x10000000, .length = 0x8000, .kind = .ram },
@@ -11125,7 +11125,7 @@ pub const STM32G473PE = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32G473PE",
-        .cpu = MicroZig.cpus.cortex_m4,
+        .cpu = MicroZig.cpus.cortex_m4f,
         .memory_regions = &.{
             .{ .offset = 0x8000000, .length = 0x80000, .kind = .flash },
             .{ .offset = 0x10000000, .length = 0x8000, .kind = .ram },
@@ -11143,7 +11143,7 @@ pub const STM32G473QB = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32G473QB",
-        .cpu = MicroZig.cpus.cortex_m4,
+        .cpu = MicroZig.cpus.cortex_m4f,
         .memory_regions = &.{
             .{ .offset = 0x8000000, .length = 0x20000, .kind = .flash },
             .{ .offset = 0x10000000, .length = 0x8000, .kind = .ram },
@@ -11161,7 +11161,7 @@ pub const STM32G473QC = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32G473QC",
-        .cpu = MicroZig.cpus.cortex_m4,
+        .cpu = MicroZig.cpus.cortex_m4f,
         .memory_regions = &.{
             .{ .offset = 0x8000000, .length = 0x40000, .kind = .flash },
             .{ .offset = 0x10000000, .length = 0x8000, .kind = .ram },
@@ -11179,7 +11179,7 @@ pub const STM32G473QE = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32G473QE",
-        .cpu = MicroZig.cpus.cortex_m4,
+        .cpu = MicroZig.cpus.cortex_m4f,
         .memory_regions = &.{
             .{ .offset = 0x8000000, .length = 0x80000, .kind = .flash },
             .{ .offset = 0x10000000, .length = 0x8000, .kind = .ram },
@@ -11197,7 +11197,7 @@ pub const STM32G473RB = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32G473RB",
-        .cpu = MicroZig.cpus.cortex_m4,
+        .cpu = MicroZig.cpus.cortex_m4f,
         .memory_regions = &.{
             .{ .offset = 0x8000000, .length = 0x20000, .kind = .flash },
             .{ .offset = 0x10000000, .length = 0x8000, .kind = .ram },
@@ -11215,7 +11215,7 @@ pub const STM32G473RC = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32G473RC",
-        .cpu = MicroZig.cpus.cortex_m4,
+        .cpu = MicroZig.cpus.cortex_m4f,
         .memory_regions = &.{
             .{ .offset = 0x8000000, .length = 0x40000, .kind = .flash },
             .{ .offset = 0x10000000, .length = 0x8000, .kind = .ram },
@@ -11233,7 +11233,7 @@ pub const STM32G473RE = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32G473RE",
-        .cpu = MicroZig.cpus.cortex_m4,
+        .cpu = MicroZig.cpus.cortex_m4f,
         .memory_regions = &.{
             .{ .offset = 0x8000000, .length = 0x80000, .kind = .flash },
             .{ .offset = 0x10000000, .length = 0x8000, .kind = .ram },
@@ -11251,7 +11251,7 @@ pub const STM32G473VB = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32G473VB",
-        .cpu = MicroZig.cpus.cortex_m4,
+        .cpu = MicroZig.cpus.cortex_m4f,
         .memory_regions = &.{
             .{ .offset = 0x8000000, .length = 0x20000, .kind = .flash },
             .{ .offset = 0x10000000, .length = 0x8000, .kind = .ram },
@@ -11269,7 +11269,7 @@ pub const STM32G473VC = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32G473VC",
-        .cpu = MicroZig.cpus.cortex_m4,
+        .cpu = MicroZig.cpus.cortex_m4f,
         .memory_regions = &.{
             .{ .offset = 0x8000000, .length = 0x40000, .kind = .flash },
             .{ .offset = 0x10000000, .length = 0x8000, .kind = .ram },
@@ -11287,7 +11287,7 @@ pub const STM32G473VE = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32G473VE",
-        .cpu = MicroZig.cpus.cortex_m4,
+        .cpu = MicroZig.cpus.cortex_m4f,
         .memory_regions = &.{
             .{ .offset = 0x8000000, .length = 0x80000, .kind = .flash },
             .{ .offset = 0x10000000, .length = 0x8000, .kind = .ram },
@@ -11305,7 +11305,7 @@ pub const STM32G474CB = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32G474CB",
-        .cpu = MicroZig.cpus.cortex_m4,
+        .cpu = MicroZig.cpus.cortex_m4f,
         .memory_regions = &.{
             .{ .offset = 0x8000000, .length = 0x20000, .kind = .flash },
             .{ .offset = 0x10000000, .length = 0x8000, .kind = .ram },
@@ -11323,7 +11323,7 @@ pub const STM32G474CC = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32G474CC",
-        .cpu = MicroZig.cpus.cortex_m4,
+        .cpu = MicroZig.cpus.cortex_m4f,
         .memory_regions = &.{
             .{ .offset = 0x8000000, .length = 0x40000, .kind = .flash },
             .{ .offset = 0x10000000, .length = 0x8000, .kind = .ram },
@@ -11341,7 +11341,7 @@ pub const STM32G474CE = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32G474CE",
-        .cpu = MicroZig.cpus.cortex_m4,
+        .cpu = MicroZig.cpus.cortex_m4f,
         .memory_regions = &.{
             .{ .offset = 0x8000000, .length = 0x80000, .kind = .flash },
             .{ .offset = 0x10000000, .length = 0x8000, .kind = .ram },
@@ -11359,7 +11359,7 @@ pub const STM32G474MB = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32G474MB",
-        .cpu = MicroZig.cpus.cortex_m4,
+        .cpu = MicroZig.cpus.cortex_m4f,
         .memory_regions = &.{
             .{ .offset = 0x8000000, .length = 0x20000, .kind = .flash },
             .{ .offset = 0x10000000, .length = 0x8000, .kind = .ram },
@@ -11377,7 +11377,7 @@ pub const STM32G474MC = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32G474MC",
-        .cpu = MicroZig.cpus.cortex_m4,
+        .cpu = MicroZig.cpus.cortex_m4f,
         .memory_regions = &.{
             .{ .offset = 0x8000000, .length = 0x40000, .kind = .flash },
             .{ .offset = 0x10000000, .length = 0x8000, .kind = .ram },
@@ -11395,7 +11395,7 @@ pub const STM32G474ME = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32G474ME",
-        .cpu = MicroZig.cpus.cortex_m4,
+        .cpu = MicroZig.cpus.cortex_m4f,
         .memory_regions = &.{
             .{ .offset = 0x8000000, .length = 0x80000, .kind = .flash },
             .{ .offset = 0x10000000, .length = 0x8000, .kind = .ram },
@@ -11413,7 +11413,7 @@ pub const STM32G474PB = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32G474PB",
-        .cpu = MicroZig.cpus.cortex_m4,
+        .cpu = MicroZig.cpus.cortex_m4f,
         .memory_regions = &.{
             .{ .offset = 0x8000000, .length = 0x20000, .kind = .flash },
             .{ .offset = 0x10000000, .length = 0x8000, .kind = .ram },
@@ -11431,7 +11431,7 @@ pub const STM32G474PC = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32G474PC",
-        .cpu = MicroZig.cpus.cortex_m4,
+        .cpu = MicroZig.cpus.cortex_m4f,
         .memory_regions = &.{
             .{ .offset = 0x8000000, .length = 0x40000, .kind = .flash },
             .{ .offset = 0x10000000, .length = 0x8000, .kind = .ram },
@@ -11449,7 +11449,7 @@ pub const STM32G474PE = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32G474PE",
-        .cpu = MicroZig.cpus.cortex_m4,
+        .cpu = MicroZig.cpus.cortex_m4f,
         .memory_regions = &.{
             .{ .offset = 0x8000000, .length = 0x80000, .kind = .flash },
             .{ .offset = 0x10000000, .length = 0x8000, .kind = .ram },
@@ -11467,7 +11467,7 @@ pub const STM32G474QB = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32G474QB",
-        .cpu = MicroZig.cpus.cortex_m4,
+        .cpu = MicroZig.cpus.cortex_m4f,
         .memory_regions = &.{
             .{ .offset = 0x8000000, .length = 0x20000, .kind = .flash },
             .{ .offset = 0x10000000, .length = 0x8000, .kind = .ram },
@@ -11485,7 +11485,7 @@ pub const STM32G474QC = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32G474QC",
-        .cpu = MicroZig.cpus.cortex_m4,
+        .cpu = MicroZig.cpus.cortex_m4f,
         .memory_regions = &.{
             .{ .offset = 0x8000000, .length = 0x40000, .kind = .flash },
             .{ .offset = 0x10000000, .length = 0x8000, .kind = .ram },
@@ -11503,7 +11503,7 @@ pub const STM32G474QE = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32G474QE",
-        .cpu = MicroZig.cpus.cortex_m4,
+        .cpu = MicroZig.cpus.cortex_m4f,
         .memory_regions = &.{
             .{ .offset = 0x8000000, .length = 0x80000, .kind = .flash },
             .{ .offset = 0x10000000, .length = 0x8000, .kind = .ram },
@@ -11521,7 +11521,7 @@ pub const STM32G474RB = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32G474RB",
-        .cpu = MicroZig.cpus.cortex_m4,
+        .cpu = MicroZig.cpus.cortex_m4f,
         .memory_regions = &.{
             .{ .offset = 0x8000000, .length = 0x20000, .kind = .flash },
             .{ .offset = 0x10000000, .length = 0x8000, .kind = .ram },
@@ -11539,7 +11539,7 @@ pub const STM32G474RC = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32G474RC",
-        .cpu = MicroZig.cpus.cortex_m4,
+        .cpu = MicroZig.cpus.cortex_m4f,
         .memory_regions = &.{
             .{ .offset = 0x8000000, .length = 0x40000, .kind = .flash },
             .{ .offset = 0x10000000, .length = 0x8000, .kind = .ram },
@@ -11557,7 +11557,7 @@ pub const STM32G474RE = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32G474RE",
-        .cpu = MicroZig.cpus.cortex_m4,
+        .cpu = MicroZig.cpus.cortex_m4f,
         .memory_regions = &.{
             .{ .offset = 0x8000000, .length = 0x80000, .kind = .flash },
             .{ .offset = 0x10000000, .length = 0x8000, .kind = .ram },
@@ -11575,7 +11575,7 @@ pub const STM32G474VB = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32G474VB",
-        .cpu = MicroZig.cpus.cortex_m4,
+        .cpu = MicroZig.cpus.cortex_m4f,
         .memory_regions = &.{
             .{ .offset = 0x8000000, .length = 0x20000, .kind = .flash },
             .{ .offset = 0x10000000, .length = 0x8000, .kind = .ram },
@@ -11593,7 +11593,7 @@ pub const STM32G474VC = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32G474VC",
-        .cpu = MicroZig.cpus.cortex_m4,
+        .cpu = MicroZig.cpus.cortex_m4f,
         .memory_regions = &.{
             .{ .offset = 0x8000000, .length = 0x40000, .kind = .flash },
             .{ .offset = 0x10000000, .length = 0x8000, .kind = .ram },
@@ -11611,7 +11611,7 @@ pub const STM32G474VE = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32G474VE",
-        .cpu = MicroZig.cpus.cortex_m4,
+        .cpu = MicroZig.cpus.cortex_m4f,
         .memory_regions = &.{
             .{ .offset = 0x8000000, .length = 0x80000, .kind = .flash },
             .{ .offset = 0x10000000, .length = 0x8000, .kind = .ram },
@@ -11629,7 +11629,7 @@ pub const STM32G483CE = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32G483CE",
-        .cpu = MicroZig.cpus.cortex_m4,
+        .cpu = MicroZig.cpus.cortex_m4f,
         .memory_regions = &.{
             .{ .offset = 0x8000000, .length = 0x80000, .kind = .flash },
             .{ .offset = 0x10000000, .length = 0x8000, .kind = .ram },
@@ -11647,7 +11647,7 @@ pub const STM32G483ME = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32G483ME",
-        .cpu = MicroZig.cpus.cortex_m4,
+        .cpu = MicroZig.cpus.cortex_m4f,
         .memory_regions = &.{
             .{ .offset = 0x8000000, .length = 0x80000, .kind = .flash },
             .{ .offset = 0x10000000, .length = 0x8000, .kind = .ram },
@@ -11665,7 +11665,7 @@ pub const STM32G483PE = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32G483PE",
-        .cpu = MicroZig.cpus.cortex_m4,
+        .cpu = MicroZig.cpus.cortex_m4f,
         .memory_regions = &.{
             .{ .offset = 0x8000000, .length = 0x80000, .kind = .flash },
             .{ .offset = 0x10000000, .length = 0x8000, .kind = .ram },
@@ -11683,7 +11683,7 @@ pub const STM32G483QE = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32G483QE",
-        .cpu = MicroZig.cpus.cortex_m4,
+        .cpu = MicroZig.cpus.cortex_m4f,
         .memory_regions = &.{
             .{ .offset = 0x8000000, .length = 0x80000, .kind = .flash },
             .{ .offset = 0x10000000, .length = 0x8000, .kind = .ram },
@@ -11701,7 +11701,7 @@ pub const STM32G483RE = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32G483RE",
-        .cpu = MicroZig.cpus.cortex_m4,
+        .cpu = MicroZig.cpus.cortex_m4f,
         .memory_regions = &.{
             .{ .offset = 0x8000000, .length = 0x80000, .kind = .flash },
             .{ .offset = 0x10000000, .length = 0x8000, .kind = .ram },
@@ -11719,7 +11719,7 @@ pub const STM32G483VE = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32G483VE",
-        .cpu = MicroZig.cpus.cortex_m4,
+        .cpu = MicroZig.cpus.cortex_m4f,
         .memory_regions = &.{
             .{ .offset = 0x8000000, .length = 0x80000, .kind = .flash },
             .{ .offset = 0x10000000, .length = 0x8000, .kind = .ram },
@@ -11737,7 +11737,7 @@ pub const STM32G484CE = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32G484CE",
-        .cpu = MicroZig.cpus.cortex_m4,
+        .cpu = MicroZig.cpus.cortex_m4f,
         .memory_regions = &.{
             .{ .offset = 0x8000000, .length = 0x80000, .kind = .flash },
             .{ .offset = 0x10000000, .length = 0x8000, .kind = .ram },
@@ -11755,7 +11755,7 @@ pub const STM32G484ME = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32G484ME",
-        .cpu = MicroZig.cpus.cortex_m4,
+        .cpu = MicroZig.cpus.cortex_m4f,
         .memory_regions = &.{
             .{ .offset = 0x8000000, .length = 0x80000, .kind = .flash },
             .{ .offset = 0x10000000, .length = 0x8000, .kind = .ram },
@@ -11773,7 +11773,7 @@ pub const STM32G484PE = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32G484PE",
-        .cpu = MicroZig.cpus.cortex_m4,
+        .cpu = MicroZig.cpus.cortex_m4f,
         .memory_regions = &.{
             .{ .offset = 0x8000000, .length = 0x80000, .kind = .flash },
             .{ .offset = 0x10000000, .length = 0x8000, .kind = .ram },
@@ -11791,7 +11791,7 @@ pub const STM32G484QE = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32G484QE",
-        .cpu = MicroZig.cpus.cortex_m4,
+        .cpu = MicroZig.cpus.cortex_m4f,
         .memory_regions = &.{
             .{ .offset = 0x8000000, .length = 0x80000, .kind = .flash },
             .{ .offset = 0x10000000, .length = 0x8000, .kind = .ram },
@@ -11809,7 +11809,7 @@ pub const STM32G484RE = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32G484RE",
-        .cpu = MicroZig.cpus.cortex_m4,
+        .cpu = MicroZig.cpus.cortex_m4f,
         .memory_regions = &.{
             .{ .offset = 0x8000000, .length = 0x80000, .kind = .flash },
             .{ .offset = 0x10000000, .length = 0x8000, .kind = .ram },
@@ -11827,7 +11827,7 @@ pub const STM32G484VE = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32G484VE",
-        .cpu = MicroZig.cpus.cortex_m4,
+        .cpu = MicroZig.cpus.cortex_m4f,
         .memory_regions = &.{
             .{ .offset = 0x8000000, .length = 0x80000, .kind = .flash },
             .{ .offset = 0x10000000, .length = 0x8000, .kind = .ram },
@@ -11845,7 +11845,7 @@ pub const STM32G491CC = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32G491CC",
-        .cpu = MicroZig.cpus.cortex_m4,
+        .cpu = MicroZig.cpus.cortex_m4f,
         .memory_regions = &.{
             .{ .offset = 0x8000000, .length = 0x40000, .kind = .flash },
             .{ .offset = 0x10000000, .length = 0x4000, .kind = .ram },
@@ -11863,7 +11863,7 @@ pub const STM32G491CE = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32G491CE",
-        .cpu = MicroZig.cpus.cortex_m4,
+        .cpu = MicroZig.cpus.cortex_m4f,
         .memory_regions = &.{
             .{ .offset = 0x8000000, .length = 0x80000, .kind = .flash },
             .{ .offset = 0x10000000, .length = 0x4000, .kind = .ram },
@@ -11881,7 +11881,7 @@ pub const STM32G491KC = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32G491KC",
-        .cpu = MicroZig.cpus.cortex_m4,
+        .cpu = MicroZig.cpus.cortex_m4f,
         .memory_regions = &.{
             .{ .offset = 0x8000000, .length = 0x40000, .kind = .flash },
             .{ .offset = 0x10000000, .length = 0x4000, .kind = .ram },
@@ -11899,7 +11899,7 @@ pub const STM32G491KE = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32G491KE",
-        .cpu = MicroZig.cpus.cortex_m4,
+        .cpu = MicroZig.cpus.cortex_m4f,
         .memory_regions = &.{
             .{ .offset = 0x8000000, .length = 0x80000, .kind = .flash },
             .{ .offset = 0x10000000, .length = 0x4000, .kind = .ram },
@@ -11917,7 +11917,7 @@ pub const STM32G491MC = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32G491MC",
-        .cpu = MicroZig.cpus.cortex_m4,
+        .cpu = MicroZig.cpus.cortex_m4f,
         .memory_regions = &.{
             .{ .offset = 0x8000000, .length = 0x40000, .kind = .flash },
             .{ .offset = 0x10000000, .length = 0x4000, .kind = .ram },
@@ -11935,7 +11935,7 @@ pub const STM32G491ME = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32G491ME",
-        .cpu = MicroZig.cpus.cortex_m4,
+        .cpu = MicroZig.cpus.cortex_m4f,
         .memory_regions = &.{
             .{ .offset = 0x8000000, .length = 0x80000, .kind = .flash },
             .{ .offset = 0x10000000, .length = 0x4000, .kind = .ram },
@@ -11953,7 +11953,7 @@ pub const STM32G491RC = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32G491RC",
-        .cpu = MicroZig.cpus.cortex_m4,
+        .cpu = MicroZig.cpus.cortex_m4f,
         .memory_regions = &.{
             .{ .offset = 0x8000000, .length = 0x40000, .kind = .flash },
             .{ .offset = 0x10000000, .length = 0x4000, .kind = .ram },
@@ -11971,7 +11971,7 @@ pub const STM32G491RE = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32G491RE",
-        .cpu = MicroZig.cpus.cortex_m4,
+        .cpu = MicroZig.cpus.cortex_m4f,
         .memory_regions = &.{
             .{ .offset = 0x8000000, .length = 0x80000, .kind = .flash },
             .{ .offset = 0x10000000, .length = 0x4000, .kind = .ram },
@@ -11989,7 +11989,7 @@ pub const STM32G491VC = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32G491VC",
-        .cpu = MicroZig.cpus.cortex_m4,
+        .cpu = MicroZig.cpus.cortex_m4f,
         .memory_regions = &.{
             .{ .offset = 0x8000000, .length = 0x40000, .kind = .flash },
             .{ .offset = 0x10000000, .length = 0x4000, .kind = .ram },
@@ -12007,7 +12007,7 @@ pub const STM32G491VE = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32G491VE",
-        .cpu = MicroZig.cpus.cortex_m4,
+        .cpu = MicroZig.cpus.cortex_m4f,
         .memory_regions = &.{
             .{ .offset = 0x8000000, .length = 0x80000, .kind = .flash },
             .{ .offset = 0x10000000, .length = 0x4000, .kind = .ram },
@@ -12025,7 +12025,7 @@ pub const STM32G4A1CE = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32G4A1CE",
-        .cpu = MicroZig.cpus.cortex_m4,
+        .cpu = MicroZig.cpus.cortex_m4f,
         .memory_regions = &.{
             .{ .offset = 0x8000000, .length = 0x80000, .kind = .flash },
             .{ .offset = 0x10000000, .length = 0x4000, .kind = .ram },
@@ -12043,7 +12043,7 @@ pub const STM32G4A1KE = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32G4A1KE",
-        .cpu = MicroZig.cpus.cortex_m4,
+        .cpu = MicroZig.cpus.cortex_m4f,
         .memory_regions = &.{
             .{ .offset = 0x8000000, .length = 0x80000, .kind = .flash },
             .{ .offset = 0x10000000, .length = 0x4000, .kind = .ram },
@@ -12061,7 +12061,7 @@ pub const STM32G4A1ME = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32G4A1ME",
-        .cpu = MicroZig.cpus.cortex_m4,
+        .cpu = MicroZig.cpus.cortex_m4f,
         .memory_regions = &.{
             .{ .offset = 0x8000000, .length = 0x80000, .kind = .flash },
             .{ .offset = 0x10000000, .length = 0x4000, .kind = .ram },
@@ -12079,7 +12079,7 @@ pub const STM32G4A1RE = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32G4A1RE",
-        .cpu = MicroZig.cpus.cortex_m4,
+        .cpu = MicroZig.cpus.cortex_m4f,
         .memory_regions = &.{
             .{ .offset = 0x8000000, .length = 0x80000, .kind = .flash },
             .{ .offset = 0x10000000, .length = 0x4000, .kind = .ram },
@@ -12097,7 +12097,7 @@ pub const STM32G4A1VE = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32G4A1VE",
-        .cpu = MicroZig.cpus.cortex_m4,
+        .cpu = MicroZig.cpus.cortex_m4f,
         .memory_regions = &.{
             .{ .offset = 0x8000000, .length = 0x80000, .kind = .flash },
             .{ .offset = 0x10000000, .length = 0x4000, .kind = .ram },
@@ -12115,7 +12115,7 @@ pub const STM32H503CB = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32H503CB",
-        .cpu = MicroZig.cpus.cortex_m33,
+        .cpu = MicroZig.cpus.cortex_m33f,
         .memory_regions = &.{
             .{ .offset = 0x8000000, .length = 0x10000, .kind = .flash },
             .{ .offset = 0x8010000, .length = 0x10000, .kind = .flash },
@@ -12132,7 +12132,7 @@ pub const STM32H503EB = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32H503EB",
-        .cpu = MicroZig.cpus.cortex_m33,
+        .cpu = MicroZig.cpus.cortex_m33f,
         .memory_regions = &.{
             .{ .offset = 0x8000000, .length = 0x10000, .kind = .flash },
             .{ .offset = 0x8010000, .length = 0x10000, .kind = .flash },
@@ -12149,7 +12149,7 @@ pub const STM32H503KB = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32H503KB",
-        .cpu = MicroZig.cpus.cortex_m33,
+        .cpu = MicroZig.cpus.cortex_m33f,
         .memory_regions = &.{
             .{ .offset = 0x8000000, .length = 0x10000, .kind = .flash },
             .{ .offset = 0x8010000, .length = 0x10000, .kind = .flash },
@@ -12166,7 +12166,7 @@ pub const STM32H503RB = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32H503RB",
-        .cpu = MicroZig.cpus.cortex_m33,
+        .cpu = MicroZig.cpus.cortex_m33f,
         .memory_regions = &.{
             .{ .offset = 0x8000000, .length = 0x10000, .kind = .flash },
             .{ .offset = 0x8010000, .length = 0x10000, .kind = .flash },
@@ -12183,7 +12183,7 @@ pub const STM32H523CC = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32H523CC",
-        .cpu = MicroZig.cpus.cortex_m33,
+        .cpu = MicroZig.cpus.cortex_m33f,
         .memory_regions = &.{
             .{ .offset = 0x8000000, .length = 0x20000, .kind = .flash },
             .{ .offset = 0x8020000, .length = 0x20000, .kind = .flash },
@@ -12201,7 +12201,7 @@ pub const STM32H523CE = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32H523CE",
-        .cpu = MicroZig.cpus.cortex_m33,
+        .cpu = MicroZig.cpus.cortex_m33f,
         .memory_regions = &.{
             .{ .offset = 0x8000000, .length = 0x40000, .kind = .flash },
             .{ .offset = 0x8040000, .length = 0x40000, .kind = .flash },
@@ -12219,7 +12219,7 @@ pub const STM32H523HE = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32H523HE",
-        .cpu = MicroZig.cpus.cortex_m33,
+        .cpu = MicroZig.cpus.cortex_m33f,
         .memory_regions = &.{
             .{ .offset = 0x8000000, .length = 0x40000, .kind = .flash },
             .{ .offset = 0x8040000, .length = 0x40000, .kind = .flash },
@@ -12237,7 +12237,7 @@ pub const STM32H523RC = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32H523RC",
-        .cpu = MicroZig.cpus.cortex_m33,
+        .cpu = MicroZig.cpus.cortex_m33f,
         .memory_regions = &.{
             .{ .offset = 0x8000000, .length = 0x20000, .kind = .flash },
             .{ .offset = 0x8020000, .length = 0x20000, .kind = .flash },
@@ -12255,7 +12255,7 @@ pub const STM32H523RE = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32H523RE",
-        .cpu = MicroZig.cpus.cortex_m33,
+        .cpu = MicroZig.cpus.cortex_m33f,
         .memory_regions = &.{
             .{ .offset = 0x8000000, .length = 0x40000, .kind = .flash },
             .{ .offset = 0x8040000, .length = 0x40000, .kind = .flash },
@@ -12273,7 +12273,7 @@ pub const STM32H523VC = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32H523VC",
-        .cpu = MicroZig.cpus.cortex_m33,
+        .cpu = MicroZig.cpus.cortex_m33f,
         .memory_regions = &.{
             .{ .offset = 0x8000000, .length = 0x20000, .kind = .flash },
             .{ .offset = 0x8020000, .length = 0x20000, .kind = .flash },
@@ -12291,7 +12291,7 @@ pub const STM32H523VE = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32H523VE",
-        .cpu = MicroZig.cpus.cortex_m33,
+        .cpu = MicroZig.cpus.cortex_m33f,
         .memory_regions = &.{
             .{ .offset = 0x8000000, .length = 0x40000, .kind = .flash },
             .{ .offset = 0x8040000, .length = 0x40000, .kind = .flash },
@@ -12309,7 +12309,7 @@ pub const STM32H523ZC = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32H523ZC",
-        .cpu = MicroZig.cpus.cortex_m33,
+        .cpu = MicroZig.cpus.cortex_m33f,
         .memory_regions = &.{
             .{ .offset = 0x8000000, .length = 0x20000, .kind = .flash },
             .{ .offset = 0x8020000, .length = 0x20000, .kind = .flash },
@@ -12327,7 +12327,7 @@ pub const STM32H523ZE = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32H523ZE",
-        .cpu = MicroZig.cpus.cortex_m33,
+        .cpu = MicroZig.cpus.cortex_m33f,
         .memory_regions = &.{
             .{ .offset = 0x8000000, .length = 0x40000, .kind = .flash },
             .{ .offset = 0x8040000, .length = 0x40000, .kind = .flash },
@@ -12345,7 +12345,7 @@ pub const STM32H533CE = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32H533CE",
-        .cpu = MicroZig.cpus.cortex_m33,
+        .cpu = MicroZig.cpus.cortex_m33f,
         .memory_regions = &.{
             .{ .offset = 0x8000000, .length = 0x40000, .kind = .flash },
             .{ .offset = 0x8040000, .length = 0x40000, .kind = .flash },
@@ -12363,7 +12363,7 @@ pub const STM32H533HE = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32H533HE",
-        .cpu = MicroZig.cpus.cortex_m33,
+        .cpu = MicroZig.cpus.cortex_m33f,
         .memory_regions = &.{
             .{ .offset = 0x8000000, .length = 0x40000, .kind = .flash },
             .{ .offset = 0x8040000, .length = 0x40000, .kind = .flash },
@@ -12381,7 +12381,7 @@ pub const STM32H533RE = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32H533RE",
-        .cpu = MicroZig.cpus.cortex_m33,
+        .cpu = MicroZig.cpus.cortex_m33f,
         .memory_regions = &.{
             .{ .offset = 0x8000000, .length = 0x40000, .kind = .flash },
             .{ .offset = 0x8040000, .length = 0x40000, .kind = .flash },
@@ -12399,7 +12399,7 @@ pub const STM32H533VE = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32H533VE",
-        .cpu = MicroZig.cpus.cortex_m33,
+        .cpu = MicroZig.cpus.cortex_m33f,
         .memory_regions = &.{
             .{ .offset = 0x8000000, .length = 0x40000, .kind = .flash },
             .{ .offset = 0x8040000, .length = 0x40000, .kind = .flash },
@@ -12417,7 +12417,7 @@ pub const STM32H533ZE = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32H533ZE",
-        .cpu = MicroZig.cpus.cortex_m33,
+        .cpu = MicroZig.cpus.cortex_m33f,
         .memory_regions = &.{
             .{ .offset = 0x8000000, .length = 0x40000, .kind = .flash },
             .{ .offset = 0x8040000, .length = 0x40000, .kind = .flash },
@@ -12435,7 +12435,7 @@ pub const STM32H562AG = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32H562AG",
-        .cpu = MicroZig.cpus.cortex_m33,
+        .cpu = MicroZig.cpus.cortex_m33f,
         .memory_regions = &.{
             .{ .offset = 0x8000000, .length = 0x80000, .kind = .flash },
             .{ .offset = 0x8080000, .length = 0x80000, .kind = .flash },
@@ -12453,7 +12453,7 @@ pub const STM32H562AI = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32H562AI",
-        .cpu = MicroZig.cpus.cortex_m33,
+        .cpu = MicroZig.cpus.cortex_m33f,
         .memory_regions = &.{
             .{ .offset = 0x8000000, .length = 0x100000, .kind = .flash },
             .{ .offset = 0x8100000, .length = 0x100000, .kind = .flash },
@@ -12471,7 +12471,7 @@ pub const STM32H562IG = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32H562IG",
-        .cpu = MicroZig.cpus.cortex_m33,
+        .cpu = MicroZig.cpus.cortex_m33f,
         .memory_regions = &.{
             .{ .offset = 0x8000000, .length = 0x80000, .kind = .flash },
             .{ .offset = 0x8080000, .length = 0x80000, .kind = .flash },
@@ -12489,7 +12489,7 @@ pub const STM32H562II = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32H562II",
-        .cpu = MicroZig.cpus.cortex_m33,
+        .cpu = MicroZig.cpus.cortex_m33f,
         .memory_regions = &.{
             .{ .offset = 0x8000000, .length = 0x100000, .kind = .flash },
             .{ .offset = 0x8100000, .length = 0x100000, .kind = .flash },
@@ -12507,7 +12507,7 @@ pub const STM32H562RG = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32H562RG",
-        .cpu = MicroZig.cpus.cortex_m33,
+        .cpu = MicroZig.cpus.cortex_m33f,
         .memory_regions = &.{
             .{ .offset = 0x8000000, .length = 0x80000, .kind = .flash },
             .{ .offset = 0x8080000, .length = 0x80000, .kind = .flash },
@@ -12525,7 +12525,7 @@ pub const STM32H562RI = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32H562RI",
-        .cpu = MicroZig.cpus.cortex_m33,
+        .cpu = MicroZig.cpus.cortex_m33f,
         .memory_regions = &.{
             .{ .offset = 0x8000000, .length = 0x100000, .kind = .flash },
             .{ .offset = 0x8100000, .length = 0x100000, .kind = .flash },
@@ -12543,7 +12543,7 @@ pub const STM32H562VG = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32H562VG",
-        .cpu = MicroZig.cpus.cortex_m33,
+        .cpu = MicroZig.cpus.cortex_m33f,
         .memory_regions = &.{
             .{ .offset = 0x8000000, .length = 0x80000, .kind = .flash },
             .{ .offset = 0x8080000, .length = 0x80000, .kind = .flash },
@@ -12561,7 +12561,7 @@ pub const STM32H562VI = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32H562VI",
-        .cpu = MicroZig.cpus.cortex_m33,
+        .cpu = MicroZig.cpus.cortex_m33f,
         .memory_regions = &.{
             .{ .offset = 0x8000000, .length = 0x100000, .kind = .flash },
             .{ .offset = 0x8100000, .length = 0x100000, .kind = .flash },
@@ -12579,7 +12579,7 @@ pub const STM32H562ZG = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32H562ZG",
-        .cpu = MicroZig.cpus.cortex_m33,
+        .cpu = MicroZig.cpus.cortex_m33f,
         .memory_regions = &.{
             .{ .offset = 0x8000000, .length = 0x80000, .kind = .flash },
             .{ .offset = 0x8080000, .length = 0x80000, .kind = .flash },
@@ -12597,7 +12597,7 @@ pub const STM32H562ZI = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32H562ZI",
-        .cpu = MicroZig.cpus.cortex_m33,
+        .cpu = MicroZig.cpus.cortex_m33f,
         .memory_regions = &.{
             .{ .offset = 0x8000000, .length = 0x100000, .kind = .flash },
             .{ .offset = 0x8100000, .length = 0x100000, .kind = .flash },
@@ -12615,7 +12615,7 @@ pub const STM32H563AG = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32H563AG",
-        .cpu = MicroZig.cpus.cortex_m33,
+        .cpu = MicroZig.cpus.cortex_m33f,
         .memory_regions = &.{
             .{ .offset = 0x8000000, .length = 0x80000, .kind = .flash },
             .{ .offset = 0x8080000, .length = 0x80000, .kind = .flash },
@@ -12633,7 +12633,7 @@ pub const STM32H563AI = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32H563AI",
-        .cpu = MicroZig.cpus.cortex_m33,
+        .cpu = MicroZig.cpus.cortex_m33f,
         .memory_regions = &.{
             .{ .offset = 0x8000000, .length = 0x100000, .kind = .flash },
             .{ .offset = 0x8100000, .length = 0x100000, .kind = .flash },
@@ -12651,7 +12651,7 @@ pub const STM32H563IG = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32H563IG",
-        .cpu = MicroZig.cpus.cortex_m33,
+        .cpu = MicroZig.cpus.cortex_m33f,
         .memory_regions = &.{
             .{ .offset = 0x8000000, .length = 0x80000, .kind = .flash },
             .{ .offset = 0x8080000, .length = 0x80000, .kind = .flash },
@@ -12669,7 +12669,7 @@ pub const STM32H563II = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32H563II",
-        .cpu = MicroZig.cpus.cortex_m33,
+        .cpu = MicroZig.cpus.cortex_m33f,
         .memory_regions = &.{
             .{ .offset = 0x8000000, .length = 0x100000, .kind = .flash },
             .{ .offset = 0x8100000, .length = 0x100000, .kind = .flash },
@@ -12687,7 +12687,7 @@ pub const STM32H563MI = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32H563MI",
-        .cpu = MicroZig.cpus.cortex_m33,
+        .cpu = MicroZig.cpus.cortex_m33f,
         .memory_regions = &.{
             .{ .offset = 0x8000000, .length = 0x100000, .kind = .flash },
             .{ .offset = 0x8100000, .length = 0x100000, .kind = .flash },
@@ -12705,7 +12705,7 @@ pub const STM32H563RG = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32H563RG",
-        .cpu = MicroZig.cpus.cortex_m33,
+        .cpu = MicroZig.cpus.cortex_m33f,
         .memory_regions = &.{
             .{ .offset = 0x8000000, .length = 0x80000, .kind = .flash },
             .{ .offset = 0x8080000, .length = 0x80000, .kind = .flash },
@@ -12723,7 +12723,7 @@ pub const STM32H563RI = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32H563RI",
-        .cpu = MicroZig.cpus.cortex_m33,
+        .cpu = MicroZig.cpus.cortex_m33f,
         .memory_regions = &.{
             .{ .offset = 0x8000000, .length = 0x100000, .kind = .flash },
             .{ .offset = 0x8100000, .length = 0x100000, .kind = .flash },
@@ -12741,7 +12741,7 @@ pub const STM32H563VG = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32H563VG",
-        .cpu = MicroZig.cpus.cortex_m33,
+        .cpu = MicroZig.cpus.cortex_m33f,
         .memory_regions = &.{
             .{ .offset = 0x8000000, .length = 0x80000, .kind = .flash },
             .{ .offset = 0x8080000, .length = 0x80000, .kind = .flash },
@@ -12759,7 +12759,7 @@ pub const STM32H563VI = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32H563VI",
-        .cpu = MicroZig.cpus.cortex_m33,
+        .cpu = MicroZig.cpus.cortex_m33f,
         .memory_regions = &.{
             .{ .offset = 0x8000000, .length = 0x100000, .kind = .flash },
             .{ .offset = 0x8100000, .length = 0x100000, .kind = .flash },
@@ -12777,7 +12777,7 @@ pub const STM32H563ZG = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32H563ZG",
-        .cpu = MicroZig.cpus.cortex_m33,
+        .cpu = MicroZig.cpus.cortex_m33f,
         .memory_regions = &.{
             .{ .offset = 0x8000000, .length = 0x80000, .kind = .flash },
             .{ .offset = 0x8080000, .length = 0x80000, .kind = .flash },
@@ -12795,7 +12795,7 @@ pub const STM32H563ZI = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32H563ZI",
-        .cpu = MicroZig.cpus.cortex_m33,
+        .cpu = MicroZig.cpus.cortex_m33f,
         .memory_regions = &.{
             .{ .offset = 0x8000000, .length = 0x100000, .kind = .flash },
             .{ .offset = 0x8100000, .length = 0x100000, .kind = .flash },
@@ -12813,7 +12813,7 @@ pub const STM32H573AI = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32H573AI",
-        .cpu = MicroZig.cpus.cortex_m33,
+        .cpu = MicroZig.cpus.cortex_m33f,
         .memory_regions = &.{
             .{ .offset = 0x8000000, .length = 0x100000, .kind = .flash },
             .{ .offset = 0x8100000, .length = 0x100000, .kind = .flash },
@@ -12831,7 +12831,7 @@ pub const STM32H573II = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32H573II",
-        .cpu = MicroZig.cpus.cortex_m33,
+        .cpu = MicroZig.cpus.cortex_m33f,
         .memory_regions = &.{
             .{ .offset = 0x8000000, .length = 0x100000, .kind = .flash },
             .{ .offset = 0x8100000, .length = 0x100000, .kind = .flash },
@@ -12849,7 +12849,7 @@ pub const STM32H573MI = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32H573MI",
-        .cpu = MicroZig.cpus.cortex_m33,
+        .cpu = MicroZig.cpus.cortex_m33f,
         .memory_regions = &.{
             .{ .offset = 0x8000000, .length = 0x100000, .kind = .flash },
             .{ .offset = 0x8100000, .length = 0x100000, .kind = .flash },
@@ -12867,7 +12867,7 @@ pub const STM32H573RI = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32H573RI",
-        .cpu = MicroZig.cpus.cortex_m33,
+        .cpu = MicroZig.cpus.cortex_m33f,
         .memory_regions = &.{
             .{ .offset = 0x8000000, .length = 0x100000, .kind = .flash },
             .{ .offset = 0x8100000, .length = 0x100000, .kind = .flash },
@@ -12885,7 +12885,7 @@ pub const STM32H573VI = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32H573VI",
-        .cpu = MicroZig.cpus.cortex_m33,
+        .cpu = MicroZig.cpus.cortex_m33f,
         .memory_regions = &.{
             .{ .offset = 0x8000000, .length = 0x100000, .kind = .flash },
             .{ .offset = 0x8100000, .length = 0x100000, .kind = .flash },
@@ -12903,7 +12903,7 @@ pub const STM32H573ZI = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32H573ZI",
-        .cpu = MicroZig.cpus.cortex_m33,
+        .cpu = MicroZig.cpus.cortex_m33f,
         .memory_regions = &.{
             .{ .offset = 0x8000000, .length = 0x100000, .kind = .flash },
             .{ .offset = 0x8100000, .length = 0x100000, .kind = .flash },
@@ -12921,7 +12921,7 @@ pub const STM32H723VE = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32H723VE",
-        .cpu = MicroZig.cpus.cortex_m7,
+        .cpu = MicroZig.cpus.cortex_m7f,
         .memory_regions = &.{
             .{ .offset = 0x0, .length = 0x10000, .kind = .ram },
             .{ .offset = 0x8000000, .length = 0x80000, .kind = .flash },
@@ -12940,7 +12940,7 @@ pub const STM32H723VG = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32H723VG",
-        .cpu = MicroZig.cpus.cortex_m7,
+        .cpu = MicroZig.cpus.cortex_m7f,
         .memory_regions = &.{
             .{ .offset = 0x0, .length = 0x10000, .kind = .ram },
             .{ .offset = 0x8000000, .length = 0x100000, .kind = .flash },
@@ -12959,7 +12959,7 @@ pub const STM32H723ZE = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32H723ZE",
-        .cpu = MicroZig.cpus.cortex_m7,
+        .cpu = MicroZig.cpus.cortex_m7f,
         .memory_regions = &.{
             .{ .offset = 0x0, .length = 0x10000, .kind = .ram },
             .{ .offset = 0x8000000, .length = 0x80000, .kind = .flash },
@@ -12978,7 +12978,7 @@ pub const STM32H723ZG = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32H723ZG",
-        .cpu = MicroZig.cpus.cortex_m7,
+        .cpu = MicroZig.cpus.cortex_m7f,
         .memory_regions = &.{
             .{ .offset = 0x0, .length = 0x10000, .kind = .ram },
             .{ .offset = 0x8000000, .length = 0x100000, .kind = .flash },
@@ -12997,7 +12997,7 @@ pub const STM32H725AE = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32H725AE",
-        .cpu = MicroZig.cpus.cortex_m7,
+        .cpu = MicroZig.cpus.cortex_m7f,
         .memory_regions = &.{
             .{ .offset = 0x0, .length = 0x10000, .kind = .ram },
             .{ .offset = 0x8000000, .length = 0x80000, .kind = .flash },
@@ -13016,7 +13016,7 @@ pub const STM32H725AG = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32H725AG",
-        .cpu = MicroZig.cpus.cortex_m7,
+        .cpu = MicroZig.cpus.cortex_m7f,
         .memory_regions = &.{
             .{ .offset = 0x0, .length = 0x10000, .kind = .ram },
             .{ .offset = 0x8000000, .length = 0x100000, .kind = .flash },
@@ -13035,7 +13035,7 @@ pub const STM32H725IE = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32H725IE",
-        .cpu = MicroZig.cpus.cortex_m7,
+        .cpu = MicroZig.cpus.cortex_m7f,
         .memory_regions = &.{
             .{ .offset = 0x0, .length = 0x10000, .kind = .ram },
             .{ .offset = 0x8000000, .length = 0x80000, .kind = .flash },
@@ -13054,7 +13054,7 @@ pub const STM32H725IG = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32H725IG",
-        .cpu = MicroZig.cpus.cortex_m7,
+        .cpu = MicroZig.cpus.cortex_m7f,
         .memory_regions = &.{
             .{ .offset = 0x0, .length = 0x10000, .kind = .ram },
             .{ .offset = 0x8000000, .length = 0x100000, .kind = .flash },
@@ -13073,7 +13073,7 @@ pub const STM32H725RE = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32H725RE",
-        .cpu = MicroZig.cpus.cortex_m7,
+        .cpu = MicroZig.cpus.cortex_m7f,
         .memory_regions = &.{
             .{ .offset = 0x0, .length = 0x10000, .kind = .ram },
             .{ .offset = 0x8000000, .length = 0x80000, .kind = .flash },
@@ -13092,7 +13092,7 @@ pub const STM32H725RG = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32H725RG",
-        .cpu = MicroZig.cpus.cortex_m7,
+        .cpu = MicroZig.cpus.cortex_m7f,
         .memory_regions = &.{
             .{ .offset = 0x0, .length = 0x10000, .kind = .ram },
             .{ .offset = 0x8000000, .length = 0x100000, .kind = .flash },
@@ -13111,7 +13111,7 @@ pub const STM32H725VE = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32H725VE",
-        .cpu = MicroZig.cpus.cortex_m7,
+        .cpu = MicroZig.cpus.cortex_m7f,
         .memory_regions = &.{
             .{ .offset = 0x0, .length = 0x10000, .kind = .ram },
             .{ .offset = 0x8000000, .length = 0x80000, .kind = .flash },
@@ -13130,7 +13130,7 @@ pub const STM32H725VG = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32H725VG",
-        .cpu = MicroZig.cpus.cortex_m7,
+        .cpu = MicroZig.cpus.cortex_m7f,
         .memory_regions = &.{
             .{ .offset = 0x0, .length = 0x10000, .kind = .ram },
             .{ .offset = 0x8000000, .length = 0x100000, .kind = .flash },
@@ -13149,7 +13149,7 @@ pub const STM32H725ZE = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32H725ZE",
-        .cpu = MicroZig.cpus.cortex_m7,
+        .cpu = MicroZig.cpus.cortex_m7f,
         .memory_regions = &.{
             .{ .offset = 0x0, .length = 0x10000, .kind = .ram },
             .{ .offset = 0x8000000, .length = 0x80000, .kind = .flash },
@@ -13168,7 +13168,7 @@ pub const STM32H725ZG = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32H725ZG",
-        .cpu = MicroZig.cpus.cortex_m7,
+        .cpu = MicroZig.cpus.cortex_m7f,
         .memory_regions = &.{
             .{ .offset = 0x0, .length = 0x10000, .kind = .ram },
             .{ .offset = 0x8000000, .length = 0x100000, .kind = .flash },
@@ -13187,7 +13187,7 @@ pub const STM32H730AB = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32H730AB",
-        .cpu = MicroZig.cpus.cortex_m7,
+        .cpu = MicroZig.cpus.cortex_m7f,
         .memory_regions = &.{
             .{ .offset = 0x0, .length = 0x10000, .kind = .ram },
             .{ .offset = 0x8000000, .length = 0x20000, .kind = .flash },
@@ -13206,7 +13206,7 @@ pub const STM32H730IB = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32H730IB",
-        .cpu = MicroZig.cpus.cortex_m7,
+        .cpu = MicroZig.cpus.cortex_m7f,
         .memory_regions = &.{
             .{ .offset = 0x0, .length = 0x10000, .kind = .ram },
             .{ .offset = 0x8000000, .length = 0x20000, .kind = .flash },
@@ -13225,7 +13225,7 @@ pub const STM32H730VB = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32H730VB",
-        .cpu = MicroZig.cpus.cortex_m7,
+        .cpu = MicroZig.cpus.cortex_m7f,
         .memory_regions = &.{
             .{ .offset = 0x0, .length = 0x10000, .kind = .ram },
             .{ .offset = 0x8000000, .length = 0x20000, .kind = .flash },
@@ -13244,7 +13244,7 @@ pub const STM32H730ZB = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32H730ZB",
-        .cpu = MicroZig.cpus.cortex_m7,
+        .cpu = MicroZig.cpus.cortex_m7f,
         .memory_regions = &.{
             .{ .offset = 0x0, .length = 0x10000, .kind = .ram },
             .{ .offset = 0x8000000, .length = 0x20000, .kind = .flash },
@@ -13263,7 +13263,7 @@ pub const STM32H733VG = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32H733VG",
-        .cpu = MicroZig.cpus.cortex_m7,
+        .cpu = MicroZig.cpus.cortex_m7f,
         .memory_regions = &.{
             .{ .offset = 0x0, .length = 0x10000, .kind = .ram },
             .{ .offset = 0x8000000, .length = 0x100000, .kind = .flash },
@@ -13282,7 +13282,7 @@ pub const STM32H733ZG = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32H733ZG",
-        .cpu = MicroZig.cpus.cortex_m7,
+        .cpu = MicroZig.cpus.cortex_m7f,
         .memory_regions = &.{
             .{ .offset = 0x0, .length = 0x10000, .kind = .ram },
             .{ .offset = 0x8000000, .length = 0x100000, .kind = .flash },
@@ -13301,7 +13301,7 @@ pub const STM32H735AG = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32H735AG",
-        .cpu = MicroZig.cpus.cortex_m7,
+        .cpu = MicroZig.cpus.cortex_m7f,
         .memory_regions = &.{
             .{ .offset = 0x0, .length = 0x10000, .kind = .ram },
             .{ .offset = 0x8000000, .length = 0x100000, .kind = .flash },
@@ -13320,7 +13320,7 @@ pub const STM32H735IG = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32H735IG",
-        .cpu = MicroZig.cpus.cortex_m7,
+        .cpu = MicroZig.cpus.cortex_m7f,
         .memory_regions = &.{
             .{ .offset = 0x0, .length = 0x10000, .kind = .ram },
             .{ .offset = 0x8000000, .length = 0x100000, .kind = .flash },
@@ -13339,7 +13339,7 @@ pub const STM32H735RG = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32H735RG",
-        .cpu = MicroZig.cpus.cortex_m7,
+        .cpu = MicroZig.cpus.cortex_m7f,
         .memory_regions = &.{
             .{ .offset = 0x0, .length = 0x10000, .kind = .ram },
             .{ .offset = 0x8000000, .length = 0x100000, .kind = .flash },
@@ -13358,7 +13358,7 @@ pub const STM32H735VG = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32H735VG",
-        .cpu = MicroZig.cpus.cortex_m7,
+        .cpu = MicroZig.cpus.cortex_m7f,
         .memory_regions = &.{
             .{ .offset = 0x0, .length = 0x10000, .kind = .ram },
             .{ .offset = 0x8000000, .length = 0x100000, .kind = .flash },
@@ -13377,7 +13377,7 @@ pub const STM32H735ZG = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32H735ZG",
-        .cpu = MicroZig.cpus.cortex_m7,
+        .cpu = MicroZig.cpus.cortex_m7f,
         .memory_regions = &.{
             .{ .offset = 0x0, .length = 0x10000, .kind = .ram },
             .{ .offset = 0x8000000, .length = 0x100000, .kind = .flash },
@@ -13396,7 +13396,7 @@ pub const STM32H742AG = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32H742AG",
-        .cpu = MicroZig.cpus.cortex_m7,
+        .cpu = MicroZig.cpus.cortex_m7f,
         .memory_regions = &.{
             .{ .offset = 0x0, .length = 0x10000, .kind = .ram },
             .{ .offset = 0x8000000, .length = 0x80000, .kind = .flash },
@@ -13417,7 +13417,7 @@ pub const STM32H742AI = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32H742AI",
-        .cpu = MicroZig.cpus.cortex_m7,
+        .cpu = MicroZig.cpus.cortex_m7f,
         .memory_regions = &.{
             .{ .offset = 0x0, .length = 0x10000, .kind = .ram },
             .{ .offset = 0x8000000, .length = 0x100000, .kind = .flash },
@@ -13438,7 +13438,7 @@ pub const STM32H742BG = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32H742BG",
-        .cpu = MicroZig.cpus.cortex_m7,
+        .cpu = MicroZig.cpus.cortex_m7f,
         .memory_regions = &.{
             .{ .offset = 0x0, .length = 0x10000, .kind = .ram },
             .{ .offset = 0x8000000, .length = 0x80000, .kind = .flash },
@@ -13459,7 +13459,7 @@ pub const STM32H742BI = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32H742BI",
-        .cpu = MicroZig.cpus.cortex_m7,
+        .cpu = MicroZig.cpus.cortex_m7f,
         .memory_regions = &.{
             .{ .offset = 0x0, .length = 0x10000, .kind = .ram },
             .{ .offset = 0x8000000, .length = 0x100000, .kind = .flash },
@@ -13480,7 +13480,7 @@ pub const STM32H742IG = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32H742IG",
-        .cpu = MicroZig.cpus.cortex_m7,
+        .cpu = MicroZig.cpus.cortex_m7f,
         .memory_regions = &.{
             .{ .offset = 0x0, .length = 0x10000, .kind = .ram },
             .{ .offset = 0x8000000, .length = 0x80000, .kind = .flash },
@@ -13501,7 +13501,7 @@ pub const STM32H742II = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32H742II",
-        .cpu = MicroZig.cpus.cortex_m7,
+        .cpu = MicroZig.cpus.cortex_m7f,
         .memory_regions = &.{
             .{ .offset = 0x0, .length = 0x10000, .kind = .ram },
             .{ .offset = 0x8000000, .length = 0x100000, .kind = .flash },
@@ -13522,7 +13522,7 @@ pub const STM32H742VG = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32H742VG",
-        .cpu = MicroZig.cpus.cortex_m7,
+        .cpu = MicroZig.cpus.cortex_m7f,
         .memory_regions = &.{
             .{ .offset = 0x0, .length = 0x10000, .kind = .ram },
             .{ .offset = 0x8000000, .length = 0x80000, .kind = .flash },
@@ -13543,7 +13543,7 @@ pub const STM32H742VI = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32H742VI",
-        .cpu = MicroZig.cpus.cortex_m7,
+        .cpu = MicroZig.cpus.cortex_m7f,
         .memory_regions = &.{
             .{ .offset = 0x0, .length = 0x10000, .kind = .ram },
             .{ .offset = 0x8000000, .length = 0x100000, .kind = .flash },
@@ -13564,7 +13564,7 @@ pub const STM32H742XG = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32H742XG",
-        .cpu = MicroZig.cpus.cortex_m7,
+        .cpu = MicroZig.cpus.cortex_m7f,
         .memory_regions = &.{
             .{ .offset = 0x0, .length = 0x10000, .kind = .ram },
             .{ .offset = 0x8000000, .length = 0x80000, .kind = .flash },
@@ -13585,7 +13585,7 @@ pub const STM32H742XI = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32H742XI",
-        .cpu = MicroZig.cpus.cortex_m7,
+        .cpu = MicroZig.cpus.cortex_m7f,
         .memory_regions = &.{
             .{ .offset = 0x0, .length = 0x10000, .kind = .ram },
             .{ .offset = 0x8000000, .length = 0x100000, .kind = .flash },
@@ -13606,7 +13606,7 @@ pub const STM32H742ZG = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32H742ZG",
-        .cpu = MicroZig.cpus.cortex_m7,
+        .cpu = MicroZig.cpus.cortex_m7f,
         .memory_regions = &.{
             .{ .offset = 0x0, .length = 0x10000, .kind = .ram },
             .{ .offset = 0x8000000, .length = 0x80000, .kind = .flash },
@@ -13627,7 +13627,7 @@ pub const STM32H742ZI = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32H742ZI",
-        .cpu = MicroZig.cpus.cortex_m7,
+        .cpu = MicroZig.cpus.cortex_m7f,
         .memory_regions = &.{
             .{ .offset = 0x0, .length = 0x10000, .kind = .ram },
             .{ .offset = 0x8000000, .length = 0x100000, .kind = .flash },
@@ -13648,7 +13648,7 @@ pub const STM32H743AG = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32H743AG",
-        .cpu = MicroZig.cpus.cortex_m7,
+        .cpu = MicroZig.cpus.cortex_m7f,
         .memory_regions = &.{
             .{ .offset = 0x0, .length = 0x10000, .kind = .ram },
             .{ .offset = 0x8000000, .length = 0x80000, .kind = .flash },
@@ -13668,7 +13668,7 @@ pub const STM32H743AI = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32H743AI",
-        .cpu = MicroZig.cpus.cortex_m7,
+        .cpu = MicroZig.cpus.cortex_m7f,
         .memory_regions = &.{
             .{ .offset = 0x0, .length = 0x10000, .kind = .ram },
             .{ .offset = 0x8000000, .length = 0x100000, .kind = .flash },
@@ -13688,7 +13688,7 @@ pub const STM32H743BG = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32H743BG",
-        .cpu = MicroZig.cpus.cortex_m7,
+        .cpu = MicroZig.cpus.cortex_m7f,
         .memory_regions = &.{
             .{ .offset = 0x0, .length = 0x10000, .kind = .ram },
             .{ .offset = 0x8000000, .length = 0x80000, .kind = .flash },
@@ -13708,7 +13708,7 @@ pub const STM32H743BI = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32H743BI",
-        .cpu = MicroZig.cpus.cortex_m7,
+        .cpu = MicroZig.cpus.cortex_m7f,
         .memory_regions = &.{
             .{ .offset = 0x0, .length = 0x10000, .kind = .ram },
             .{ .offset = 0x8000000, .length = 0x100000, .kind = .flash },
@@ -13728,7 +13728,7 @@ pub const STM32H743IG = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32H743IG",
-        .cpu = MicroZig.cpus.cortex_m7,
+        .cpu = MicroZig.cpus.cortex_m7f,
         .memory_regions = &.{
             .{ .offset = 0x0, .length = 0x10000, .kind = .ram },
             .{ .offset = 0x8000000, .length = 0x80000, .kind = .flash },
@@ -13748,7 +13748,7 @@ pub const STM32H743II = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32H743II",
-        .cpu = MicroZig.cpus.cortex_m7,
+        .cpu = MicroZig.cpus.cortex_m7f,
         .memory_regions = &.{
             .{ .offset = 0x0, .length = 0x10000, .kind = .ram },
             .{ .offset = 0x8000000, .length = 0x100000, .kind = .flash },
@@ -13768,7 +13768,7 @@ pub const STM32H743VG = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32H743VG",
-        .cpu = MicroZig.cpus.cortex_m7,
+        .cpu = MicroZig.cpus.cortex_m7f,
         .memory_regions = &.{
             .{ .offset = 0x0, .length = 0x10000, .kind = .ram },
             .{ .offset = 0x8000000, .length = 0x80000, .kind = .flash },
@@ -13788,7 +13788,7 @@ pub const STM32H743VI = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32H743VI",
-        .cpu = MicroZig.cpus.cortex_m7,
+        .cpu = MicroZig.cpus.cortex_m7f,
         .memory_regions = &.{
             .{ .offset = 0x0, .length = 0x10000, .kind = .ram },
             .{ .offset = 0x8000000, .length = 0x100000, .kind = .flash },
@@ -13808,7 +13808,7 @@ pub const STM32H743XG = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32H743XG",
-        .cpu = MicroZig.cpus.cortex_m7,
+        .cpu = MicroZig.cpus.cortex_m7f,
         .memory_regions = &.{
             .{ .offset = 0x0, .length = 0x10000, .kind = .ram },
             .{ .offset = 0x8000000, .length = 0x80000, .kind = .flash },
@@ -13828,7 +13828,7 @@ pub const STM32H743XI = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32H743XI",
-        .cpu = MicroZig.cpus.cortex_m7,
+        .cpu = MicroZig.cpus.cortex_m7f,
         .memory_regions = &.{
             .{ .offset = 0x0, .length = 0x10000, .kind = .ram },
             .{ .offset = 0x8000000, .length = 0x100000, .kind = .flash },
@@ -13848,7 +13848,7 @@ pub const STM32H743ZG = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32H743ZG",
-        .cpu = MicroZig.cpus.cortex_m7,
+        .cpu = MicroZig.cpus.cortex_m7f,
         .memory_regions = &.{
             .{ .offset = 0x0, .length = 0x10000, .kind = .ram },
             .{ .offset = 0x8000000, .length = 0x80000, .kind = .flash },
@@ -13868,7 +13868,7 @@ pub const STM32H743ZI = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32H743ZI",
-        .cpu = MicroZig.cpus.cortex_m7,
+        .cpu = MicroZig.cpus.cortex_m7f,
         .memory_regions = &.{
             .{ .offset = 0x0, .length = 0x10000, .kind = .ram },
             .{ .offset = 0x8000000, .length = 0x100000, .kind = .flash },
@@ -13888,7 +13888,7 @@ pub const STM32H745BG = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32H745BG",
-        .cpu = MicroZig.cpus.cortex_m7,
+        .cpu = MicroZig.cpus.cortex_m7f,
         .memory_regions = &.{
             .{ .offset = 0x0, .length = 0x10000, .kind = .ram },
             .{ .offset = 0x8000000, .length = 0x100000, .kind = .flash },
@@ -13908,7 +13908,7 @@ pub const STM32H745BI = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32H745BI",
-        .cpu = MicroZig.cpus.cortex_m7,
+        .cpu = MicroZig.cpus.cortex_m7f,
         .memory_regions = &.{
             .{ .offset = 0x0, .length = 0x10000, .kind = .ram },
             .{ .offset = 0x8000000, .length = 0x100000, .kind = .flash },
@@ -13928,7 +13928,7 @@ pub const STM32H745IG = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32H745IG",
-        .cpu = MicroZig.cpus.cortex_m7,
+        .cpu = MicroZig.cpus.cortex_m7f,
         .memory_regions = &.{
             .{ .offset = 0x0, .length = 0x10000, .kind = .ram },
             .{ .offset = 0x8000000, .length = 0x100000, .kind = .flash },
@@ -13948,7 +13948,7 @@ pub const STM32H745II = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32H745II",
-        .cpu = MicroZig.cpus.cortex_m7,
+        .cpu = MicroZig.cpus.cortex_m7f,
         .memory_regions = &.{
             .{ .offset = 0x0, .length = 0x10000, .kind = .ram },
             .{ .offset = 0x8000000, .length = 0x100000, .kind = .flash },
@@ -13968,7 +13968,7 @@ pub const STM32H745XG = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32H745XG",
-        .cpu = MicroZig.cpus.cortex_m7,
+        .cpu = MicroZig.cpus.cortex_m7f,
         .memory_regions = &.{
             .{ .offset = 0x0, .length = 0x10000, .kind = .ram },
             .{ .offset = 0x8000000, .length = 0x100000, .kind = .flash },
@@ -13988,7 +13988,7 @@ pub const STM32H745XI = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32H745XI",
-        .cpu = MicroZig.cpus.cortex_m7,
+        .cpu = MicroZig.cpus.cortex_m7f,
         .memory_regions = &.{
             .{ .offset = 0x0, .length = 0x10000, .kind = .ram },
             .{ .offset = 0x8000000, .length = 0x100000, .kind = .flash },
@@ -14008,7 +14008,7 @@ pub const STM32H745ZG = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32H745ZG",
-        .cpu = MicroZig.cpus.cortex_m7,
+        .cpu = MicroZig.cpus.cortex_m7f,
         .memory_regions = &.{
             .{ .offset = 0x0, .length = 0x10000, .kind = .ram },
             .{ .offset = 0x8000000, .length = 0x100000, .kind = .flash },
@@ -14028,7 +14028,7 @@ pub const STM32H745ZI = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32H745ZI",
-        .cpu = MicroZig.cpus.cortex_m7,
+        .cpu = MicroZig.cpus.cortex_m7f,
         .memory_regions = &.{
             .{ .offset = 0x0, .length = 0x10000, .kind = .ram },
             .{ .offset = 0x8000000, .length = 0x100000, .kind = .flash },
@@ -14048,7 +14048,7 @@ pub const STM32H747AG = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32H747AG",
-        .cpu = MicroZig.cpus.cortex_m7,
+        .cpu = MicroZig.cpus.cortex_m7f,
         .memory_regions = &.{
             .{ .offset = 0x0, .length = 0x10000, .kind = .ram },
             .{ .offset = 0x8000000, .length = 0x100000, .kind = .flash },
@@ -14068,7 +14068,7 @@ pub const STM32H747AI = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32H747AI",
-        .cpu = MicroZig.cpus.cortex_m7,
+        .cpu = MicroZig.cpus.cortex_m7f,
         .memory_regions = &.{
             .{ .offset = 0x0, .length = 0x10000, .kind = .ram },
             .{ .offset = 0x8000000, .length = 0x100000, .kind = .flash },
@@ -14088,7 +14088,7 @@ pub const STM32H747BG = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32H747BG",
-        .cpu = MicroZig.cpus.cortex_m7,
+        .cpu = MicroZig.cpus.cortex_m7f,
         .memory_regions = &.{
             .{ .offset = 0x0, .length = 0x10000, .kind = .ram },
             .{ .offset = 0x8000000, .length = 0x100000, .kind = .flash },
@@ -14108,7 +14108,7 @@ pub const STM32H747BI = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32H747BI",
-        .cpu = MicroZig.cpus.cortex_m7,
+        .cpu = MicroZig.cpus.cortex_m7f,
         .memory_regions = &.{
             .{ .offset = 0x0, .length = 0x10000, .kind = .ram },
             .{ .offset = 0x8000000, .length = 0x100000, .kind = .flash },
@@ -14128,7 +14128,7 @@ pub const STM32H747IG = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32H747IG",
-        .cpu = MicroZig.cpus.cortex_m7,
+        .cpu = MicroZig.cpus.cortex_m7f,
         .memory_regions = &.{
             .{ .offset = 0x0, .length = 0x10000, .kind = .ram },
             .{ .offset = 0x8000000, .length = 0x100000, .kind = .flash },
@@ -14148,7 +14148,7 @@ pub const STM32H747II = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32H747II",
-        .cpu = MicroZig.cpus.cortex_m7,
+        .cpu = MicroZig.cpus.cortex_m7f,
         .memory_regions = &.{
             .{ .offset = 0x0, .length = 0x10000, .kind = .ram },
             .{ .offset = 0x8000000, .length = 0x100000, .kind = .flash },
@@ -14168,7 +14168,7 @@ pub const STM32H747XG = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32H747XG",
-        .cpu = MicroZig.cpus.cortex_m7,
+        .cpu = MicroZig.cpus.cortex_m7f,
         .memory_regions = &.{
             .{ .offset = 0x0, .length = 0x10000, .kind = .ram },
             .{ .offset = 0x8000000, .length = 0x100000, .kind = .flash },
@@ -14188,7 +14188,7 @@ pub const STM32H747XI = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32H747XI",
-        .cpu = MicroZig.cpus.cortex_m7,
+        .cpu = MicroZig.cpus.cortex_m7f,
         .memory_regions = &.{
             .{ .offset = 0x0, .length = 0x10000, .kind = .ram },
             .{ .offset = 0x8000000, .length = 0x100000, .kind = .flash },
@@ -14208,7 +14208,7 @@ pub const STM32H747ZI = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32H747ZI",
-        .cpu = MicroZig.cpus.cortex_m7,
+        .cpu = MicroZig.cpus.cortex_m7f,
         .memory_regions = &.{
             .{ .offset = 0x0, .length = 0x10000, .kind = .ram },
             .{ .offset = 0x8000000, .length = 0x100000, .kind = .flash },
@@ -14228,7 +14228,7 @@ pub const STM32H750IB = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32H750IB",
-        .cpu = MicroZig.cpus.cortex_m7,
+        .cpu = MicroZig.cpus.cortex_m7f,
         .memory_regions = &.{
             .{ .offset = 0x0, .length = 0x10000, .kind = .ram },
             .{ .offset = 0x8000000, .length = 0x20000, .kind = .flash },
@@ -14247,7 +14247,7 @@ pub const STM32H750VB = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32H750VB",
-        .cpu = MicroZig.cpus.cortex_m7,
+        .cpu = MicroZig.cpus.cortex_m7f,
         .memory_regions = &.{
             .{ .offset = 0x0, .length = 0x10000, .kind = .ram },
             .{ .offset = 0x8000000, .length = 0x20000, .kind = .flash },
@@ -14266,7 +14266,7 @@ pub const STM32H750XB = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32H750XB",
-        .cpu = MicroZig.cpus.cortex_m7,
+        .cpu = MicroZig.cpus.cortex_m7f,
         .memory_regions = &.{
             .{ .offset = 0x0, .length = 0x10000, .kind = .ram },
             .{ .offset = 0x8000000, .length = 0x20000, .kind = .flash },
@@ -14285,7 +14285,7 @@ pub const STM32H750ZB = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32H750ZB",
-        .cpu = MicroZig.cpus.cortex_m7,
+        .cpu = MicroZig.cpus.cortex_m7f,
         .memory_regions = &.{
             .{ .offset = 0x0, .length = 0x10000, .kind = .ram },
             .{ .offset = 0x8000000, .length = 0x20000, .kind = .flash },
@@ -14304,7 +14304,7 @@ pub const STM32H753AI = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32H753AI",
-        .cpu = MicroZig.cpus.cortex_m7,
+        .cpu = MicroZig.cpus.cortex_m7f,
         .memory_regions = &.{
             .{ .offset = 0x0, .length = 0x10000, .kind = .ram },
             .{ .offset = 0x8000000, .length = 0x100000, .kind = .flash },
@@ -14324,7 +14324,7 @@ pub const STM32H753BI = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32H753BI",
-        .cpu = MicroZig.cpus.cortex_m7,
+        .cpu = MicroZig.cpus.cortex_m7f,
         .memory_regions = &.{
             .{ .offset = 0x0, .length = 0x10000, .kind = .ram },
             .{ .offset = 0x8000000, .length = 0x100000, .kind = .flash },
@@ -14344,7 +14344,7 @@ pub const STM32H753II = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32H753II",
-        .cpu = MicroZig.cpus.cortex_m7,
+        .cpu = MicroZig.cpus.cortex_m7f,
         .memory_regions = &.{
             .{ .offset = 0x0, .length = 0x10000, .kind = .ram },
             .{ .offset = 0x8000000, .length = 0x100000, .kind = .flash },
@@ -14364,7 +14364,7 @@ pub const STM32H753VI = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32H753VI",
-        .cpu = MicroZig.cpus.cortex_m7,
+        .cpu = MicroZig.cpus.cortex_m7f,
         .memory_regions = &.{
             .{ .offset = 0x0, .length = 0x10000, .kind = .ram },
             .{ .offset = 0x8000000, .length = 0x100000, .kind = .flash },
@@ -14384,7 +14384,7 @@ pub const STM32H753XI = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32H753XI",
-        .cpu = MicroZig.cpus.cortex_m7,
+        .cpu = MicroZig.cpus.cortex_m7f,
         .memory_regions = &.{
             .{ .offset = 0x0, .length = 0x10000, .kind = .ram },
             .{ .offset = 0x8000000, .length = 0x100000, .kind = .flash },
@@ -14404,7 +14404,7 @@ pub const STM32H753ZI = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32H753ZI",
-        .cpu = MicroZig.cpus.cortex_m7,
+        .cpu = MicroZig.cpus.cortex_m7f,
         .memory_regions = &.{
             .{ .offset = 0x0, .length = 0x10000, .kind = .ram },
             .{ .offset = 0x8000000, .length = 0x100000, .kind = .flash },
@@ -14424,7 +14424,7 @@ pub const STM32H755BI = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32H755BI",
-        .cpu = MicroZig.cpus.cortex_m7,
+        .cpu = MicroZig.cpus.cortex_m7f,
         .memory_regions = &.{
             .{ .offset = 0x0, .length = 0x10000, .kind = .ram },
             .{ .offset = 0x8000000, .length = 0x100000, .kind = .flash },
@@ -14444,7 +14444,7 @@ pub const STM32H755II = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32H755II",
-        .cpu = MicroZig.cpus.cortex_m7,
+        .cpu = MicroZig.cpus.cortex_m7f,
         .memory_regions = &.{
             .{ .offset = 0x0, .length = 0x10000, .kind = .ram },
             .{ .offset = 0x8000000, .length = 0x100000, .kind = .flash },
@@ -14464,7 +14464,7 @@ pub const STM32H755XI = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32H755XI",
-        .cpu = MicroZig.cpus.cortex_m7,
+        .cpu = MicroZig.cpus.cortex_m7f,
         .memory_regions = &.{
             .{ .offset = 0x0, .length = 0x10000, .kind = .ram },
             .{ .offset = 0x8000000, .length = 0x100000, .kind = .flash },
@@ -14484,7 +14484,7 @@ pub const STM32H755ZI = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32H755ZI",
-        .cpu = MicroZig.cpus.cortex_m7,
+        .cpu = MicroZig.cpus.cortex_m7f,
         .memory_regions = &.{
             .{ .offset = 0x0, .length = 0x10000, .kind = .ram },
             .{ .offset = 0x8000000, .length = 0x100000, .kind = .flash },
@@ -14504,7 +14504,7 @@ pub const STM32H757AI = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32H757AI",
-        .cpu = MicroZig.cpus.cortex_m7,
+        .cpu = MicroZig.cpus.cortex_m7f,
         .memory_regions = &.{
             .{ .offset = 0x0, .length = 0x10000, .kind = .ram },
             .{ .offset = 0x8000000, .length = 0x100000, .kind = .flash },
@@ -14524,7 +14524,7 @@ pub const STM32H757BI = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32H757BI",
-        .cpu = MicroZig.cpus.cortex_m7,
+        .cpu = MicroZig.cpus.cortex_m7f,
         .memory_regions = &.{
             .{ .offset = 0x0, .length = 0x10000, .kind = .ram },
             .{ .offset = 0x8000000, .length = 0x100000, .kind = .flash },
@@ -14544,7 +14544,7 @@ pub const STM32H757II = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32H757II",
-        .cpu = MicroZig.cpus.cortex_m7,
+        .cpu = MicroZig.cpus.cortex_m7f,
         .memory_regions = &.{
             .{ .offset = 0x0, .length = 0x10000, .kind = .ram },
             .{ .offset = 0x8000000, .length = 0x100000, .kind = .flash },
@@ -14564,7 +14564,7 @@ pub const STM32H757XI = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32H757XI",
-        .cpu = MicroZig.cpus.cortex_m7,
+        .cpu = MicroZig.cpus.cortex_m7f,
         .memory_regions = &.{
             .{ .offset = 0x0, .length = 0x10000, .kind = .ram },
             .{ .offset = 0x8000000, .length = 0x100000, .kind = .flash },
@@ -14584,7 +14584,7 @@ pub const STM32H757ZI = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32H757ZI",
-        .cpu = MicroZig.cpus.cortex_m7,
+        .cpu = MicroZig.cpus.cortex_m7f,
         .memory_regions = &.{
             .{ .offset = 0x0, .length = 0x10000, .kind = .ram },
             .{ .offset = 0x8000000, .length = 0x100000, .kind = .flash },
@@ -14604,7 +14604,7 @@ pub const STM32H7A3AG = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32H7A3AG",
-        .cpu = MicroZig.cpus.cortex_m7,
+        .cpu = MicroZig.cpus.cortex_m7f,
         .memory_regions = &.{
             .{ .offset = 0x0, .length = 0x10000, .kind = .ram },
             .{ .offset = 0x8000000, .length = 0x80000, .kind = .flash },
@@ -14622,7 +14622,7 @@ pub const STM32H7A3AI = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32H7A3AI",
-        .cpu = MicroZig.cpus.cortex_m7,
+        .cpu = MicroZig.cpus.cortex_m7f,
         .memory_regions = &.{
             .{ .offset = 0x0, .length = 0x10000, .kind = .ram },
             .{ .offset = 0x8000000, .length = 0x100000, .kind = .flash },
@@ -14640,7 +14640,7 @@ pub const STM32H7A3IG = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32H7A3IG",
-        .cpu = MicroZig.cpus.cortex_m7,
+        .cpu = MicroZig.cpus.cortex_m7f,
         .memory_regions = &.{
             .{ .offset = 0x0, .length = 0x10000, .kind = .ram },
             .{ .offset = 0x8000000, .length = 0x80000, .kind = .flash },
@@ -14658,7 +14658,7 @@ pub const STM32H7A3II = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32H7A3II",
-        .cpu = MicroZig.cpus.cortex_m7,
+        .cpu = MicroZig.cpus.cortex_m7f,
         .memory_regions = &.{
             .{ .offset = 0x0, .length = 0x10000, .kind = .ram },
             .{ .offset = 0x8000000, .length = 0x100000, .kind = .flash },
@@ -14676,7 +14676,7 @@ pub const STM32H7A3LG = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32H7A3LG",
-        .cpu = MicroZig.cpus.cortex_m7,
+        .cpu = MicroZig.cpus.cortex_m7f,
         .memory_regions = &.{
             .{ .offset = 0x0, .length = 0x10000, .kind = .ram },
             .{ .offset = 0x8000000, .length = 0x80000, .kind = .flash },
@@ -14694,7 +14694,7 @@ pub const STM32H7A3LI = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32H7A3LI",
-        .cpu = MicroZig.cpus.cortex_m7,
+        .cpu = MicroZig.cpus.cortex_m7f,
         .memory_regions = &.{
             .{ .offset = 0x0, .length = 0x10000, .kind = .ram },
             .{ .offset = 0x8000000, .length = 0x100000, .kind = .flash },
@@ -14712,7 +14712,7 @@ pub const STM32H7A3NG = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32H7A3NG",
-        .cpu = MicroZig.cpus.cortex_m7,
+        .cpu = MicroZig.cpus.cortex_m7f,
         .memory_regions = &.{
             .{ .offset = 0x0, .length = 0x10000, .kind = .ram },
             .{ .offset = 0x8000000, .length = 0x80000, .kind = .flash },
@@ -14730,7 +14730,7 @@ pub const STM32H7A3NI = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32H7A3NI",
-        .cpu = MicroZig.cpus.cortex_m7,
+        .cpu = MicroZig.cpus.cortex_m7f,
         .memory_regions = &.{
             .{ .offset = 0x0, .length = 0x10000, .kind = .ram },
             .{ .offset = 0x8000000, .length = 0x100000, .kind = .flash },
@@ -14748,7 +14748,7 @@ pub const STM32H7A3QI = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32H7A3QI",
-        .cpu = MicroZig.cpus.cortex_m7,
+        .cpu = MicroZig.cpus.cortex_m7f,
         .memory_regions = &.{
             .{ .offset = 0x0, .length = 0x10000, .kind = .ram },
             .{ .offset = 0x8000000, .length = 0x100000, .kind = .flash },
@@ -14766,7 +14766,7 @@ pub const STM32H7A3RG = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32H7A3RG",
-        .cpu = MicroZig.cpus.cortex_m7,
+        .cpu = MicroZig.cpus.cortex_m7f,
         .memory_regions = &.{
             .{ .offset = 0x0, .length = 0x10000, .kind = .ram },
             .{ .offset = 0x8000000, .length = 0x80000, .kind = .flash },
@@ -14784,7 +14784,7 @@ pub const STM32H7A3RI = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32H7A3RI",
-        .cpu = MicroZig.cpus.cortex_m7,
+        .cpu = MicroZig.cpus.cortex_m7f,
         .memory_regions = &.{
             .{ .offset = 0x0, .length = 0x10000, .kind = .ram },
             .{ .offset = 0x8000000, .length = 0x100000, .kind = .flash },
@@ -14802,7 +14802,7 @@ pub const STM32H7A3VG = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32H7A3VG",
-        .cpu = MicroZig.cpus.cortex_m7,
+        .cpu = MicroZig.cpus.cortex_m7f,
         .memory_regions = &.{
             .{ .offset = 0x0, .length = 0x10000, .kind = .ram },
             .{ .offset = 0x8000000, .length = 0x80000, .kind = .flash },
@@ -14820,7 +14820,7 @@ pub const STM32H7A3VI = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32H7A3VI",
-        .cpu = MicroZig.cpus.cortex_m7,
+        .cpu = MicroZig.cpus.cortex_m7f,
         .memory_regions = &.{
             .{ .offset = 0x0, .length = 0x10000, .kind = .ram },
             .{ .offset = 0x8000000, .length = 0x100000, .kind = .flash },
@@ -14838,7 +14838,7 @@ pub const STM32H7A3ZG = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32H7A3ZG",
-        .cpu = MicroZig.cpus.cortex_m7,
+        .cpu = MicroZig.cpus.cortex_m7f,
         .memory_regions = &.{
             .{ .offset = 0x0, .length = 0x10000, .kind = .ram },
             .{ .offset = 0x8000000, .length = 0x80000, .kind = .flash },
@@ -14856,7 +14856,7 @@ pub const STM32H7A3ZI = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32H7A3ZI",
-        .cpu = MicroZig.cpus.cortex_m7,
+        .cpu = MicroZig.cpus.cortex_m7f,
         .memory_regions = &.{
             .{ .offset = 0x0, .length = 0x10000, .kind = .ram },
             .{ .offset = 0x8000000, .length = 0x100000, .kind = .flash },
@@ -14874,7 +14874,7 @@ pub const STM32H7B0AB = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32H7B0AB",
-        .cpu = MicroZig.cpus.cortex_m7,
+        .cpu = MicroZig.cpus.cortex_m7f,
         .memory_regions = &.{
             .{ .offset = 0x0, .length = 0x10000, .kind = .ram },
             .{ .offset = 0x8000000, .length = 0x20000, .kind = .flash },
@@ -14891,7 +14891,7 @@ pub const STM32H7B0IB = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32H7B0IB",
-        .cpu = MicroZig.cpus.cortex_m7,
+        .cpu = MicroZig.cpus.cortex_m7f,
         .memory_regions = &.{
             .{ .offset = 0x0, .length = 0x10000, .kind = .ram },
             .{ .offset = 0x8000000, .length = 0x20000, .kind = .flash },
@@ -14908,7 +14908,7 @@ pub const STM32H7B0RB = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32H7B0RB",
-        .cpu = MicroZig.cpus.cortex_m7,
+        .cpu = MicroZig.cpus.cortex_m7f,
         .memory_regions = &.{
             .{ .offset = 0x0, .length = 0x10000, .kind = .ram },
             .{ .offset = 0x8000000, .length = 0x20000, .kind = .flash },
@@ -14925,7 +14925,7 @@ pub const STM32H7B0VB = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32H7B0VB",
-        .cpu = MicroZig.cpus.cortex_m7,
+        .cpu = MicroZig.cpus.cortex_m7f,
         .memory_regions = &.{
             .{ .offset = 0x0, .length = 0x10000, .kind = .ram },
             .{ .offset = 0x8000000, .length = 0x20000, .kind = .flash },
@@ -14942,7 +14942,7 @@ pub const STM32H7B0ZB = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32H7B0ZB",
-        .cpu = MicroZig.cpus.cortex_m7,
+        .cpu = MicroZig.cpus.cortex_m7f,
         .memory_regions = &.{
             .{ .offset = 0x0, .length = 0x10000, .kind = .ram },
             .{ .offset = 0x8000000, .length = 0x20000, .kind = .flash },
@@ -14959,7 +14959,7 @@ pub const STM32H7B3AI = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32H7B3AI",
-        .cpu = MicroZig.cpus.cortex_m7,
+        .cpu = MicroZig.cpus.cortex_m7f,
         .memory_regions = &.{
             .{ .offset = 0x0, .length = 0x10000, .kind = .ram },
             .{ .offset = 0x8000000, .length = 0x100000, .kind = .flash },
@@ -14977,7 +14977,7 @@ pub const STM32H7B3II = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32H7B3II",
-        .cpu = MicroZig.cpus.cortex_m7,
+        .cpu = MicroZig.cpus.cortex_m7f,
         .memory_regions = &.{
             .{ .offset = 0x0, .length = 0x10000, .kind = .ram },
             .{ .offset = 0x8000000, .length = 0x100000, .kind = .flash },
@@ -14995,7 +14995,7 @@ pub const STM32H7B3LI = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32H7B3LI",
-        .cpu = MicroZig.cpus.cortex_m7,
+        .cpu = MicroZig.cpus.cortex_m7f,
         .memory_regions = &.{
             .{ .offset = 0x0, .length = 0x10000, .kind = .ram },
             .{ .offset = 0x8000000, .length = 0x100000, .kind = .flash },
@@ -15013,7 +15013,7 @@ pub const STM32H7B3NI = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32H7B3NI",
-        .cpu = MicroZig.cpus.cortex_m7,
+        .cpu = MicroZig.cpus.cortex_m7f,
         .memory_regions = &.{
             .{ .offset = 0x0, .length = 0x10000, .kind = .ram },
             .{ .offset = 0x8000000, .length = 0x100000, .kind = .flash },
@@ -15031,7 +15031,7 @@ pub const STM32H7B3QI = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32H7B3QI",
-        .cpu = MicroZig.cpus.cortex_m7,
+        .cpu = MicroZig.cpus.cortex_m7f,
         .memory_regions = &.{
             .{ .offset = 0x0, .length = 0x10000, .kind = .ram },
             .{ .offset = 0x8000000, .length = 0x100000, .kind = .flash },
@@ -15049,7 +15049,7 @@ pub const STM32H7B3RI = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32H7B3RI",
-        .cpu = MicroZig.cpus.cortex_m7,
+        .cpu = MicroZig.cpus.cortex_m7f,
         .memory_regions = &.{
             .{ .offset = 0x0, .length = 0x10000, .kind = .ram },
             .{ .offset = 0x8000000, .length = 0x100000, .kind = .flash },
@@ -15067,7 +15067,7 @@ pub const STM32H7B3VI = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32H7B3VI",
-        .cpu = MicroZig.cpus.cortex_m7,
+        .cpu = MicroZig.cpus.cortex_m7f,
         .memory_regions = &.{
             .{ .offset = 0x0, .length = 0x10000, .kind = .ram },
             .{ .offset = 0x8000000, .length = 0x100000, .kind = .flash },
@@ -15085,7 +15085,7 @@ pub const STM32H7B3ZI = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32H7B3ZI",
-        .cpu = MicroZig.cpus.cortex_m7,
+        .cpu = MicroZig.cpus.cortex_m7f,
         .memory_regions = &.{
             .{ .offset = 0x0, .length = 0x10000, .kind = .ram },
             .{ .offset = 0x8000000, .length = 0x100000, .kind = .flash },
@@ -15103,7 +15103,7 @@ pub const STM32H7R3A8 = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32H7R3A8",
-        .cpu = MicroZig.cpus.cortex_m7,
+        .cpu = MicroZig.cpus.cortex_m7f,
         .memory_regions = &.{
             .{ .offset = 0x0, .length = 0x30000, .kind = .ram },
             .{ .offset = 0x8000000, .length = 0x10000, .kind = .flash },
@@ -15125,7 +15125,7 @@ pub const STM32H7R3I8 = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32H7R3I8",
-        .cpu = MicroZig.cpus.cortex_m7,
+        .cpu = MicroZig.cpus.cortex_m7f,
         .memory_regions = &.{
             .{ .offset = 0x0, .length = 0x30000, .kind = .ram },
             .{ .offset = 0x8000000, .length = 0x10000, .kind = .flash },
@@ -15147,7 +15147,7 @@ pub const STM32H7R3L8 = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32H7R3L8",
-        .cpu = MicroZig.cpus.cortex_m7,
+        .cpu = MicroZig.cpus.cortex_m7f,
         .memory_regions = &.{
             .{ .offset = 0x0, .length = 0x30000, .kind = .ram },
             .{ .offset = 0x8000000, .length = 0x10000, .kind = .flash },
@@ -15169,7 +15169,7 @@ pub const STM32H7R3R8 = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32H7R3R8",
-        .cpu = MicroZig.cpus.cortex_m7,
+        .cpu = MicroZig.cpus.cortex_m7f,
         .memory_regions = &.{
             .{ .offset = 0x0, .length = 0x30000, .kind = .ram },
             .{ .offset = 0x8000000, .length = 0x10000, .kind = .flash },
@@ -15191,7 +15191,7 @@ pub const STM32H7R3V8 = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32H7R3V8",
-        .cpu = MicroZig.cpus.cortex_m7,
+        .cpu = MicroZig.cpus.cortex_m7f,
         .memory_regions = &.{
             .{ .offset = 0x0, .length = 0x30000, .kind = .ram },
             .{ .offset = 0x8000000, .length = 0x10000, .kind = .flash },
@@ -15213,7 +15213,7 @@ pub const STM32H7R3Z8 = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32H7R3Z8",
-        .cpu = MicroZig.cpus.cortex_m7,
+        .cpu = MicroZig.cpus.cortex_m7f,
         .memory_regions = &.{
             .{ .offset = 0x0, .length = 0x30000, .kind = .ram },
             .{ .offset = 0x8000000, .length = 0x10000, .kind = .flash },
@@ -15235,7 +15235,7 @@ pub const STM32H7R7A8 = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32H7R7A8",
-        .cpu = MicroZig.cpus.cortex_m7,
+        .cpu = MicroZig.cpus.cortex_m7f,
         .memory_regions = &.{
             .{ .offset = 0x0, .length = 0x30000, .kind = .ram },
             .{ .offset = 0x8000000, .length = 0x10000, .kind = .flash },
@@ -15257,7 +15257,7 @@ pub const STM32H7R7I8 = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32H7R7I8",
-        .cpu = MicroZig.cpus.cortex_m7,
+        .cpu = MicroZig.cpus.cortex_m7f,
         .memory_regions = &.{
             .{ .offset = 0x0, .length = 0x30000, .kind = .ram },
             .{ .offset = 0x8000000, .length = 0x10000, .kind = .flash },
@@ -15279,7 +15279,7 @@ pub const STM32H7R7L8 = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32H7R7L8",
-        .cpu = MicroZig.cpus.cortex_m7,
+        .cpu = MicroZig.cpus.cortex_m7f,
         .memory_regions = &.{
             .{ .offset = 0x0, .length = 0x30000, .kind = .ram },
             .{ .offset = 0x8000000, .length = 0x10000, .kind = .flash },
@@ -15301,7 +15301,7 @@ pub const STM32H7R7Z8 = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32H7R7Z8",
-        .cpu = MicroZig.cpus.cortex_m7,
+        .cpu = MicroZig.cpus.cortex_m7f,
         .memory_regions = &.{
             .{ .offset = 0x0, .length = 0x30000, .kind = .ram },
             .{ .offset = 0x8000000, .length = 0x10000, .kind = .flash },
@@ -15323,7 +15323,7 @@ pub const STM32H7S3A8 = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32H7S3A8",
-        .cpu = MicroZig.cpus.cortex_m7,
+        .cpu = MicroZig.cpus.cortex_m7f,
         .memory_regions = &.{
             .{ .offset = 0x0, .length = 0x30000, .kind = .ram },
             .{ .offset = 0x8000000, .length = 0x10000, .kind = .flash },
@@ -15345,7 +15345,7 @@ pub const STM32H7S3I8 = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32H7S3I8",
-        .cpu = MicroZig.cpus.cortex_m7,
+        .cpu = MicroZig.cpus.cortex_m7f,
         .memory_regions = &.{
             .{ .offset = 0x0, .length = 0x30000, .kind = .ram },
             .{ .offset = 0x8000000, .length = 0x10000, .kind = .flash },
@@ -15367,7 +15367,7 @@ pub const STM32H7S3L8 = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32H7S3L8",
-        .cpu = MicroZig.cpus.cortex_m7,
+        .cpu = MicroZig.cpus.cortex_m7f,
         .memory_regions = &.{
             .{ .offset = 0x0, .length = 0x30000, .kind = .ram },
             .{ .offset = 0x8000000, .length = 0x10000, .kind = .flash },
@@ -15389,7 +15389,7 @@ pub const STM32H7S3R8 = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32H7S3R8",
-        .cpu = MicroZig.cpus.cortex_m7,
+        .cpu = MicroZig.cpus.cortex_m7f,
         .memory_regions = &.{
             .{ .offset = 0x0, .length = 0x30000, .kind = .ram },
             .{ .offset = 0x8000000, .length = 0x10000, .kind = .flash },
@@ -15411,7 +15411,7 @@ pub const STM32H7S3V8 = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32H7S3V8",
-        .cpu = MicroZig.cpus.cortex_m7,
+        .cpu = MicroZig.cpus.cortex_m7f,
         .memory_regions = &.{
             .{ .offset = 0x0, .length = 0x30000, .kind = .ram },
             .{ .offset = 0x8000000, .length = 0x10000, .kind = .flash },
@@ -15433,7 +15433,7 @@ pub const STM32H7S3Z8 = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32H7S3Z8",
-        .cpu = MicroZig.cpus.cortex_m7,
+        .cpu = MicroZig.cpus.cortex_m7f,
         .memory_regions = &.{
             .{ .offset = 0x0, .length = 0x30000, .kind = .ram },
             .{ .offset = 0x8000000, .length = 0x10000, .kind = .flash },
@@ -15455,7 +15455,7 @@ pub const STM32H7S7A8 = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32H7S7A8",
-        .cpu = MicroZig.cpus.cortex_m7,
+        .cpu = MicroZig.cpus.cortex_m7f,
         .memory_regions = &.{
             .{ .offset = 0x0, .length = 0x30000, .kind = .ram },
             .{ .offset = 0x8000000, .length = 0x10000, .kind = .flash },
@@ -15477,7 +15477,7 @@ pub const STM32H7S7I8 = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32H7S7I8",
-        .cpu = MicroZig.cpus.cortex_m7,
+        .cpu = MicroZig.cpus.cortex_m7f,
         .memory_regions = &.{
             .{ .offset = 0x0, .length = 0x30000, .kind = .ram },
             .{ .offset = 0x8000000, .length = 0x10000, .kind = .flash },
@@ -15499,7 +15499,7 @@ pub const STM32H7S7L8 = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32H7S7L8",
-        .cpu = MicroZig.cpus.cortex_m7,
+        .cpu = MicroZig.cpus.cortex_m7f,
         .memory_regions = &.{
             .{ .offset = 0x0, .length = 0x30000, .kind = .ram },
             .{ .offset = 0x8000000, .length = 0x10000, .kind = .flash },
@@ -15521,7 +15521,7 @@ pub const STM32H7S7Z8 = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32H7S7Z8",
-        .cpu = MicroZig.cpus.cortex_m7,
+        .cpu = MicroZig.cpus.cortex_m7f,
         .memory_regions = &.{
             .{ .offset = 0x0, .length = 0x30000, .kind = .ram },
             .{ .offset = 0x8000000, .length = 0x10000, .kind = .flash },
@@ -18374,7 +18374,7 @@ pub const STM32L412C8 = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32L412C8",
-        .cpu = MicroZig.cpus.cortex_m4,
+        .cpu = MicroZig.cpus.cortex_m4f,
         .memory_regions = &.{
             .{ .offset = 0x8000000, .length = 0x10000, .kind = .flash },
             .{ .offset = 0x10000000, .length = 0x2000, .kind = .ram },
@@ -18391,7 +18391,7 @@ pub const STM32L412CB = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32L412CB",
-        .cpu = MicroZig.cpus.cortex_m4,
+        .cpu = MicroZig.cpus.cortex_m4f,
         .memory_regions = &.{
             .{ .offset = 0x8000000, .length = 0x20000, .kind = .flash },
             .{ .offset = 0x10000000, .length = 0x2000, .kind = .ram },
@@ -18408,7 +18408,7 @@ pub const STM32L412K8 = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32L412K8",
-        .cpu = MicroZig.cpus.cortex_m4,
+        .cpu = MicroZig.cpus.cortex_m4f,
         .memory_regions = &.{
             .{ .offset = 0x8000000, .length = 0x10000, .kind = .flash },
             .{ .offset = 0x10000000, .length = 0x2000, .kind = .ram },
@@ -18425,7 +18425,7 @@ pub const STM32L412KB = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32L412KB",
-        .cpu = MicroZig.cpus.cortex_m4,
+        .cpu = MicroZig.cpus.cortex_m4f,
         .memory_regions = &.{
             .{ .offset = 0x8000000, .length = 0x20000, .kind = .flash },
             .{ .offset = 0x10000000, .length = 0x2000, .kind = .ram },
@@ -18442,7 +18442,7 @@ pub const STM32L412R8 = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32L412R8",
-        .cpu = MicroZig.cpus.cortex_m4,
+        .cpu = MicroZig.cpus.cortex_m4f,
         .memory_regions = &.{
             .{ .offset = 0x8000000, .length = 0x10000, .kind = .flash },
             .{ .offset = 0x10000000, .length = 0x2000, .kind = .ram },
@@ -18459,7 +18459,7 @@ pub const STM32L412RB = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32L412RB",
-        .cpu = MicroZig.cpus.cortex_m4,
+        .cpu = MicroZig.cpus.cortex_m4f,
         .memory_regions = &.{
             .{ .offset = 0x8000000, .length = 0x20000, .kind = .flash },
             .{ .offset = 0x10000000, .length = 0x2000, .kind = .ram },
@@ -18476,7 +18476,7 @@ pub const STM32L412T8 = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32L412T8",
-        .cpu = MicroZig.cpus.cortex_m4,
+        .cpu = MicroZig.cpus.cortex_m4f,
         .memory_regions = &.{
             .{ .offset = 0x8000000, .length = 0x10000, .kind = .flash },
             .{ .offset = 0x10000000, .length = 0x2000, .kind = .ram },
@@ -18493,7 +18493,7 @@ pub const STM32L412TB = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32L412TB",
-        .cpu = MicroZig.cpus.cortex_m4,
+        .cpu = MicroZig.cpus.cortex_m4f,
         .memory_regions = &.{
             .{ .offset = 0x8000000, .length = 0x20000, .kind = .flash },
             .{ .offset = 0x10000000, .length = 0x2000, .kind = .ram },
@@ -18510,7 +18510,7 @@ pub const STM32L422CB = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32L422CB",
-        .cpu = MicroZig.cpus.cortex_m4,
+        .cpu = MicroZig.cpus.cortex_m4f,
         .memory_regions = &.{
             .{ .offset = 0x8000000, .length = 0x20000, .kind = .flash },
             .{ .offset = 0x10000000, .length = 0x2000, .kind = .ram },
@@ -18527,7 +18527,7 @@ pub const STM32L422KB = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32L422KB",
-        .cpu = MicroZig.cpus.cortex_m4,
+        .cpu = MicroZig.cpus.cortex_m4f,
         .memory_regions = &.{
             .{ .offset = 0x8000000, .length = 0x20000, .kind = .flash },
             .{ .offset = 0x10000000, .length = 0x2000, .kind = .ram },
@@ -18544,7 +18544,7 @@ pub const STM32L422RB = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32L422RB",
-        .cpu = MicroZig.cpus.cortex_m4,
+        .cpu = MicroZig.cpus.cortex_m4f,
         .memory_regions = &.{
             .{ .offset = 0x8000000, .length = 0x20000, .kind = .flash },
             .{ .offset = 0x10000000, .length = 0x2000, .kind = .ram },
@@ -18561,7 +18561,7 @@ pub const STM32L422TB = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32L422TB",
-        .cpu = MicroZig.cpus.cortex_m4,
+        .cpu = MicroZig.cpus.cortex_m4f,
         .memory_regions = &.{
             .{ .offset = 0x8000000, .length = 0x20000, .kind = .flash },
             .{ .offset = 0x10000000, .length = 0x2000, .kind = .ram },
@@ -18578,7 +18578,7 @@ pub const STM32L431CB = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32L431CB",
-        .cpu = MicroZig.cpus.cortex_m4,
+        .cpu = MicroZig.cpus.cortex_m4f,
         .memory_regions = &.{
             .{ .offset = 0x8000000, .length = 0x20000, .kind = .flash },
             .{ .offset = 0x10000000, .length = 0x4000, .kind = .ram },
@@ -18595,7 +18595,7 @@ pub const STM32L431CC = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32L431CC",
-        .cpu = MicroZig.cpus.cortex_m4,
+        .cpu = MicroZig.cpus.cortex_m4f,
         .memory_regions = &.{
             .{ .offset = 0x8000000, .length = 0x40000, .kind = .flash },
             .{ .offset = 0x10000000, .length = 0x4000, .kind = .ram },
@@ -18612,7 +18612,7 @@ pub const STM32L431KB = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32L431KB",
-        .cpu = MicroZig.cpus.cortex_m4,
+        .cpu = MicroZig.cpus.cortex_m4f,
         .memory_regions = &.{
             .{ .offset = 0x8000000, .length = 0x20000, .kind = .flash },
             .{ .offset = 0x10000000, .length = 0x4000, .kind = .ram },
@@ -18629,7 +18629,7 @@ pub const STM32L431KC = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32L431KC",
-        .cpu = MicroZig.cpus.cortex_m4,
+        .cpu = MicroZig.cpus.cortex_m4f,
         .memory_regions = &.{
             .{ .offset = 0x8000000, .length = 0x40000, .kind = .flash },
             .{ .offset = 0x10000000, .length = 0x4000, .kind = .ram },
@@ -18646,7 +18646,7 @@ pub const STM32L431RB = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32L431RB",
-        .cpu = MicroZig.cpus.cortex_m4,
+        .cpu = MicroZig.cpus.cortex_m4f,
         .memory_regions = &.{
             .{ .offset = 0x8000000, .length = 0x20000, .kind = .flash },
             .{ .offset = 0x10000000, .length = 0x4000, .kind = .ram },
@@ -18663,7 +18663,7 @@ pub const STM32L431RC = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32L431RC",
-        .cpu = MicroZig.cpus.cortex_m4,
+        .cpu = MicroZig.cpus.cortex_m4f,
         .memory_regions = &.{
             .{ .offset = 0x8000000, .length = 0x40000, .kind = .flash },
             .{ .offset = 0x10000000, .length = 0x4000, .kind = .ram },
@@ -18680,7 +18680,7 @@ pub const STM32L431VC = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32L431VC",
-        .cpu = MicroZig.cpus.cortex_m4,
+        .cpu = MicroZig.cpus.cortex_m4f,
         .memory_regions = &.{
             .{ .offset = 0x8000000, .length = 0x40000, .kind = .flash },
             .{ .offset = 0x10000000, .length = 0x4000, .kind = .ram },
@@ -18697,7 +18697,7 @@ pub const STM32L432KB = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32L432KB",
-        .cpu = MicroZig.cpus.cortex_m4,
+        .cpu = MicroZig.cpus.cortex_m4f,
         .memory_regions = &.{
             .{ .offset = 0x8000000, .length = 0x20000, .kind = .flash },
             .{ .offset = 0x10000000, .length = 0x4000, .kind = .ram },
@@ -18714,7 +18714,7 @@ pub const STM32L432KC = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32L432KC",
-        .cpu = MicroZig.cpus.cortex_m4,
+        .cpu = MicroZig.cpus.cortex_m4f,
         .memory_regions = &.{
             .{ .offset = 0x8000000, .length = 0x40000, .kind = .flash },
             .{ .offset = 0x10000000, .length = 0x4000, .kind = .ram },
@@ -18731,7 +18731,7 @@ pub const STM32L433CB = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32L433CB",
-        .cpu = MicroZig.cpus.cortex_m4,
+        .cpu = MicroZig.cpus.cortex_m4f,
         .memory_regions = &.{
             .{ .offset = 0x8000000, .length = 0x20000, .kind = .flash },
             .{ .offset = 0x10000000, .length = 0x4000, .kind = .ram },
@@ -18748,7 +18748,7 @@ pub const STM32L433CC = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32L433CC",
-        .cpu = MicroZig.cpus.cortex_m4,
+        .cpu = MicroZig.cpus.cortex_m4f,
         .memory_regions = &.{
             .{ .offset = 0x8000000, .length = 0x40000, .kind = .flash },
             .{ .offset = 0x10000000, .length = 0x4000, .kind = .ram },
@@ -18765,7 +18765,7 @@ pub const STM32L433RB = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32L433RB",
-        .cpu = MicroZig.cpus.cortex_m4,
+        .cpu = MicroZig.cpus.cortex_m4f,
         .memory_regions = &.{
             .{ .offset = 0x8000000, .length = 0x20000, .kind = .flash },
             .{ .offset = 0x10000000, .length = 0x4000, .kind = .ram },
@@ -18782,7 +18782,7 @@ pub const STM32L433RC = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32L433RC",
-        .cpu = MicroZig.cpus.cortex_m4,
+        .cpu = MicroZig.cpus.cortex_m4f,
         .memory_regions = &.{
             .{ .offset = 0x8000000, .length = 0x40000, .kind = .flash },
             .{ .offset = 0x10000000, .length = 0x4000, .kind = .ram },
@@ -18799,7 +18799,7 @@ pub const STM32L433VC = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32L433VC",
-        .cpu = MicroZig.cpus.cortex_m4,
+        .cpu = MicroZig.cpus.cortex_m4f,
         .memory_regions = &.{
             .{ .offset = 0x8000000, .length = 0x40000, .kind = .flash },
             .{ .offset = 0x10000000, .length = 0x4000, .kind = .ram },
@@ -18816,7 +18816,7 @@ pub const STM32L442KC = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32L442KC",
-        .cpu = MicroZig.cpus.cortex_m4,
+        .cpu = MicroZig.cpus.cortex_m4f,
         .memory_regions = &.{
             .{ .offset = 0x8000000, .length = 0x40000, .kind = .flash },
             .{ .offset = 0x10000000, .length = 0x4000, .kind = .ram },
@@ -18833,7 +18833,7 @@ pub const STM32L443CC = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32L443CC",
-        .cpu = MicroZig.cpus.cortex_m4,
+        .cpu = MicroZig.cpus.cortex_m4f,
         .memory_regions = &.{
             .{ .offset = 0x8000000, .length = 0x40000, .kind = .flash },
             .{ .offset = 0x10000000, .length = 0x4000, .kind = .ram },
@@ -18850,7 +18850,7 @@ pub const STM32L443RC = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32L443RC",
-        .cpu = MicroZig.cpus.cortex_m4,
+        .cpu = MicroZig.cpus.cortex_m4f,
         .memory_regions = &.{
             .{ .offset = 0x8000000, .length = 0x40000, .kind = .flash },
             .{ .offset = 0x10000000, .length = 0x4000, .kind = .ram },
@@ -18867,7 +18867,7 @@ pub const STM32L443VC = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32L443VC",
-        .cpu = MicroZig.cpus.cortex_m4,
+        .cpu = MicroZig.cpus.cortex_m4f,
         .memory_regions = &.{
             .{ .offset = 0x8000000, .length = 0x40000, .kind = .flash },
             .{ .offset = 0x10000000, .length = 0x4000, .kind = .ram },
@@ -18884,7 +18884,7 @@ pub const STM32L451CC = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32L451CC",
-        .cpu = MicroZig.cpus.cortex_m4,
+        .cpu = MicroZig.cpus.cortex_m4f,
         .memory_regions = &.{
             .{ .offset = 0x8000000, .length = 0x40000, .kind = .flash },
             .{ .offset = 0x10000000, .length = 0x8000, .kind = .ram },
@@ -18901,7 +18901,7 @@ pub const STM32L451CE = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32L451CE",
-        .cpu = MicroZig.cpus.cortex_m4,
+        .cpu = MicroZig.cpus.cortex_m4f,
         .memory_regions = &.{
             .{ .offset = 0x8000000, .length = 0x80000, .kind = .flash },
             .{ .offset = 0x10000000, .length = 0x8000, .kind = .ram },
@@ -18918,7 +18918,7 @@ pub const STM32L451RC = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32L451RC",
-        .cpu = MicroZig.cpus.cortex_m4,
+        .cpu = MicroZig.cpus.cortex_m4f,
         .memory_regions = &.{
             .{ .offset = 0x8000000, .length = 0x40000, .kind = .flash },
             .{ .offset = 0x10000000, .length = 0x8000, .kind = .ram },
@@ -18935,7 +18935,7 @@ pub const STM32L451RE = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32L451RE",
-        .cpu = MicroZig.cpus.cortex_m4,
+        .cpu = MicroZig.cpus.cortex_m4f,
         .memory_regions = &.{
             .{ .offset = 0x8000000, .length = 0x80000, .kind = .flash },
             .{ .offset = 0x10000000, .length = 0x8000, .kind = .ram },
@@ -18952,7 +18952,7 @@ pub const STM32L451VC = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32L451VC",
-        .cpu = MicroZig.cpus.cortex_m4,
+        .cpu = MicroZig.cpus.cortex_m4f,
         .memory_regions = &.{
             .{ .offset = 0x8000000, .length = 0x40000, .kind = .flash },
             .{ .offset = 0x10000000, .length = 0x8000, .kind = .ram },
@@ -18969,7 +18969,7 @@ pub const STM32L451VE = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32L451VE",
-        .cpu = MicroZig.cpus.cortex_m4,
+        .cpu = MicroZig.cpus.cortex_m4f,
         .memory_regions = &.{
             .{ .offset = 0x8000000, .length = 0x80000, .kind = .flash },
             .{ .offset = 0x10000000, .length = 0x8000, .kind = .ram },
@@ -18986,7 +18986,7 @@ pub const STM32L452CC = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32L452CC",
-        .cpu = MicroZig.cpus.cortex_m4,
+        .cpu = MicroZig.cpus.cortex_m4f,
         .memory_regions = &.{
             .{ .offset = 0x8000000, .length = 0x40000, .kind = .flash },
             .{ .offset = 0x10000000, .length = 0x8000, .kind = .ram },
@@ -19003,7 +19003,7 @@ pub const STM32L452CE = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32L452CE",
-        .cpu = MicroZig.cpus.cortex_m4,
+        .cpu = MicroZig.cpus.cortex_m4f,
         .memory_regions = &.{
             .{ .offset = 0x8000000, .length = 0x80000, .kind = .flash },
             .{ .offset = 0x10000000, .length = 0x8000, .kind = .ram },
@@ -19020,7 +19020,7 @@ pub const STM32L452RC = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32L452RC",
-        .cpu = MicroZig.cpus.cortex_m4,
+        .cpu = MicroZig.cpus.cortex_m4f,
         .memory_regions = &.{
             .{ .offset = 0x8000000, .length = 0x40000, .kind = .flash },
             .{ .offset = 0x10000000, .length = 0x8000, .kind = .ram },
@@ -19037,7 +19037,7 @@ pub const STM32L452RE = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32L452RE",
-        .cpu = MicroZig.cpus.cortex_m4,
+        .cpu = MicroZig.cpus.cortex_m4f,
         .memory_regions = &.{
             .{ .offset = 0x8000000, .length = 0x80000, .kind = .flash },
             .{ .offset = 0x10000000, .length = 0x8000, .kind = .ram },
@@ -19054,7 +19054,7 @@ pub const STM32L452VC = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32L452VC",
-        .cpu = MicroZig.cpus.cortex_m4,
+        .cpu = MicroZig.cpus.cortex_m4f,
         .memory_regions = &.{
             .{ .offset = 0x8000000, .length = 0x40000, .kind = .flash },
             .{ .offset = 0x10000000, .length = 0x8000, .kind = .ram },
@@ -19071,7 +19071,7 @@ pub const STM32L452VE = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32L452VE",
-        .cpu = MicroZig.cpus.cortex_m4,
+        .cpu = MicroZig.cpus.cortex_m4f,
         .memory_regions = &.{
             .{ .offset = 0x8000000, .length = 0x80000, .kind = .flash },
             .{ .offset = 0x10000000, .length = 0x8000, .kind = .ram },
@@ -19088,7 +19088,7 @@ pub const STM32L462CE = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32L462CE",
-        .cpu = MicroZig.cpus.cortex_m4,
+        .cpu = MicroZig.cpus.cortex_m4f,
         .memory_regions = &.{
             .{ .offset = 0x8000000, .length = 0x80000, .kind = .flash },
             .{ .offset = 0x10000000, .length = 0x8000, .kind = .ram },
@@ -19105,7 +19105,7 @@ pub const STM32L462RE = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32L462RE",
-        .cpu = MicroZig.cpus.cortex_m4,
+        .cpu = MicroZig.cpus.cortex_m4f,
         .memory_regions = &.{
             .{ .offset = 0x8000000, .length = 0x80000, .kind = .flash },
             .{ .offset = 0x10000000, .length = 0x8000, .kind = .ram },
@@ -19122,7 +19122,7 @@ pub const STM32L462VE = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32L462VE",
-        .cpu = MicroZig.cpus.cortex_m4,
+        .cpu = MicroZig.cpus.cortex_m4f,
         .memory_regions = &.{
             .{ .offset = 0x8000000, .length = 0x80000, .kind = .flash },
             .{ .offset = 0x10000000, .length = 0x8000, .kind = .ram },
@@ -19139,7 +19139,7 @@ pub const STM32L471QE = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32L471QE",
-        .cpu = MicroZig.cpus.cortex_m4,
+        .cpu = MicroZig.cpus.cortex_m4f,
         .memory_regions = &.{
             .{ .offset = 0x8000000, .length = 0x40000, .kind = .flash },
             .{ .offset = 0x8040000, .length = 0x40000, .kind = .flash },
@@ -19156,7 +19156,7 @@ pub const STM32L471QG = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32L471QG",
-        .cpu = MicroZig.cpus.cortex_m4,
+        .cpu = MicroZig.cpus.cortex_m4f,
         .memory_regions = &.{
             .{ .offset = 0x8000000, .length = 0x80000, .kind = .flash },
             .{ .offset = 0x8080000, .length = 0x80000, .kind = .flash },
@@ -19173,7 +19173,7 @@ pub const STM32L471RE = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32L471RE",
-        .cpu = MicroZig.cpus.cortex_m4,
+        .cpu = MicroZig.cpus.cortex_m4f,
         .memory_regions = &.{
             .{ .offset = 0x8000000, .length = 0x40000, .kind = .flash },
             .{ .offset = 0x8040000, .length = 0x40000, .kind = .flash },
@@ -19190,7 +19190,7 @@ pub const STM32L471RG = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32L471RG",
-        .cpu = MicroZig.cpus.cortex_m4,
+        .cpu = MicroZig.cpus.cortex_m4f,
         .memory_regions = &.{
             .{ .offset = 0x8000000, .length = 0x80000, .kind = .flash },
             .{ .offset = 0x8080000, .length = 0x80000, .kind = .flash },
@@ -19207,7 +19207,7 @@ pub const STM32L471VE = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32L471VE",
-        .cpu = MicroZig.cpus.cortex_m4,
+        .cpu = MicroZig.cpus.cortex_m4f,
         .memory_regions = &.{
             .{ .offset = 0x8000000, .length = 0x40000, .kind = .flash },
             .{ .offset = 0x8040000, .length = 0x40000, .kind = .flash },
@@ -19224,7 +19224,7 @@ pub const STM32L471VG = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32L471VG",
-        .cpu = MicroZig.cpus.cortex_m4,
+        .cpu = MicroZig.cpus.cortex_m4f,
         .memory_regions = &.{
             .{ .offset = 0x8000000, .length = 0x80000, .kind = .flash },
             .{ .offset = 0x8080000, .length = 0x80000, .kind = .flash },
@@ -19241,7 +19241,7 @@ pub const STM32L471ZE = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32L471ZE",
-        .cpu = MicroZig.cpus.cortex_m4,
+        .cpu = MicroZig.cpus.cortex_m4f,
         .memory_regions = &.{
             .{ .offset = 0x8000000, .length = 0x40000, .kind = .flash },
             .{ .offset = 0x8040000, .length = 0x40000, .kind = .flash },
@@ -19258,7 +19258,7 @@ pub const STM32L471ZG = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32L471ZG",
-        .cpu = MicroZig.cpus.cortex_m4,
+        .cpu = MicroZig.cpus.cortex_m4f,
         .memory_regions = &.{
             .{ .offset = 0x8000000, .length = 0x80000, .kind = .flash },
             .{ .offset = 0x8080000, .length = 0x80000, .kind = .flash },
@@ -19275,7 +19275,7 @@ pub const STM32L475RC = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32L475RC",
-        .cpu = MicroZig.cpus.cortex_m4,
+        .cpu = MicroZig.cpus.cortex_m4f,
         .memory_regions = &.{
             .{ .offset = 0x8000000, .length = 0x20000, .kind = .flash },
             .{ .offset = 0x8020000, .length = 0x20000, .kind = .flash },
@@ -19292,7 +19292,7 @@ pub const STM32L475RE = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32L475RE",
-        .cpu = MicroZig.cpus.cortex_m4,
+        .cpu = MicroZig.cpus.cortex_m4f,
         .memory_regions = &.{
             .{ .offset = 0x8000000, .length = 0x40000, .kind = .flash },
             .{ .offset = 0x8040000, .length = 0x40000, .kind = .flash },
@@ -19309,7 +19309,7 @@ pub const STM32L475RG = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32L475RG",
-        .cpu = MicroZig.cpus.cortex_m4,
+        .cpu = MicroZig.cpus.cortex_m4f,
         .memory_regions = &.{
             .{ .offset = 0x8000000, .length = 0x80000, .kind = .flash },
             .{ .offset = 0x8080000, .length = 0x80000, .kind = .flash },
@@ -19326,7 +19326,7 @@ pub const STM32L475VC = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32L475VC",
-        .cpu = MicroZig.cpus.cortex_m4,
+        .cpu = MicroZig.cpus.cortex_m4f,
         .memory_regions = &.{
             .{ .offset = 0x8000000, .length = 0x20000, .kind = .flash },
             .{ .offset = 0x8020000, .length = 0x20000, .kind = .flash },
@@ -19343,7 +19343,7 @@ pub const STM32L475VE = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32L475VE",
-        .cpu = MicroZig.cpus.cortex_m4,
+        .cpu = MicroZig.cpus.cortex_m4f,
         .memory_regions = &.{
             .{ .offset = 0x8000000, .length = 0x40000, .kind = .flash },
             .{ .offset = 0x8040000, .length = 0x40000, .kind = .flash },
@@ -19360,7 +19360,7 @@ pub const STM32L475VG = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32L475VG",
-        .cpu = MicroZig.cpus.cortex_m4,
+        .cpu = MicroZig.cpus.cortex_m4f,
         .memory_regions = &.{
             .{ .offset = 0x8000000, .length = 0x80000, .kind = .flash },
             .{ .offset = 0x8080000, .length = 0x80000, .kind = .flash },
@@ -19377,7 +19377,7 @@ pub const STM32L476JE = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32L476JE",
-        .cpu = MicroZig.cpus.cortex_m4,
+        .cpu = MicroZig.cpus.cortex_m4f,
         .memory_regions = &.{
             .{ .offset = 0x8000000, .length = 0x40000, .kind = .flash },
             .{ .offset = 0x8040000, .length = 0x40000, .kind = .flash },
@@ -19394,7 +19394,7 @@ pub const STM32L476JG = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32L476JG",
-        .cpu = MicroZig.cpus.cortex_m4,
+        .cpu = MicroZig.cpus.cortex_m4f,
         .memory_regions = &.{
             .{ .offset = 0x8000000, .length = 0x80000, .kind = .flash },
             .{ .offset = 0x8080000, .length = 0x80000, .kind = .flash },
@@ -19411,7 +19411,7 @@ pub const STM32L476ME = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32L476ME",
-        .cpu = MicroZig.cpus.cortex_m4,
+        .cpu = MicroZig.cpus.cortex_m4f,
         .memory_regions = &.{
             .{ .offset = 0x8000000, .length = 0x40000, .kind = .flash },
             .{ .offset = 0x8040000, .length = 0x40000, .kind = .flash },
@@ -19428,7 +19428,7 @@ pub const STM32L476MG = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32L476MG",
-        .cpu = MicroZig.cpus.cortex_m4,
+        .cpu = MicroZig.cpus.cortex_m4f,
         .memory_regions = &.{
             .{ .offset = 0x8000000, .length = 0x80000, .kind = .flash },
             .{ .offset = 0x8080000, .length = 0x80000, .kind = .flash },
@@ -19445,7 +19445,7 @@ pub const STM32L476QE = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32L476QE",
-        .cpu = MicroZig.cpus.cortex_m4,
+        .cpu = MicroZig.cpus.cortex_m4f,
         .memory_regions = &.{
             .{ .offset = 0x8000000, .length = 0x40000, .kind = .flash },
             .{ .offset = 0x8040000, .length = 0x40000, .kind = .flash },
@@ -19462,7 +19462,7 @@ pub const STM32L476QG = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32L476QG",
-        .cpu = MicroZig.cpus.cortex_m4,
+        .cpu = MicroZig.cpus.cortex_m4f,
         .memory_regions = &.{
             .{ .offset = 0x8000000, .length = 0x80000, .kind = .flash },
             .{ .offset = 0x8080000, .length = 0x80000, .kind = .flash },
@@ -19479,7 +19479,7 @@ pub const STM32L476RC = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32L476RC",
-        .cpu = MicroZig.cpus.cortex_m4,
+        .cpu = MicroZig.cpus.cortex_m4f,
         .memory_regions = &.{
             .{ .offset = 0x8000000, .length = 0x20000, .kind = .flash },
             .{ .offset = 0x8020000, .length = 0x20000, .kind = .flash },
@@ -19496,7 +19496,7 @@ pub const STM32L476RE = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32L476RE",
-        .cpu = MicroZig.cpus.cortex_m4,
+        .cpu = MicroZig.cpus.cortex_m4f,
         .memory_regions = &.{
             .{ .offset = 0x8000000, .length = 0x40000, .kind = .flash },
             .{ .offset = 0x8040000, .length = 0x40000, .kind = .flash },
@@ -19513,7 +19513,7 @@ pub const STM32L476RG = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32L476RG",
-        .cpu = MicroZig.cpus.cortex_m4,
+        .cpu = MicroZig.cpus.cortex_m4f,
         .memory_regions = &.{
             .{ .offset = 0x8000000, .length = 0x80000, .kind = .flash },
             .{ .offset = 0x8080000, .length = 0x80000, .kind = .flash },
@@ -19530,7 +19530,7 @@ pub const STM32L476VC = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32L476VC",
-        .cpu = MicroZig.cpus.cortex_m4,
+        .cpu = MicroZig.cpus.cortex_m4f,
         .memory_regions = &.{
             .{ .offset = 0x8000000, .length = 0x20000, .kind = .flash },
             .{ .offset = 0x8020000, .length = 0x20000, .kind = .flash },
@@ -19547,7 +19547,7 @@ pub const STM32L476VE = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32L476VE",
-        .cpu = MicroZig.cpus.cortex_m4,
+        .cpu = MicroZig.cpus.cortex_m4f,
         .memory_regions = &.{
             .{ .offset = 0x8000000, .length = 0x40000, .kind = .flash },
             .{ .offset = 0x8040000, .length = 0x40000, .kind = .flash },
@@ -19564,7 +19564,7 @@ pub const STM32L476VG = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32L476VG",
-        .cpu = MicroZig.cpus.cortex_m4,
+        .cpu = MicroZig.cpus.cortex_m4f,
         .memory_regions = &.{
             .{ .offset = 0x8000000, .length = 0x80000, .kind = .flash },
             .{ .offset = 0x8080000, .length = 0x80000, .kind = .flash },
@@ -19581,7 +19581,7 @@ pub const STM32L476ZE = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32L476ZE",
-        .cpu = MicroZig.cpus.cortex_m4,
+        .cpu = MicroZig.cpus.cortex_m4f,
         .memory_regions = &.{
             .{ .offset = 0x8000000, .length = 0x40000, .kind = .flash },
             .{ .offset = 0x8040000, .length = 0x40000, .kind = .flash },
@@ -19598,7 +19598,7 @@ pub const STM32L476ZG = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32L476ZG",
-        .cpu = MicroZig.cpus.cortex_m4,
+        .cpu = MicroZig.cpus.cortex_m4f,
         .memory_regions = &.{
             .{ .offset = 0x8000000, .length = 0x80000, .kind = .flash },
             .{ .offset = 0x8080000, .length = 0x80000, .kind = .flash },
@@ -19615,7 +19615,7 @@ pub const STM32L486JG = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32L486JG",
-        .cpu = MicroZig.cpus.cortex_m4,
+        .cpu = MicroZig.cpus.cortex_m4f,
         .memory_regions = &.{
             .{ .offset = 0x8000000, .length = 0x80000, .kind = .flash },
             .{ .offset = 0x8080000, .length = 0x80000, .kind = .flash },
@@ -19632,7 +19632,7 @@ pub const STM32L486QG = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32L486QG",
-        .cpu = MicroZig.cpus.cortex_m4,
+        .cpu = MicroZig.cpus.cortex_m4f,
         .memory_regions = &.{
             .{ .offset = 0x8000000, .length = 0x80000, .kind = .flash },
             .{ .offset = 0x8080000, .length = 0x80000, .kind = .flash },
@@ -19649,7 +19649,7 @@ pub const STM32L486RG = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32L486RG",
-        .cpu = MicroZig.cpus.cortex_m4,
+        .cpu = MicroZig.cpus.cortex_m4f,
         .memory_regions = &.{
             .{ .offset = 0x8000000, .length = 0x80000, .kind = .flash },
             .{ .offset = 0x8080000, .length = 0x80000, .kind = .flash },
@@ -19666,7 +19666,7 @@ pub const STM32L486VG = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32L486VG",
-        .cpu = MicroZig.cpus.cortex_m4,
+        .cpu = MicroZig.cpus.cortex_m4f,
         .memory_regions = &.{
             .{ .offset = 0x8000000, .length = 0x80000, .kind = .flash },
             .{ .offset = 0x8080000, .length = 0x80000, .kind = .flash },
@@ -19683,7 +19683,7 @@ pub const STM32L486ZG = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32L486ZG",
-        .cpu = MicroZig.cpus.cortex_m4,
+        .cpu = MicroZig.cpus.cortex_m4f,
         .memory_regions = &.{
             .{ .offset = 0x8000000, .length = 0x80000, .kind = .flash },
             .{ .offset = 0x8080000, .length = 0x80000, .kind = .flash },
@@ -19700,7 +19700,7 @@ pub const STM32L496AE = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32L496AE",
-        .cpu = MicroZig.cpus.cortex_m4,
+        .cpu = MicroZig.cpus.cortex_m4f,
         .memory_regions = &.{
             .{ .offset = 0x8000000, .length = 0x40000, .kind = .flash },
             .{ .offset = 0x8040000, .length = 0x40000, .kind = .flash },
@@ -19718,7 +19718,7 @@ pub const STM32L496AG = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32L496AG",
-        .cpu = MicroZig.cpus.cortex_m4,
+        .cpu = MicroZig.cpus.cortex_m4f,
         .memory_regions = &.{
             .{ .offset = 0x8000000, .length = 0x80000, .kind = .flash },
             .{ .offset = 0x8080000, .length = 0x80000, .kind = .flash },
@@ -19736,7 +19736,7 @@ pub const STM32L496QE = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32L496QE",
-        .cpu = MicroZig.cpus.cortex_m4,
+        .cpu = MicroZig.cpus.cortex_m4f,
         .memory_regions = &.{
             .{ .offset = 0x8000000, .length = 0x40000, .kind = .flash },
             .{ .offset = 0x8040000, .length = 0x40000, .kind = .flash },
@@ -19754,7 +19754,7 @@ pub const STM32L496QG = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32L496QG",
-        .cpu = MicroZig.cpus.cortex_m4,
+        .cpu = MicroZig.cpus.cortex_m4f,
         .memory_regions = &.{
             .{ .offset = 0x8000000, .length = 0x80000, .kind = .flash },
             .{ .offset = 0x8080000, .length = 0x80000, .kind = .flash },
@@ -19772,7 +19772,7 @@ pub const STM32L496RE = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32L496RE",
-        .cpu = MicroZig.cpus.cortex_m4,
+        .cpu = MicroZig.cpus.cortex_m4f,
         .memory_regions = &.{
             .{ .offset = 0x8000000, .length = 0x40000, .kind = .flash },
             .{ .offset = 0x8040000, .length = 0x40000, .kind = .flash },
@@ -19790,7 +19790,7 @@ pub const STM32L496RG = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32L496RG",
-        .cpu = MicroZig.cpus.cortex_m4,
+        .cpu = MicroZig.cpus.cortex_m4f,
         .memory_regions = &.{
             .{ .offset = 0x8000000, .length = 0x80000, .kind = .flash },
             .{ .offset = 0x8080000, .length = 0x80000, .kind = .flash },
@@ -19808,7 +19808,7 @@ pub const STM32L496VE = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32L496VE",
-        .cpu = MicroZig.cpus.cortex_m4,
+        .cpu = MicroZig.cpus.cortex_m4f,
         .memory_regions = &.{
             .{ .offset = 0x8000000, .length = 0x40000, .kind = .flash },
             .{ .offset = 0x8040000, .length = 0x40000, .kind = .flash },
@@ -19826,7 +19826,7 @@ pub const STM32L496VG = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32L496VG",
-        .cpu = MicroZig.cpus.cortex_m4,
+        .cpu = MicroZig.cpus.cortex_m4f,
         .memory_regions = &.{
             .{ .offset = 0x8000000, .length = 0x80000, .kind = .flash },
             .{ .offset = 0x8080000, .length = 0x80000, .kind = .flash },
@@ -19844,7 +19844,7 @@ pub const STM32L496WG = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32L496WG",
-        .cpu = MicroZig.cpus.cortex_m4,
+        .cpu = MicroZig.cpus.cortex_m4f,
         .memory_regions = &.{
             .{ .offset = 0x8000000, .length = 0x80000, .kind = .flash },
             .{ .offset = 0x8080000, .length = 0x80000, .kind = .flash },
@@ -19862,7 +19862,7 @@ pub const STM32L496ZE = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32L496ZE",
-        .cpu = MicroZig.cpus.cortex_m4,
+        .cpu = MicroZig.cpus.cortex_m4f,
         .memory_regions = &.{
             .{ .offset = 0x8000000, .length = 0x40000, .kind = .flash },
             .{ .offset = 0x8040000, .length = 0x40000, .kind = .flash },
@@ -19880,7 +19880,7 @@ pub const STM32L496ZG = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32L496ZG",
-        .cpu = MicroZig.cpus.cortex_m4,
+        .cpu = MicroZig.cpus.cortex_m4f,
         .memory_regions = &.{
             .{ .offset = 0x8000000, .length = 0x80000, .kind = .flash },
             .{ .offset = 0x8080000, .length = 0x80000, .kind = .flash },
@@ -19898,7 +19898,7 @@ pub const STM32L4A6AG = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32L4A6AG",
-        .cpu = MicroZig.cpus.cortex_m4,
+        .cpu = MicroZig.cpus.cortex_m4f,
         .memory_regions = &.{
             .{ .offset = 0x8000000, .length = 0x80000, .kind = .flash },
             .{ .offset = 0x8080000, .length = 0x80000, .kind = .flash },
@@ -19916,7 +19916,7 @@ pub const STM32L4A6QG = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32L4A6QG",
-        .cpu = MicroZig.cpus.cortex_m4,
+        .cpu = MicroZig.cpus.cortex_m4f,
         .memory_regions = &.{
             .{ .offset = 0x8000000, .length = 0x80000, .kind = .flash },
             .{ .offset = 0x8080000, .length = 0x80000, .kind = .flash },
@@ -19934,7 +19934,7 @@ pub const STM32L4A6RG = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32L4A6RG",
-        .cpu = MicroZig.cpus.cortex_m4,
+        .cpu = MicroZig.cpus.cortex_m4f,
         .memory_regions = &.{
             .{ .offset = 0x8000000, .length = 0x80000, .kind = .flash },
             .{ .offset = 0x8080000, .length = 0x80000, .kind = .flash },
@@ -19952,7 +19952,7 @@ pub const STM32L4A6VG = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32L4A6VG",
-        .cpu = MicroZig.cpus.cortex_m4,
+        .cpu = MicroZig.cpus.cortex_m4f,
         .memory_regions = &.{
             .{ .offset = 0x8000000, .length = 0x80000, .kind = .flash },
             .{ .offset = 0x8080000, .length = 0x80000, .kind = .flash },
@@ -19970,7 +19970,7 @@ pub const STM32L4A6ZG = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32L4A6ZG",
-        .cpu = MicroZig.cpus.cortex_m4,
+        .cpu = MicroZig.cpus.cortex_m4f,
         .memory_regions = &.{
             .{ .offset = 0x8000000, .length = 0x80000, .kind = .flash },
             .{ .offset = 0x8080000, .length = 0x80000, .kind = .flash },
@@ -19988,7 +19988,7 @@ pub const STM32L4P5AE = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32L4P5AE",
-        .cpu = MicroZig.cpus.cortex_m4,
+        .cpu = MicroZig.cpus.cortex_m4f,
         .memory_regions = &.{
             .{ .offset = 0x8000000, .length = 0x80000, .kind = .flash },
             .{ .offset = 0x20000000, .length = 0x50000, .kind = .ram },
@@ -20003,7 +20003,7 @@ pub const STM32L4P5AG = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32L4P5AG",
-        .cpu = MicroZig.cpus.cortex_m4,
+        .cpu = MicroZig.cpus.cortex_m4f,
         .memory_regions = &.{
             .{ .offset = 0x8000000, .length = 0x100000, .kind = .flash },
             .{ .offset = 0x20000000, .length = 0x50000, .kind = .ram },
@@ -20018,7 +20018,7 @@ pub const STM32L4P5CE = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32L4P5CE",
-        .cpu = MicroZig.cpus.cortex_m4,
+        .cpu = MicroZig.cpus.cortex_m4f,
         .memory_regions = &.{
             .{ .offset = 0x8000000, .length = 0x80000, .kind = .flash },
             .{ .offset = 0x20000000, .length = 0x50000, .kind = .ram },
@@ -20033,7 +20033,7 @@ pub const STM32L4P5CG = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32L4P5CG",
-        .cpu = MicroZig.cpus.cortex_m4,
+        .cpu = MicroZig.cpus.cortex_m4f,
         .memory_regions = &.{
             .{ .offset = 0x8000000, .length = 0x100000, .kind = .flash },
             .{ .offset = 0x20000000, .length = 0x50000, .kind = .ram },
@@ -20048,7 +20048,7 @@ pub const STM32L4P5QE = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32L4P5QE",
-        .cpu = MicroZig.cpus.cortex_m4,
+        .cpu = MicroZig.cpus.cortex_m4f,
         .memory_regions = &.{
             .{ .offset = 0x8000000, .length = 0x80000, .kind = .flash },
             .{ .offset = 0x20000000, .length = 0x50000, .kind = .ram },
@@ -20063,7 +20063,7 @@ pub const STM32L4P5QG = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32L4P5QG",
-        .cpu = MicroZig.cpus.cortex_m4,
+        .cpu = MicroZig.cpus.cortex_m4f,
         .memory_regions = &.{
             .{ .offset = 0x8000000, .length = 0x100000, .kind = .flash },
             .{ .offset = 0x20000000, .length = 0x50000, .kind = .ram },
@@ -20078,7 +20078,7 @@ pub const STM32L4P5RE = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32L4P5RE",
-        .cpu = MicroZig.cpus.cortex_m4,
+        .cpu = MicroZig.cpus.cortex_m4f,
         .memory_regions = &.{
             .{ .offset = 0x8000000, .length = 0x80000, .kind = .flash },
             .{ .offset = 0x20000000, .length = 0x50000, .kind = .ram },
@@ -20093,7 +20093,7 @@ pub const STM32L4P5RG = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32L4P5RG",
-        .cpu = MicroZig.cpus.cortex_m4,
+        .cpu = MicroZig.cpus.cortex_m4f,
         .memory_regions = &.{
             .{ .offset = 0x8000000, .length = 0x100000, .kind = .flash },
             .{ .offset = 0x20000000, .length = 0x50000, .kind = .ram },
@@ -20108,7 +20108,7 @@ pub const STM32L4P5VE = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32L4P5VE",
-        .cpu = MicroZig.cpus.cortex_m4,
+        .cpu = MicroZig.cpus.cortex_m4f,
         .memory_regions = &.{
             .{ .offset = 0x8000000, .length = 0x80000, .kind = .flash },
             .{ .offset = 0x20000000, .length = 0x50000, .kind = .ram },
@@ -20123,7 +20123,7 @@ pub const STM32L4P5VG = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32L4P5VG",
-        .cpu = MicroZig.cpus.cortex_m4,
+        .cpu = MicroZig.cpus.cortex_m4f,
         .memory_regions = &.{
             .{ .offset = 0x8000000, .length = 0x100000, .kind = .flash },
             .{ .offset = 0x20000000, .length = 0x50000, .kind = .ram },
@@ -20138,7 +20138,7 @@ pub const STM32L4P5ZE = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32L4P5ZE",
-        .cpu = MicroZig.cpus.cortex_m4,
+        .cpu = MicroZig.cpus.cortex_m4f,
         .memory_regions = &.{
             .{ .offset = 0x8000000, .length = 0x80000, .kind = .flash },
             .{ .offset = 0x20000000, .length = 0x50000, .kind = .ram },
@@ -20153,7 +20153,7 @@ pub const STM32L4P5ZG = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32L4P5ZG",
-        .cpu = MicroZig.cpus.cortex_m4,
+        .cpu = MicroZig.cpus.cortex_m4f,
         .memory_regions = &.{
             .{ .offset = 0x8000000, .length = 0x100000, .kind = .flash },
             .{ .offset = 0x20000000, .length = 0x50000, .kind = .ram },
@@ -20168,7 +20168,7 @@ pub const STM32L4Q5AG = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32L4Q5AG",
-        .cpu = MicroZig.cpus.cortex_m4,
+        .cpu = MicroZig.cpus.cortex_m4f,
         .memory_regions = &.{
             .{ .offset = 0x8000000, .length = 0x100000, .kind = .flash },
             .{ .offset = 0x20000000, .length = 0x50000, .kind = .ram },
@@ -20183,7 +20183,7 @@ pub const STM32L4Q5CG = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32L4Q5CG",
-        .cpu = MicroZig.cpus.cortex_m4,
+        .cpu = MicroZig.cpus.cortex_m4f,
         .memory_regions = &.{
             .{ .offset = 0x8000000, .length = 0x100000, .kind = .flash },
             .{ .offset = 0x20000000, .length = 0x50000, .kind = .ram },
@@ -20198,7 +20198,7 @@ pub const STM32L4Q5QG = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32L4Q5QG",
-        .cpu = MicroZig.cpus.cortex_m4,
+        .cpu = MicroZig.cpus.cortex_m4f,
         .memory_regions = &.{
             .{ .offset = 0x8000000, .length = 0x100000, .kind = .flash },
             .{ .offset = 0x20000000, .length = 0x50000, .kind = .ram },
@@ -20213,7 +20213,7 @@ pub const STM32L4Q5RG = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32L4Q5RG",
-        .cpu = MicroZig.cpus.cortex_m4,
+        .cpu = MicroZig.cpus.cortex_m4f,
         .memory_regions = &.{
             .{ .offset = 0x8000000, .length = 0x100000, .kind = .flash },
             .{ .offset = 0x20000000, .length = 0x50000, .kind = .ram },
@@ -20228,7 +20228,7 @@ pub const STM32L4Q5VG = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32L4Q5VG",
-        .cpu = MicroZig.cpus.cortex_m4,
+        .cpu = MicroZig.cpus.cortex_m4f,
         .memory_regions = &.{
             .{ .offset = 0x8000000, .length = 0x100000, .kind = .flash },
             .{ .offset = 0x20000000, .length = 0x50000, .kind = .ram },
@@ -20243,7 +20243,7 @@ pub const STM32L4Q5ZG = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32L4Q5ZG",
-        .cpu = MicroZig.cpus.cortex_m4,
+        .cpu = MicroZig.cpus.cortex_m4f,
         .memory_regions = &.{
             .{ .offset = 0x8000000, .length = 0x100000, .kind = .flash },
             .{ .offset = 0x20000000, .length = 0x50000, .kind = .ram },
@@ -20258,7 +20258,7 @@ pub const STM32L4R5AG = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32L4R5AG",
-        .cpu = MicroZig.cpus.cortex_m4,
+        .cpu = MicroZig.cpus.cortex_m4f,
         .memory_regions = &.{
             .{ .offset = 0x8000000, .length = 0x100000, .kind = .flash },
             .{ .offset = 0x20000000, .length = 0xA0000, .kind = .ram },
@@ -20273,7 +20273,7 @@ pub const STM32L4R5AI = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32L4R5AI",
-        .cpu = MicroZig.cpus.cortex_m4,
+        .cpu = MicroZig.cpus.cortex_m4f,
         .memory_regions = &.{
             .{ .offset = 0x8000000, .length = 0x200000, .kind = .flash },
             .{ .offset = 0x20000000, .length = 0xA0000, .kind = .ram },
@@ -20288,7 +20288,7 @@ pub const STM32L4R5QG = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32L4R5QG",
-        .cpu = MicroZig.cpus.cortex_m4,
+        .cpu = MicroZig.cpus.cortex_m4f,
         .memory_regions = &.{
             .{ .offset = 0x8000000, .length = 0x100000, .kind = .flash },
             .{ .offset = 0x20000000, .length = 0xA0000, .kind = .ram },
@@ -20303,7 +20303,7 @@ pub const STM32L4R5QI = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32L4R5QI",
-        .cpu = MicroZig.cpus.cortex_m4,
+        .cpu = MicroZig.cpus.cortex_m4f,
         .memory_regions = &.{
             .{ .offset = 0x8000000, .length = 0x200000, .kind = .flash },
             .{ .offset = 0x20000000, .length = 0xA0000, .kind = .ram },
@@ -20318,7 +20318,7 @@ pub const STM32L4R5VG = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32L4R5VG",
-        .cpu = MicroZig.cpus.cortex_m4,
+        .cpu = MicroZig.cpus.cortex_m4f,
         .memory_regions = &.{
             .{ .offset = 0x8000000, .length = 0x100000, .kind = .flash },
             .{ .offset = 0x20000000, .length = 0xA0000, .kind = .ram },
@@ -20333,7 +20333,7 @@ pub const STM32L4R5VI = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32L4R5VI",
-        .cpu = MicroZig.cpus.cortex_m4,
+        .cpu = MicroZig.cpus.cortex_m4f,
         .memory_regions = &.{
             .{ .offset = 0x8000000, .length = 0x200000, .kind = .flash },
             .{ .offset = 0x20000000, .length = 0xA0000, .kind = .ram },
@@ -20348,7 +20348,7 @@ pub const STM32L4R5ZG = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32L4R5ZG",
-        .cpu = MicroZig.cpus.cortex_m4,
+        .cpu = MicroZig.cpus.cortex_m4f,
         .memory_regions = &.{
             .{ .offset = 0x8000000, .length = 0x100000, .kind = .flash },
             .{ .offset = 0x20000000, .length = 0xA0000, .kind = .ram },
@@ -20363,7 +20363,7 @@ pub const STM32L4R5ZI = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32L4R5ZI",
-        .cpu = MicroZig.cpus.cortex_m4,
+        .cpu = MicroZig.cpus.cortex_m4f,
         .memory_regions = &.{
             .{ .offset = 0x8000000, .length = 0x200000, .kind = .flash },
             .{ .offset = 0x20000000, .length = 0xA0000, .kind = .ram },
@@ -20378,7 +20378,7 @@ pub const STM32L4R7AI = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32L4R7AI",
-        .cpu = MicroZig.cpus.cortex_m4,
+        .cpu = MicroZig.cpus.cortex_m4f,
         .memory_regions = &.{
             .{ .offset = 0x8000000, .length = 0x200000, .kind = .flash },
             .{ .offset = 0x20000000, .length = 0xA0000, .kind = .ram },
@@ -20393,7 +20393,7 @@ pub const STM32L4R7VI = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32L4R7VI",
-        .cpu = MicroZig.cpus.cortex_m4,
+        .cpu = MicroZig.cpus.cortex_m4f,
         .memory_regions = &.{
             .{ .offset = 0x8000000, .length = 0x200000, .kind = .flash },
             .{ .offset = 0x20000000, .length = 0xA0000, .kind = .ram },
@@ -20408,7 +20408,7 @@ pub const STM32L4R7ZI = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32L4R7ZI",
-        .cpu = MicroZig.cpus.cortex_m4,
+        .cpu = MicroZig.cpus.cortex_m4f,
         .memory_regions = &.{
             .{ .offset = 0x8000000, .length = 0x200000, .kind = .flash },
             .{ .offset = 0x20000000, .length = 0xA0000, .kind = .ram },
@@ -20423,7 +20423,7 @@ pub const STM32L4R9AG = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32L4R9AG",
-        .cpu = MicroZig.cpus.cortex_m4,
+        .cpu = MicroZig.cpus.cortex_m4f,
         .memory_regions = &.{
             .{ .offset = 0x8000000, .length = 0x100000, .kind = .flash },
             .{ .offset = 0x20000000, .length = 0xA0000, .kind = .ram },
@@ -20438,7 +20438,7 @@ pub const STM32L4R9AI = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32L4R9AI",
-        .cpu = MicroZig.cpus.cortex_m4,
+        .cpu = MicroZig.cpus.cortex_m4f,
         .memory_regions = &.{
             .{ .offset = 0x8000000, .length = 0x200000, .kind = .flash },
             .{ .offset = 0x20000000, .length = 0xA0000, .kind = .ram },
@@ -20453,7 +20453,7 @@ pub const STM32L4R9VG = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32L4R9VG",
-        .cpu = MicroZig.cpus.cortex_m4,
+        .cpu = MicroZig.cpus.cortex_m4f,
         .memory_regions = &.{
             .{ .offset = 0x8000000, .length = 0x100000, .kind = .flash },
             .{ .offset = 0x20000000, .length = 0xA0000, .kind = .ram },
@@ -20468,7 +20468,7 @@ pub const STM32L4R9VI = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32L4R9VI",
-        .cpu = MicroZig.cpus.cortex_m4,
+        .cpu = MicroZig.cpus.cortex_m4f,
         .memory_regions = &.{
             .{ .offset = 0x8000000, .length = 0x200000, .kind = .flash },
             .{ .offset = 0x20000000, .length = 0xA0000, .kind = .ram },
@@ -20483,7 +20483,7 @@ pub const STM32L4R9ZG = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32L4R9ZG",
-        .cpu = MicroZig.cpus.cortex_m4,
+        .cpu = MicroZig.cpus.cortex_m4f,
         .memory_regions = &.{
             .{ .offset = 0x8000000, .length = 0x100000, .kind = .flash },
             .{ .offset = 0x20000000, .length = 0xA0000, .kind = .ram },
@@ -20498,7 +20498,7 @@ pub const STM32L4R9ZI = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32L4R9ZI",
-        .cpu = MicroZig.cpus.cortex_m4,
+        .cpu = MicroZig.cpus.cortex_m4f,
         .memory_regions = &.{
             .{ .offset = 0x8000000, .length = 0x200000, .kind = .flash },
             .{ .offset = 0x20000000, .length = 0xA0000, .kind = .ram },
@@ -20513,7 +20513,7 @@ pub const STM32L4S5AI = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32L4S5AI",
-        .cpu = MicroZig.cpus.cortex_m4,
+        .cpu = MicroZig.cpus.cortex_m4f,
         .memory_regions = &.{
             .{ .offset = 0x8000000, .length = 0x200000, .kind = .flash },
             .{ .offset = 0x20000000, .length = 0xA0000, .kind = .ram },
@@ -20528,7 +20528,7 @@ pub const STM32L4S5QI = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32L4S5QI",
-        .cpu = MicroZig.cpus.cortex_m4,
+        .cpu = MicroZig.cpus.cortex_m4f,
         .memory_regions = &.{
             .{ .offset = 0x8000000, .length = 0x200000, .kind = .flash },
             .{ .offset = 0x20000000, .length = 0xA0000, .kind = .ram },
@@ -20543,7 +20543,7 @@ pub const STM32L4S5VI = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32L4S5VI",
-        .cpu = MicroZig.cpus.cortex_m4,
+        .cpu = MicroZig.cpus.cortex_m4f,
         .memory_regions = &.{
             .{ .offset = 0x8000000, .length = 0x200000, .kind = .flash },
             .{ .offset = 0x20000000, .length = 0xA0000, .kind = .ram },
@@ -20558,7 +20558,7 @@ pub const STM32L4S5ZI = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32L4S5ZI",
-        .cpu = MicroZig.cpus.cortex_m4,
+        .cpu = MicroZig.cpus.cortex_m4f,
         .memory_regions = &.{
             .{ .offset = 0x8000000, .length = 0x200000, .kind = .flash },
             .{ .offset = 0x20000000, .length = 0xA0000, .kind = .ram },
@@ -20573,7 +20573,7 @@ pub const STM32L4S7AI = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32L4S7AI",
-        .cpu = MicroZig.cpus.cortex_m4,
+        .cpu = MicroZig.cpus.cortex_m4f,
         .memory_regions = &.{
             .{ .offset = 0x8000000, .length = 0x200000, .kind = .flash },
             .{ .offset = 0x20000000, .length = 0xA0000, .kind = .ram },
@@ -20588,7 +20588,7 @@ pub const STM32L4S7VI = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32L4S7VI",
-        .cpu = MicroZig.cpus.cortex_m4,
+        .cpu = MicroZig.cpus.cortex_m4f,
         .memory_regions = &.{
             .{ .offset = 0x8000000, .length = 0x200000, .kind = .flash },
             .{ .offset = 0x20000000, .length = 0xA0000, .kind = .ram },
@@ -20603,7 +20603,7 @@ pub const STM32L4S7ZI = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32L4S7ZI",
-        .cpu = MicroZig.cpus.cortex_m4,
+        .cpu = MicroZig.cpus.cortex_m4f,
         .memory_regions = &.{
             .{ .offset = 0x8000000, .length = 0x200000, .kind = .flash },
             .{ .offset = 0x20000000, .length = 0xA0000, .kind = .ram },
@@ -20618,7 +20618,7 @@ pub const STM32L4S9AI = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32L4S9AI",
-        .cpu = MicroZig.cpus.cortex_m4,
+        .cpu = MicroZig.cpus.cortex_m4f,
         .memory_regions = &.{
             .{ .offset = 0x8000000, .length = 0x200000, .kind = .flash },
             .{ .offset = 0x20000000, .length = 0xA0000, .kind = .ram },
@@ -20633,7 +20633,7 @@ pub const STM32L4S9VI = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32L4S9VI",
-        .cpu = MicroZig.cpus.cortex_m4,
+        .cpu = MicroZig.cpus.cortex_m4f,
         .memory_regions = &.{
             .{ .offset = 0x8000000, .length = 0x200000, .kind = .flash },
             .{ .offset = 0x20000000, .length = 0xA0000, .kind = .ram },
@@ -20648,7 +20648,7 @@ pub const STM32L4S9ZI = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32L4S9ZI",
-        .cpu = MicroZig.cpus.cortex_m4,
+        .cpu = MicroZig.cpus.cortex_m4f,
         .memory_regions = &.{
             .{ .offset = 0x8000000, .length = 0x200000, .kind = .flash },
             .{ .offset = 0x20000000, .length = 0xA0000, .kind = .ram },
@@ -20663,7 +20663,7 @@ pub const STM32L552CC = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32L552CC",
-        .cpu = MicroZig.cpus.cortex_m33,
+        .cpu = MicroZig.cpus.cortex_m33f,
         .memory_regions = &.{
             .{ .offset = 0x8000000, .length = 0x40000, .kind = .flash },
             .{ .offset = 0x20000000, .length = 0x40000, .kind = .ram },
@@ -20678,7 +20678,7 @@ pub const STM32L552CE = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32L552CE",
-        .cpu = MicroZig.cpus.cortex_m33,
+        .cpu = MicroZig.cpus.cortex_m33f,
         .memory_regions = &.{
             .{ .offset = 0x8000000, .length = 0x80000, .kind = .flash },
             .{ .offset = 0x20000000, .length = 0x40000, .kind = .ram },
@@ -20693,7 +20693,7 @@ pub const STM32L552ME = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32L552ME",
-        .cpu = MicroZig.cpus.cortex_m33,
+        .cpu = MicroZig.cpus.cortex_m33f,
         .memory_regions = &.{
             .{ .offset = 0x8000000, .length = 0x80000, .kind = .flash },
             .{ .offset = 0x20000000, .length = 0x40000, .kind = .ram },
@@ -20708,7 +20708,7 @@ pub const STM32L552QC = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32L552QC",
-        .cpu = MicroZig.cpus.cortex_m33,
+        .cpu = MicroZig.cpus.cortex_m33f,
         .memory_regions = &.{
             .{ .offset = 0x8000000, .length = 0x40000, .kind = .flash },
             .{ .offset = 0x20000000, .length = 0x40000, .kind = .ram },
@@ -20723,7 +20723,7 @@ pub const STM32L552QE = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32L552QE",
-        .cpu = MicroZig.cpus.cortex_m33,
+        .cpu = MicroZig.cpus.cortex_m33f,
         .memory_regions = &.{
             .{ .offset = 0x8000000, .length = 0x80000, .kind = .flash },
             .{ .offset = 0x20000000, .length = 0x40000, .kind = .ram },
@@ -20738,7 +20738,7 @@ pub const STM32L552RC = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32L552RC",
-        .cpu = MicroZig.cpus.cortex_m33,
+        .cpu = MicroZig.cpus.cortex_m33f,
         .memory_regions = &.{
             .{ .offset = 0x8000000, .length = 0x40000, .kind = .flash },
             .{ .offset = 0x20000000, .length = 0x40000, .kind = .ram },
@@ -20753,7 +20753,7 @@ pub const STM32L552RE = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32L552RE",
-        .cpu = MicroZig.cpus.cortex_m33,
+        .cpu = MicroZig.cpus.cortex_m33f,
         .memory_regions = &.{
             .{ .offset = 0x8000000, .length = 0x80000, .kind = .flash },
             .{ .offset = 0x20000000, .length = 0x40000, .kind = .ram },
@@ -20768,7 +20768,7 @@ pub const STM32L552VC = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32L552VC",
-        .cpu = MicroZig.cpus.cortex_m33,
+        .cpu = MicroZig.cpus.cortex_m33f,
         .memory_regions = &.{
             .{ .offset = 0x8000000, .length = 0x40000, .kind = .flash },
             .{ .offset = 0x20000000, .length = 0x40000, .kind = .ram },
@@ -20783,7 +20783,7 @@ pub const STM32L552VE = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32L552VE",
-        .cpu = MicroZig.cpus.cortex_m33,
+        .cpu = MicroZig.cpus.cortex_m33f,
         .memory_regions = &.{
             .{ .offset = 0x8000000, .length = 0x80000, .kind = .flash },
             .{ .offset = 0x20000000, .length = 0x40000, .kind = .ram },
@@ -20798,7 +20798,7 @@ pub const STM32L552ZC = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32L552ZC",
-        .cpu = MicroZig.cpus.cortex_m33,
+        .cpu = MicroZig.cpus.cortex_m33f,
         .memory_regions = &.{
             .{ .offset = 0x8000000, .length = 0x40000, .kind = .flash },
             .{ .offset = 0x20000000, .length = 0x40000, .kind = .ram },
@@ -20813,7 +20813,7 @@ pub const STM32L552ZE = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32L552ZE",
-        .cpu = MicroZig.cpus.cortex_m33,
+        .cpu = MicroZig.cpus.cortex_m33f,
         .memory_regions = &.{
             .{ .offset = 0x8000000, .length = 0x80000, .kind = .flash },
             .{ .offset = 0x20000000, .length = 0x40000, .kind = .ram },
@@ -20828,7 +20828,7 @@ pub const STM32L562CE = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32L562CE",
-        .cpu = MicroZig.cpus.cortex_m33,
+        .cpu = MicroZig.cpus.cortex_m33f,
         .memory_regions = &.{
             .{ .offset = 0x8000000, .length = 0x80000, .kind = .flash },
             .{ .offset = 0x20000000, .length = 0x40000, .kind = .ram },
@@ -20843,7 +20843,7 @@ pub const STM32L562ME = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32L562ME",
-        .cpu = MicroZig.cpus.cortex_m33,
+        .cpu = MicroZig.cpus.cortex_m33f,
         .memory_regions = &.{
             .{ .offset = 0x8000000, .length = 0x80000, .kind = .flash },
             .{ .offset = 0x20000000, .length = 0x40000, .kind = .ram },
@@ -20858,7 +20858,7 @@ pub const STM32L562QE = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32L562QE",
-        .cpu = MicroZig.cpus.cortex_m33,
+        .cpu = MicroZig.cpus.cortex_m33f,
         .memory_regions = &.{
             .{ .offset = 0x8000000, .length = 0x80000, .kind = .flash },
             .{ .offset = 0x20000000, .length = 0x40000, .kind = .ram },
@@ -20873,7 +20873,7 @@ pub const STM32L562RE = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32L562RE",
-        .cpu = MicroZig.cpus.cortex_m33,
+        .cpu = MicroZig.cpus.cortex_m33f,
         .memory_regions = &.{
             .{ .offset = 0x8000000, .length = 0x80000, .kind = .flash },
             .{ .offset = 0x20000000, .length = 0x40000, .kind = .ram },
@@ -20888,7 +20888,7 @@ pub const STM32L562VE = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32L562VE",
-        .cpu = MicroZig.cpus.cortex_m33,
+        .cpu = MicroZig.cpus.cortex_m33f,
         .memory_regions = &.{
             .{ .offset = 0x8000000, .length = 0x80000, .kind = .flash },
             .{ .offset = 0x20000000, .length = 0x40000, .kind = .ram },
@@ -20903,7 +20903,7 @@ pub const STM32L562ZE = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32L562ZE",
-        .cpu = MicroZig.cpus.cortex_m33,
+        .cpu = MicroZig.cpus.cortex_m33f,
         .memory_regions = &.{
             .{ .offset = 0x8000000, .length = 0x80000, .kind = .flash },
             .{ .offset = 0x20000000, .length = 0x40000, .kind = .ram },
@@ -21398,7 +21398,7 @@ pub const STM32U535CB = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32U535CB",
-        .cpu = MicroZig.cpus.cortex_m33,
+        .cpu = MicroZig.cpus.cortex_m33f,
         .memory_regions = &.{
             .{ .offset = 0x8000000, .length = 0x10000, .kind = .flash },
             .{ .offset = 0x8010000, .length = 0x10000, .kind = .flash },
@@ -21415,7 +21415,7 @@ pub const STM32U535CC = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32U535CC",
-        .cpu = MicroZig.cpus.cortex_m33,
+        .cpu = MicroZig.cpus.cortex_m33f,
         .memory_regions = &.{
             .{ .offset = 0x8000000, .length = 0x20000, .kind = .flash },
             .{ .offset = 0x8020000, .length = 0x20000, .kind = .flash },
@@ -21432,7 +21432,7 @@ pub const STM32U535CE = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32U535CE",
-        .cpu = MicroZig.cpus.cortex_m33,
+        .cpu = MicroZig.cpus.cortex_m33f,
         .memory_regions = &.{
             .{ .offset = 0x8000000, .length = 0x40000, .kind = .flash },
             .{ .offset = 0x8040000, .length = 0x40000, .kind = .flash },
@@ -21449,7 +21449,7 @@ pub const STM32U535JE = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32U535JE",
-        .cpu = MicroZig.cpus.cortex_m33,
+        .cpu = MicroZig.cpus.cortex_m33f,
         .memory_regions = &.{
             .{ .offset = 0x8000000, .length = 0x40000, .kind = .flash },
             .{ .offset = 0x8040000, .length = 0x40000, .kind = .flash },
@@ -21466,7 +21466,7 @@ pub const STM32U535NC = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32U535NC",
-        .cpu = MicroZig.cpus.cortex_m33,
+        .cpu = MicroZig.cpus.cortex_m33f,
         .memory_regions = &.{
             .{ .offset = 0x8000000, .length = 0x20000, .kind = .flash },
             .{ .offset = 0x8020000, .length = 0x20000, .kind = .flash },
@@ -21483,7 +21483,7 @@ pub const STM32U535NE = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32U535NE",
-        .cpu = MicroZig.cpus.cortex_m33,
+        .cpu = MicroZig.cpus.cortex_m33f,
         .memory_regions = &.{
             .{ .offset = 0x8000000, .length = 0x40000, .kind = .flash },
             .{ .offset = 0x8040000, .length = 0x40000, .kind = .flash },
@@ -21500,7 +21500,7 @@ pub const STM32U535RB = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32U535RB",
-        .cpu = MicroZig.cpus.cortex_m33,
+        .cpu = MicroZig.cpus.cortex_m33f,
         .memory_regions = &.{
             .{ .offset = 0x8000000, .length = 0x10000, .kind = .flash },
             .{ .offset = 0x8010000, .length = 0x10000, .kind = .flash },
@@ -21517,7 +21517,7 @@ pub const STM32U535RC = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32U535RC",
-        .cpu = MicroZig.cpus.cortex_m33,
+        .cpu = MicroZig.cpus.cortex_m33f,
         .memory_regions = &.{
             .{ .offset = 0x8000000, .length = 0x20000, .kind = .flash },
             .{ .offset = 0x8020000, .length = 0x20000, .kind = .flash },
@@ -21534,7 +21534,7 @@ pub const STM32U535RE = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32U535RE",
-        .cpu = MicroZig.cpus.cortex_m33,
+        .cpu = MicroZig.cpus.cortex_m33f,
         .memory_regions = &.{
             .{ .offset = 0x8000000, .length = 0x40000, .kind = .flash },
             .{ .offset = 0x8040000, .length = 0x40000, .kind = .flash },
@@ -21551,7 +21551,7 @@ pub const STM32U535VC = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32U535VC",
-        .cpu = MicroZig.cpus.cortex_m33,
+        .cpu = MicroZig.cpus.cortex_m33f,
         .memory_regions = &.{
             .{ .offset = 0x8000000, .length = 0x20000, .kind = .flash },
             .{ .offset = 0x8020000, .length = 0x20000, .kind = .flash },
@@ -21568,7 +21568,7 @@ pub const STM32U535VE = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32U535VE",
-        .cpu = MicroZig.cpus.cortex_m33,
+        .cpu = MicroZig.cpus.cortex_m33f,
         .memory_regions = &.{
             .{ .offset = 0x8000000, .length = 0x40000, .kind = .flash },
             .{ .offset = 0x8040000, .length = 0x40000, .kind = .flash },
@@ -21585,7 +21585,7 @@ pub const STM32U545CE = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32U545CE",
-        .cpu = MicroZig.cpus.cortex_m33,
+        .cpu = MicroZig.cpus.cortex_m33f,
         .memory_regions = &.{
             .{ .offset = 0x8000000, .length = 0x40000, .kind = .flash },
             .{ .offset = 0x8040000, .length = 0x40000, .kind = .flash },
@@ -21602,7 +21602,7 @@ pub const STM32U545JE = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32U545JE",
-        .cpu = MicroZig.cpus.cortex_m33,
+        .cpu = MicroZig.cpus.cortex_m33f,
         .memory_regions = &.{
             .{ .offset = 0x8000000, .length = 0x40000, .kind = .flash },
             .{ .offset = 0x8040000, .length = 0x40000, .kind = .flash },
@@ -21619,7 +21619,7 @@ pub const STM32U545NE = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32U545NE",
-        .cpu = MicroZig.cpus.cortex_m33,
+        .cpu = MicroZig.cpus.cortex_m33f,
         .memory_regions = &.{
             .{ .offset = 0x8000000, .length = 0x40000, .kind = .flash },
             .{ .offset = 0x8040000, .length = 0x40000, .kind = .flash },
@@ -21636,7 +21636,7 @@ pub const STM32U545RE = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32U545RE",
-        .cpu = MicroZig.cpus.cortex_m33,
+        .cpu = MicroZig.cpus.cortex_m33f,
         .memory_regions = &.{
             .{ .offset = 0x8000000, .length = 0x40000, .kind = .flash },
             .{ .offset = 0x8040000, .length = 0x40000, .kind = .flash },
@@ -21653,7 +21653,7 @@ pub const STM32U545VE = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32U545VE",
-        .cpu = MicroZig.cpus.cortex_m33,
+        .cpu = MicroZig.cpus.cortex_m33f,
         .memory_regions = &.{
             .{ .offset = 0x8000000, .length = 0x40000, .kind = .flash },
             .{ .offset = 0x8040000, .length = 0x40000, .kind = .flash },
@@ -21670,7 +21670,7 @@ pub const STM32U575AG = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32U575AG",
-        .cpu = MicroZig.cpus.cortex_m33,
+        .cpu = MicroZig.cpus.cortex_m33f,
         .memory_regions = &.{
             .{ .offset = 0x8000000, .length = 0x80000, .kind = .flash },
             .{ .offset = 0x8080000, .length = 0x80000, .kind = .flash },
@@ -21688,7 +21688,7 @@ pub const STM32U575AI = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32U575AI",
-        .cpu = MicroZig.cpus.cortex_m33,
+        .cpu = MicroZig.cpus.cortex_m33f,
         .memory_regions = &.{
             .{ .offset = 0x8000000, .length = 0x100000, .kind = .flash },
             .{ .offset = 0x8100000, .length = 0x100000, .kind = .flash },
@@ -21706,7 +21706,7 @@ pub const STM32U575CG = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32U575CG",
-        .cpu = MicroZig.cpus.cortex_m33,
+        .cpu = MicroZig.cpus.cortex_m33f,
         .memory_regions = &.{
             .{ .offset = 0x8000000, .length = 0x80000, .kind = .flash },
             .{ .offset = 0x8080000, .length = 0x80000, .kind = .flash },
@@ -21724,7 +21724,7 @@ pub const STM32U575CI = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32U575CI",
-        .cpu = MicroZig.cpus.cortex_m33,
+        .cpu = MicroZig.cpus.cortex_m33f,
         .memory_regions = &.{
             .{ .offset = 0x8000000, .length = 0x100000, .kind = .flash },
             .{ .offset = 0x8100000, .length = 0x100000, .kind = .flash },
@@ -21742,7 +21742,7 @@ pub const STM32U575OG = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32U575OG",
-        .cpu = MicroZig.cpus.cortex_m33,
+        .cpu = MicroZig.cpus.cortex_m33f,
         .memory_regions = &.{
             .{ .offset = 0x8000000, .length = 0x80000, .kind = .flash },
             .{ .offset = 0x8080000, .length = 0x80000, .kind = .flash },
@@ -21760,7 +21760,7 @@ pub const STM32U575OI = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32U575OI",
-        .cpu = MicroZig.cpus.cortex_m33,
+        .cpu = MicroZig.cpus.cortex_m33f,
         .memory_regions = &.{
             .{ .offset = 0x8000000, .length = 0x100000, .kind = .flash },
             .{ .offset = 0x8100000, .length = 0x100000, .kind = .flash },
@@ -21778,7 +21778,7 @@ pub const STM32U575QG = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32U575QG",
-        .cpu = MicroZig.cpus.cortex_m33,
+        .cpu = MicroZig.cpus.cortex_m33f,
         .memory_regions = &.{
             .{ .offset = 0x8000000, .length = 0x80000, .kind = .flash },
             .{ .offset = 0x8080000, .length = 0x80000, .kind = .flash },
@@ -21796,7 +21796,7 @@ pub const STM32U575QI = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32U575QI",
-        .cpu = MicroZig.cpus.cortex_m33,
+        .cpu = MicroZig.cpus.cortex_m33f,
         .memory_regions = &.{
             .{ .offset = 0x8000000, .length = 0x100000, .kind = .flash },
             .{ .offset = 0x8100000, .length = 0x100000, .kind = .flash },
@@ -21814,7 +21814,7 @@ pub const STM32U575RG = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32U575RG",
-        .cpu = MicroZig.cpus.cortex_m33,
+        .cpu = MicroZig.cpus.cortex_m33f,
         .memory_regions = &.{
             .{ .offset = 0x8000000, .length = 0x80000, .kind = .flash },
             .{ .offset = 0x8080000, .length = 0x80000, .kind = .flash },
@@ -21832,7 +21832,7 @@ pub const STM32U575RI = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32U575RI",
-        .cpu = MicroZig.cpus.cortex_m33,
+        .cpu = MicroZig.cpus.cortex_m33f,
         .memory_regions = &.{
             .{ .offset = 0x8000000, .length = 0x100000, .kind = .flash },
             .{ .offset = 0x8100000, .length = 0x100000, .kind = .flash },
@@ -21850,7 +21850,7 @@ pub const STM32U575VG = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32U575VG",
-        .cpu = MicroZig.cpus.cortex_m33,
+        .cpu = MicroZig.cpus.cortex_m33f,
         .memory_regions = &.{
             .{ .offset = 0x8000000, .length = 0x80000, .kind = .flash },
             .{ .offset = 0x8080000, .length = 0x80000, .kind = .flash },
@@ -21868,7 +21868,7 @@ pub const STM32U575VI = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32U575VI",
-        .cpu = MicroZig.cpus.cortex_m33,
+        .cpu = MicroZig.cpus.cortex_m33f,
         .memory_regions = &.{
             .{ .offset = 0x8000000, .length = 0x100000, .kind = .flash },
             .{ .offset = 0x8100000, .length = 0x100000, .kind = .flash },
@@ -21886,7 +21886,7 @@ pub const STM32U575ZG = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32U575ZG",
-        .cpu = MicroZig.cpus.cortex_m33,
+        .cpu = MicroZig.cpus.cortex_m33f,
         .memory_regions = &.{
             .{ .offset = 0x8000000, .length = 0x80000, .kind = .flash },
             .{ .offset = 0x8080000, .length = 0x80000, .kind = .flash },
@@ -21904,7 +21904,7 @@ pub const STM32U575ZI = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32U575ZI",
-        .cpu = MicroZig.cpus.cortex_m33,
+        .cpu = MicroZig.cpus.cortex_m33f,
         .memory_regions = &.{
             .{ .offset = 0x8000000, .length = 0x100000, .kind = .flash },
             .{ .offset = 0x8100000, .length = 0x100000, .kind = .flash },
@@ -21922,7 +21922,7 @@ pub const STM32U585AI = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32U585AI",
-        .cpu = MicroZig.cpus.cortex_m33,
+        .cpu = MicroZig.cpus.cortex_m33f,
         .memory_regions = &.{
             .{ .offset = 0x8000000, .length = 0x100000, .kind = .flash },
             .{ .offset = 0x8100000, .length = 0x100000, .kind = .flash },
@@ -21940,7 +21940,7 @@ pub const STM32U585CI = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32U585CI",
-        .cpu = MicroZig.cpus.cortex_m33,
+        .cpu = MicroZig.cpus.cortex_m33f,
         .memory_regions = &.{
             .{ .offset = 0x8000000, .length = 0x100000, .kind = .flash },
             .{ .offset = 0x8100000, .length = 0x100000, .kind = .flash },
@@ -21958,7 +21958,7 @@ pub const STM32U585OI = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32U585OI",
-        .cpu = MicroZig.cpus.cortex_m33,
+        .cpu = MicroZig.cpus.cortex_m33f,
         .memory_regions = &.{
             .{ .offset = 0x8000000, .length = 0x100000, .kind = .flash },
             .{ .offset = 0x8100000, .length = 0x100000, .kind = .flash },
@@ -21976,7 +21976,7 @@ pub const STM32U585QI = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32U585QI",
-        .cpu = MicroZig.cpus.cortex_m33,
+        .cpu = MicroZig.cpus.cortex_m33f,
         .memory_regions = &.{
             .{ .offset = 0x8000000, .length = 0x100000, .kind = .flash },
             .{ .offset = 0x8100000, .length = 0x100000, .kind = .flash },
@@ -21994,7 +21994,7 @@ pub const STM32U585RI = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32U585RI",
-        .cpu = MicroZig.cpus.cortex_m33,
+        .cpu = MicroZig.cpus.cortex_m33f,
         .memory_regions = &.{
             .{ .offset = 0x8000000, .length = 0x100000, .kind = .flash },
             .{ .offset = 0x8100000, .length = 0x100000, .kind = .flash },
@@ -22012,7 +22012,7 @@ pub const STM32U585VI = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32U585VI",
-        .cpu = MicroZig.cpus.cortex_m33,
+        .cpu = MicroZig.cpus.cortex_m33f,
         .memory_regions = &.{
             .{ .offset = 0x8000000, .length = 0x100000, .kind = .flash },
             .{ .offset = 0x8100000, .length = 0x100000, .kind = .flash },
@@ -22030,7 +22030,7 @@ pub const STM32U585ZI = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32U585ZI",
-        .cpu = MicroZig.cpus.cortex_m33,
+        .cpu = MicroZig.cpus.cortex_m33f,
         .memory_regions = &.{
             .{ .offset = 0x8000000, .length = 0x100000, .kind = .flash },
             .{ .offset = 0x8100000, .length = 0x100000, .kind = .flash },
@@ -22048,7 +22048,7 @@ pub const STM32U595AI = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32U595AI",
-        .cpu = MicroZig.cpus.cortex_m33,
+        .cpu = MicroZig.cpus.cortex_m33f,
         .memory_regions = &.{
             .{ .offset = 0x8000000, .length = 0x100000, .kind = .flash },
             .{ .offset = 0x8100000, .length = 0x100000, .kind = .flash },
@@ -22067,7 +22067,7 @@ pub const STM32U595AJ = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32U595AJ",
-        .cpu = MicroZig.cpus.cortex_m33,
+        .cpu = MicroZig.cpus.cortex_m33f,
         .memory_regions = &.{
             .{ .offset = 0x8000000, .length = 0x200000, .kind = .flash },
             .{ .offset = 0x8200000, .length = 0x200000, .kind = .flash },
@@ -22086,7 +22086,7 @@ pub const STM32U595QI = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32U595QI",
-        .cpu = MicroZig.cpus.cortex_m33,
+        .cpu = MicroZig.cpus.cortex_m33f,
         .memory_regions = &.{
             .{ .offset = 0x8000000, .length = 0x100000, .kind = .flash },
             .{ .offset = 0x8100000, .length = 0x100000, .kind = .flash },
@@ -22105,7 +22105,7 @@ pub const STM32U595QJ = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32U595QJ",
-        .cpu = MicroZig.cpus.cortex_m33,
+        .cpu = MicroZig.cpus.cortex_m33f,
         .memory_regions = &.{
             .{ .offset = 0x8000000, .length = 0x200000, .kind = .flash },
             .{ .offset = 0x8200000, .length = 0x200000, .kind = .flash },
@@ -22124,7 +22124,7 @@ pub const STM32U595RI = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32U595RI",
-        .cpu = MicroZig.cpus.cortex_m33,
+        .cpu = MicroZig.cpus.cortex_m33f,
         .memory_regions = &.{
             .{ .offset = 0x8000000, .length = 0x100000, .kind = .flash },
             .{ .offset = 0x8100000, .length = 0x100000, .kind = .flash },
@@ -22143,7 +22143,7 @@ pub const STM32U595RJ = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32U595RJ",
-        .cpu = MicroZig.cpus.cortex_m33,
+        .cpu = MicroZig.cpus.cortex_m33f,
         .memory_regions = &.{
             .{ .offset = 0x8000000, .length = 0x200000, .kind = .flash },
             .{ .offset = 0x8200000, .length = 0x200000, .kind = .flash },
@@ -22162,7 +22162,7 @@ pub const STM32U595VI = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32U595VI",
-        .cpu = MicroZig.cpus.cortex_m33,
+        .cpu = MicroZig.cpus.cortex_m33f,
         .memory_regions = &.{
             .{ .offset = 0x8000000, .length = 0x100000, .kind = .flash },
             .{ .offset = 0x8100000, .length = 0x100000, .kind = .flash },
@@ -22181,7 +22181,7 @@ pub const STM32U595VJ = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32U595VJ",
-        .cpu = MicroZig.cpus.cortex_m33,
+        .cpu = MicroZig.cpus.cortex_m33f,
         .memory_regions = &.{
             .{ .offset = 0x8000000, .length = 0x200000, .kind = .flash },
             .{ .offset = 0x8200000, .length = 0x200000, .kind = .flash },
@@ -22200,7 +22200,7 @@ pub const STM32U595ZI = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32U595ZI",
-        .cpu = MicroZig.cpus.cortex_m33,
+        .cpu = MicroZig.cpus.cortex_m33f,
         .memory_regions = &.{
             .{ .offset = 0x8000000, .length = 0x100000, .kind = .flash },
             .{ .offset = 0x8100000, .length = 0x100000, .kind = .flash },
@@ -22219,7 +22219,7 @@ pub const STM32U595ZJ = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32U595ZJ",
-        .cpu = MicroZig.cpus.cortex_m33,
+        .cpu = MicroZig.cpus.cortex_m33f,
         .memory_regions = &.{
             .{ .offset = 0x8000000, .length = 0x200000, .kind = .flash },
             .{ .offset = 0x8200000, .length = 0x200000, .kind = .flash },
@@ -22238,7 +22238,7 @@ pub const STM32U599BJ = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32U599BJ",
-        .cpu = MicroZig.cpus.cortex_m33,
+        .cpu = MicroZig.cpus.cortex_m33f,
         .memory_regions = &.{
             .{ .offset = 0x8000000, .length = 0x200000, .kind = .flash },
             .{ .offset = 0x8200000, .length = 0x200000, .kind = .flash },
@@ -22257,7 +22257,7 @@ pub const STM32U599NI = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32U599NI",
-        .cpu = MicroZig.cpus.cortex_m33,
+        .cpu = MicroZig.cpus.cortex_m33f,
         .memory_regions = &.{
             .{ .offset = 0x8000000, .length = 0x100000, .kind = .flash },
             .{ .offset = 0x8100000, .length = 0x100000, .kind = .flash },
@@ -22276,7 +22276,7 @@ pub const STM32U599NJ = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32U599NJ",
-        .cpu = MicroZig.cpus.cortex_m33,
+        .cpu = MicroZig.cpus.cortex_m33f,
         .memory_regions = &.{
             .{ .offset = 0x8000000, .length = 0x200000, .kind = .flash },
             .{ .offset = 0x8200000, .length = 0x200000, .kind = .flash },
@@ -22295,7 +22295,7 @@ pub const STM32U599VI = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32U599VI",
-        .cpu = MicroZig.cpus.cortex_m33,
+        .cpu = MicroZig.cpus.cortex_m33f,
         .memory_regions = &.{
             .{ .offset = 0x8000000, .length = 0x100000, .kind = .flash },
             .{ .offset = 0x8100000, .length = 0x100000, .kind = .flash },
@@ -22314,7 +22314,7 @@ pub const STM32U599VJ = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32U599VJ",
-        .cpu = MicroZig.cpus.cortex_m33,
+        .cpu = MicroZig.cpus.cortex_m33f,
         .memory_regions = &.{
             .{ .offset = 0x8000000, .length = 0x200000, .kind = .flash },
             .{ .offset = 0x8200000, .length = 0x200000, .kind = .flash },
@@ -22333,7 +22333,7 @@ pub const STM32U599ZI = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32U599ZI",
-        .cpu = MicroZig.cpus.cortex_m33,
+        .cpu = MicroZig.cpus.cortex_m33f,
         .memory_regions = &.{
             .{ .offset = 0x8000000, .length = 0x100000, .kind = .flash },
             .{ .offset = 0x8100000, .length = 0x100000, .kind = .flash },
@@ -22352,7 +22352,7 @@ pub const STM32U599ZJ = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32U599ZJ",
-        .cpu = MicroZig.cpus.cortex_m33,
+        .cpu = MicroZig.cpus.cortex_m33f,
         .memory_regions = &.{
             .{ .offset = 0x8000000, .length = 0x200000, .kind = .flash },
             .{ .offset = 0x8200000, .length = 0x200000, .kind = .flash },
@@ -22371,7 +22371,7 @@ pub const STM32U5A5AJ = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32U5A5AJ",
-        .cpu = MicroZig.cpus.cortex_m33,
+        .cpu = MicroZig.cpus.cortex_m33f,
         .memory_regions = &.{
             .{ .offset = 0x8000000, .length = 0x200000, .kind = .flash },
             .{ .offset = 0x8200000, .length = 0x200000, .kind = .flash },
@@ -22390,7 +22390,7 @@ pub const STM32U5A5QI = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32U5A5QI",
-        .cpu = MicroZig.cpus.cortex_m33,
+        .cpu = MicroZig.cpus.cortex_m33f,
         .memory_regions = &.{
             .{ .offset = 0x8000000, .length = 0x100000, .kind = .flash },
             .{ .offset = 0x8100000, .length = 0x100000, .kind = .flash },
@@ -22409,7 +22409,7 @@ pub const STM32U5A5QJ = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32U5A5QJ",
-        .cpu = MicroZig.cpus.cortex_m33,
+        .cpu = MicroZig.cpus.cortex_m33f,
         .memory_regions = &.{
             .{ .offset = 0x8000000, .length = 0x200000, .kind = .flash },
             .{ .offset = 0x8200000, .length = 0x200000, .kind = .flash },
@@ -22428,7 +22428,7 @@ pub const STM32U5A5RJ = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32U5A5RJ",
-        .cpu = MicroZig.cpus.cortex_m33,
+        .cpu = MicroZig.cpus.cortex_m33f,
         .memory_regions = &.{
             .{ .offset = 0x8000000, .length = 0x200000, .kind = .flash },
             .{ .offset = 0x8200000, .length = 0x200000, .kind = .flash },
@@ -22447,7 +22447,7 @@ pub const STM32U5A5VJ = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32U5A5VJ",
-        .cpu = MicroZig.cpus.cortex_m33,
+        .cpu = MicroZig.cpus.cortex_m33f,
         .memory_regions = &.{
             .{ .offset = 0x8000000, .length = 0x200000, .kind = .flash },
             .{ .offset = 0x8200000, .length = 0x200000, .kind = .flash },
@@ -22466,7 +22466,7 @@ pub const STM32U5A5ZJ = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32U5A5ZJ",
-        .cpu = MicroZig.cpus.cortex_m33,
+        .cpu = MicroZig.cpus.cortex_m33f,
         .memory_regions = &.{
             .{ .offset = 0x8000000, .length = 0x200000, .kind = .flash },
             .{ .offset = 0x8200000, .length = 0x200000, .kind = .flash },
@@ -22485,7 +22485,7 @@ pub const STM32U5A9BJ = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32U5A9BJ",
-        .cpu = MicroZig.cpus.cortex_m33,
+        .cpu = MicroZig.cpus.cortex_m33f,
         .memory_regions = &.{
             .{ .offset = 0x8000000, .length = 0x200000, .kind = .flash },
             .{ .offset = 0x8200000, .length = 0x200000, .kind = .flash },
@@ -22504,7 +22504,7 @@ pub const STM32U5A9NJ = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32U5A9NJ",
-        .cpu = MicroZig.cpus.cortex_m33,
+        .cpu = MicroZig.cpus.cortex_m33f,
         .memory_regions = &.{
             .{ .offset = 0x8000000, .length = 0x200000, .kind = .flash },
             .{ .offset = 0x8200000, .length = 0x200000, .kind = .flash },
@@ -22523,7 +22523,7 @@ pub const STM32U5A9VJ = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32U5A9VJ",
-        .cpu = MicroZig.cpus.cortex_m33,
+        .cpu = MicroZig.cpus.cortex_m33f,
         .memory_regions = &.{
             .{ .offset = 0x8000000, .length = 0x200000, .kind = .flash },
             .{ .offset = 0x8200000, .length = 0x200000, .kind = .flash },
@@ -22542,7 +22542,7 @@ pub const STM32U5A9ZJ = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32U5A9ZJ",
-        .cpu = MicroZig.cpus.cortex_m33,
+        .cpu = MicroZig.cpus.cortex_m33f,
         .memory_regions = &.{
             .{ .offset = 0x8000000, .length = 0x200000, .kind = .flash },
             .{ .offset = 0x8200000, .length = 0x200000, .kind = .flash },
@@ -22561,7 +22561,7 @@ pub const STM32U5F7VI = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32U5F7VI",
-        .cpu = MicroZig.cpus.cortex_m33,
+        .cpu = MicroZig.cpus.cortex_m33f,
         .memory_regions = &.{
             .{ .offset = 0x8000000, .length = 0x100000, .kind = .flash },
             .{ .offset = 0x8200000, .length = 0x100000, .kind = .flash },
@@ -22581,7 +22581,7 @@ pub const STM32U5F7VJ = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32U5F7VJ",
-        .cpu = MicroZig.cpus.cortex_m33,
+        .cpu = MicroZig.cpus.cortex_m33f,
         .memory_regions = &.{
             .{ .offset = 0x8000000, .length = 0x200000, .kind = .flash },
             .{ .offset = 0x8200000, .length = 0x200000, .kind = .flash },
@@ -22601,7 +22601,7 @@ pub const STM32U5F9BJ = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32U5F9BJ",
-        .cpu = MicroZig.cpus.cortex_m33,
+        .cpu = MicroZig.cpus.cortex_m33f,
         .memory_regions = &.{
             .{ .offset = 0x8000000, .length = 0x200000, .kind = .flash },
             .{ .offset = 0x8200000, .length = 0x200000, .kind = .flash },
@@ -22621,7 +22621,7 @@ pub const STM32U5F9NJ = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32U5F9NJ",
-        .cpu = MicroZig.cpus.cortex_m33,
+        .cpu = MicroZig.cpus.cortex_m33f,
         .memory_regions = &.{
             .{ .offset = 0x8000000, .length = 0x200000, .kind = .flash },
             .{ .offset = 0x8200000, .length = 0x200000, .kind = .flash },
@@ -22641,7 +22641,7 @@ pub const STM32U5F9VI = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32U5F9VI",
-        .cpu = MicroZig.cpus.cortex_m33,
+        .cpu = MicroZig.cpus.cortex_m33f,
         .memory_regions = &.{
             .{ .offset = 0x8000000, .length = 0x100000, .kind = .flash },
             .{ .offset = 0x8200000, .length = 0x100000, .kind = .flash },
@@ -22661,7 +22661,7 @@ pub const STM32U5F9VJ = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32U5F9VJ",
-        .cpu = MicroZig.cpus.cortex_m33,
+        .cpu = MicroZig.cpus.cortex_m33f,
         .memory_regions = &.{
             .{ .offset = 0x8000000, .length = 0x200000, .kind = .flash },
             .{ .offset = 0x8200000, .length = 0x200000, .kind = .flash },
@@ -22681,7 +22681,7 @@ pub const STM32U5F9ZI = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32U5F9ZI",
-        .cpu = MicroZig.cpus.cortex_m33,
+        .cpu = MicroZig.cpus.cortex_m33f,
         .memory_regions = &.{
             .{ .offset = 0x8000000, .length = 0x100000, .kind = .flash },
             .{ .offset = 0x8200000, .length = 0x100000, .kind = .flash },
@@ -22701,7 +22701,7 @@ pub const STM32U5F9ZJ = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32U5F9ZJ",
-        .cpu = MicroZig.cpus.cortex_m33,
+        .cpu = MicroZig.cpus.cortex_m33f,
         .memory_regions = &.{
             .{ .offset = 0x8000000, .length = 0x200000, .kind = .flash },
             .{ .offset = 0x8200000, .length = 0x200000, .kind = .flash },
@@ -22721,7 +22721,7 @@ pub const STM32U5G7VJ = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32U5G7VJ",
-        .cpu = MicroZig.cpus.cortex_m33,
+        .cpu = MicroZig.cpus.cortex_m33f,
         .memory_regions = &.{
             .{ .offset = 0x8000000, .length = 0x200000, .kind = .flash },
             .{ .offset = 0x8200000, .length = 0x200000, .kind = .flash },
@@ -22741,7 +22741,7 @@ pub const STM32U5G9BJ = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32U5G9BJ",
-        .cpu = MicroZig.cpus.cortex_m33,
+        .cpu = MicroZig.cpus.cortex_m33f,
         .memory_regions = &.{
             .{ .offset = 0x8000000, .length = 0x200000, .kind = .flash },
             .{ .offset = 0x8200000, .length = 0x200000, .kind = .flash },
@@ -22761,7 +22761,7 @@ pub const STM32U5G9NJ = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32U5G9NJ",
-        .cpu = MicroZig.cpus.cortex_m33,
+        .cpu = MicroZig.cpus.cortex_m33f,
         .memory_regions = &.{
             .{ .offset = 0x8000000, .length = 0x200000, .kind = .flash },
             .{ .offset = 0x8200000, .length = 0x200000, .kind = .flash },
@@ -22781,7 +22781,7 @@ pub const STM32U5G9VJ = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32U5G9VJ",
-        .cpu = MicroZig.cpus.cortex_m33,
+        .cpu = MicroZig.cpus.cortex_m33f,
         .memory_regions = &.{
             .{ .offset = 0x8000000, .length = 0x200000, .kind = .flash },
             .{ .offset = 0x8200000, .length = 0x200000, .kind = .flash },
@@ -22801,7 +22801,7 @@ pub const STM32U5G9ZJ = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32U5G9ZJ",
-        .cpu = MicroZig.cpus.cortex_m33,
+        .cpu = MicroZig.cpus.cortex_m33f,
         .memory_regions = &.{
             .{ .offset = 0x8000000, .length = 0x200000, .kind = .flash },
             .{ .offset = 0x8200000, .length = 0x200000, .kind = .flash },
@@ -22821,7 +22821,7 @@ pub const STM32WB10CC = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32WB10CC",
-        .cpu = MicroZig.cpus.cortex_m4,
+        .cpu = MicroZig.cpus.cortex_m4f,
         .memory_regions = &.{
             .{ .offset = 0x8000000, .length = 0x50000, .kind = .flash },
             .{ .offset = 0x10000000, .length = 0x8000, .kind = .ram },
@@ -22840,7 +22840,7 @@ pub const STM32WB15CC = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32WB15CC",
-        .cpu = MicroZig.cpus.cortex_m4,
+        .cpu = MicroZig.cpus.cortex_m4f,
         .memory_regions = &.{
             .{ .offset = 0x8000000, .length = 0x50000, .kind = .flash },
             .{ .offset = 0x10000000, .length = 0x8000, .kind = .ram },
@@ -22859,7 +22859,7 @@ pub const STM32WB30CE = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32WB30CE",
-        .cpu = MicroZig.cpus.cortex_m4,
+        .cpu = MicroZig.cpus.cortex_m4f,
         .memory_regions = &.{
             .{ .offset = 0x8000000, .length = 0x80000, .kind = .flash },
             .{ .offset = 0x10000000, .length = 0x8000, .kind = .ram },
@@ -22878,7 +22878,7 @@ pub const STM32WB35CC = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32WB35CC",
-        .cpu = MicroZig.cpus.cortex_m4,
+        .cpu = MicroZig.cpus.cortex_m4f,
         .memory_regions = &.{
             .{ .offset = 0x8000000, .length = 0x40000, .kind = .flash },
             .{ .offset = 0x10000000, .length = 0x8000, .kind = .ram },
@@ -22897,7 +22897,7 @@ pub const STM32WB35CE = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32WB35CE",
-        .cpu = MicroZig.cpus.cortex_m4,
+        .cpu = MicroZig.cpus.cortex_m4f,
         .memory_regions = &.{
             .{ .offset = 0x8000000, .length = 0x80000, .kind = .flash },
             .{ .offset = 0x10000000, .length = 0x8000, .kind = .ram },
@@ -22916,7 +22916,7 @@ pub const STM32WB50CG = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32WB50CG",
-        .cpu = MicroZig.cpus.cortex_m4,
+        .cpu = MicroZig.cpus.cortex_m4f,
         .memory_regions = &.{
             .{ .offset = 0x8000000, .length = 0x100000, .kind = .flash },
             .{ .offset = 0x10000000, .length = 0x8000, .kind = .ram },
@@ -22935,7 +22935,7 @@ pub const STM32WB55CC = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32WB55CC",
-        .cpu = MicroZig.cpus.cortex_m4,
+        .cpu = MicroZig.cpus.cortex_m4f,
         .memory_regions = &.{
             .{ .offset = 0x8000000, .length = 0x40000, .kind = .flash },
             .{ .offset = 0x10000000, .length = 0x8000, .kind = .ram },
@@ -22954,7 +22954,7 @@ pub const STM32WB55CE = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32WB55CE",
-        .cpu = MicroZig.cpus.cortex_m4,
+        .cpu = MicroZig.cpus.cortex_m4f,
         .memory_regions = &.{
             .{ .offset = 0x8000000, .length = 0x80000, .kind = .flash },
             .{ .offset = 0x10000000, .length = 0x8000, .kind = .ram },
@@ -22973,7 +22973,7 @@ pub const STM32WB55CG = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32WB55CG",
-        .cpu = MicroZig.cpus.cortex_m4,
+        .cpu = MicroZig.cpus.cortex_m4f,
         .memory_regions = &.{
             .{ .offset = 0x8000000, .length = 0x100000, .kind = .flash },
             .{ .offset = 0x10000000, .length = 0x8000, .kind = .ram },
@@ -22992,7 +22992,7 @@ pub const STM32WB55RC = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32WB55RC",
-        .cpu = MicroZig.cpus.cortex_m4,
+        .cpu = MicroZig.cpus.cortex_m4f,
         .memory_regions = &.{
             .{ .offset = 0x8000000, .length = 0x40000, .kind = .flash },
             .{ .offset = 0x10000000, .length = 0x8000, .kind = .ram },
@@ -23011,7 +23011,7 @@ pub const STM32WB55RE = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32WB55RE",
-        .cpu = MicroZig.cpus.cortex_m4,
+        .cpu = MicroZig.cpus.cortex_m4f,
         .memory_regions = &.{
             .{ .offset = 0x8000000, .length = 0x80000, .kind = .flash },
             .{ .offset = 0x10000000, .length = 0x8000, .kind = .ram },
@@ -23030,7 +23030,7 @@ pub const STM32WB55RG = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32WB55RG",
-        .cpu = MicroZig.cpus.cortex_m4,
+        .cpu = MicroZig.cpus.cortex_m4f,
         .memory_regions = &.{
             .{ .offset = 0x8000000, .length = 0x100000, .kind = .flash },
             .{ .offset = 0x10000000, .length = 0x8000, .kind = .ram },
@@ -23049,7 +23049,7 @@ pub const STM32WB55VC = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32WB55VC",
-        .cpu = MicroZig.cpus.cortex_m4,
+        .cpu = MicroZig.cpus.cortex_m4f,
         .memory_regions = &.{
             .{ .offset = 0x8000000, .length = 0x40000, .kind = .flash },
             .{ .offset = 0x10000000, .length = 0x8000, .kind = .ram },
@@ -23068,7 +23068,7 @@ pub const STM32WB55VE = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32WB55VE",
-        .cpu = MicroZig.cpus.cortex_m4,
+        .cpu = MicroZig.cpus.cortex_m4f,
         .memory_regions = &.{
             .{ .offset = 0x8000000, .length = 0x80000, .kind = .flash },
             .{ .offset = 0x10000000, .length = 0x8000, .kind = .ram },
@@ -23087,7 +23087,7 @@ pub const STM32WB55VG = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32WB55VG",
-        .cpu = MicroZig.cpus.cortex_m4,
+        .cpu = MicroZig.cpus.cortex_m4f,
         .memory_regions = &.{
             .{ .offset = 0x8000000, .length = 0x100000, .kind = .flash },
             .{ .offset = 0x10000000, .length = 0x8000, .kind = .ram },
@@ -23106,7 +23106,7 @@ pub const STM32WB55VY = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32WB55VY",
-        .cpu = MicroZig.cpus.cortex_m4,
+        .cpu = MicroZig.cpus.cortex_m4f,
         .memory_regions = &.{
             .{ .offset = 0x8000000, .length = 0xA0000, .kind = .flash },
             .{ .offset = 0x10000000, .length = 0x8000, .kind = .ram },
@@ -23125,7 +23125,7 @@ pub const STM32WBA50KE = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32WBA50KE",
-        .cpu = MicroZig.cpus.cortex_m33,
+        .cpu = MicroZig.cpus.cortex_m33f,
         .memory_regions = &.{
             .{ .offset = 0x8000000, .length = 0x80000, .kind = .flash },
             .{ .offset = 0x20000000, .length = 0x18000, .kind = .ram },
@@ -23140,7 +23140,7 @@ pub const STM32WBA50KG = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32WBA50KG",
-        .cpu = MicroZig.cpus.cortex_m33,
+        .cpu = MicroZig.cpus.cortex_m33f,
         .memory_regions = &.{
             .{ .offset = 0x8000000, .length = 0x100000, .kind = .flash },
             .{ .offset = 0x20000000, .length = 0x20000, .kind = .ram },
@@ -23155,7 +23155,7 @@ pub const STM32WBA52CE = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32WBA52CE",
-        .cpu = MicroZig.cpus.cortex_m33,
+        .cpu = MicroZig.cpus.cortex_m33f,
         .memory_regions = &.{
             .{ .offset = 0x8000000, .length = 0x80000, .kind = .flash },
             .{ .offset = 0x20000000, .length = 0x18000, .kind = .ram },
@@ -23170,7 +23170,7 @@ pub const STM32WBA52CG = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32WBA52CG",
-        .cpu = MicroZig.cpus.cortex_m33,
+        .cpu = MicroZig.cpus.cortex_m33f,
         .memory_regions = &.{
             .{ .offset = 0x8000000, .length = 0x100000, .kind = .flash },
             .{ .offset = 0x20000000, .length = 0x20000, .kind = .ram },
@@ -23185,7 +23185,7 @@ pub const STM32WBA52KE = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32WBA52KE",
-        .cpu = MicroZig.cpus.cortex_m33,
+        .cpu = MicroZig.cpus.cortex_m33f,
         .memory_regions = &.{
             .{ .offset = 0x8000000, .length = 0x80000, .kind = .flash },
             .{ .offset = 0x20000000, .length = 0x18000, .kind = .ram },
@@ -23200,7 +23200,7 @@ pub const STM32WBA52KG = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32WBA52KG",
-        .cpu = MicroZig.cpus.cortex_m33,
+        .cpu = MicroZig.cpus.cortex_m33f,
         .memory_regions = &.{
             .{ .offset = 0x8000000, .length = 0x100000, .kind = .flash },
             .{ .offset = 0x20000000, .length = 0x20000, .kind = .ram },
@@ -23215,7 +23215,7 @@ pub const STM32WBA54CE = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32WBA54CE",
-        .cpu = MicroZig.cpus.cortex_m33,
+        .cpu = MicroZig.cpus.cortex_m33f,
         .memory_regions = &.{
             .{ .offset = 0x8000000, .length = 0x80000, .kind = .flash },
             .{ .offset = 0x20000000, .length = 0x18000, .kind = .ram },
@@ -23230,7 +23230,7 @@ pub const STM32WBA54CG = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32WBA54CG",
-        .cpu = MicroZig.cpus.cortex_m33,
+        .cpu = MicroZig.cpus.cortex_m33f,
         .memory_regions = &.{
             .{ .offset = 0x8000000, .length = 0x100000, .kind = .flash },
             .{ .offset = 0x20000000, .length = 0x20000, .kind = .ram },
@@ -23245,7 +23245,7 @@ pub const STM32WBA54KE = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32WBA54KE",
-        .cpu = MicroZig.cpus.cortex_m33,
+        .cpu = MicroZig.cpus.cortex_m33f,
         .memory_regions = &.{
             .{ .offset = 0x8000000, .length = 0x80000, .kind = .flash },
             .{ .offset = 0x20000000, .length = 0x18000, .kind = .ram },
@@ -23260,7 +23260,7 @@ pub const STM32WBA54KG = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32WBA54KG",
-        .cpu = MicroZig.cpus.cortex_m33,
+        .cpu = MicroZig.cpus.cortex_m33f,
         .memory_regions = &.{
             .{ .offset = 0x8000000, .length = 0x100000, .kind = .flash },
             .{ .offset = 0x20000000, .length = 0x20000, .kind = .ram },
@@ -23275,7 +23275,7 @@ pub const STM32WBA55CE = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32WBA55CE",
-        .cpu = MicroZig.cpus.cortex_m33,
+        .cpu = MicroZig.cpus.cortex_m33f,
         .memory_regions = &.{
             .{ .offset = 0x8000000, .length = 0x80000, .kind = .flash },
             .{ .offset = 0x20000000, .length = 0x18000, .kind = .ram },
@@ -23290,7 +23290,7 @@ pub const STM32WBA55CG = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32WBA55CG",
-        .cpu = MicroZig.cpus.cortex_m33,
+        .cpu = MicroZig.cpus.cortex_m33f,
         .memory_regions = &.{
             .{ .offset = 0x8000000, .length = 0x100000, .kind = .flash },
             .{ .offset = 0x20000000, .length = 0x20000, .kind = .ram },
@@ -23305,7 +23305,7 @@ pub const STM32WBA55HE = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32WBA55HE",
-        .cpu = MicroZig.cpus.cortex_m33,
+        .cpu = MicroZig.cpus.cortex_m33f,
         .memory_regions = &.{
             .{ .offset = 0x8000000, .length = 0x80000, .kind = .flash },
             .{ .offset = 0x20000000, .length = 0x18000, .kind = .ram },
@@ -23320,7 +23320,7 @@ pub const STM32WBA55HG = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32WBA55HG",
-        .cpu = MicroZig.cpus.cortex_m33,
+        .cpu = MicroZig.cpus.cortex_m33f,
         .memory_regions = &.{
             .{ .offset = 0x8000000, .length = 0x100000, .kind = .flash },
             .{ .offset = 0x20000000, .length = 0x20000, .kind = .ram },
@@ -23335,7 +23335,7 @@ pub const STM32WBA55UE = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32WBA55UE",
-        .cpu = MicroZig.cpus.cortex_m33,
+        .cpu = MicroZig.cpus.cortex_m33f,
         .memory_regions = &.{
             .{ .offset = 0x8000000, .length = 0x80000, .kind = .flash },
             .{ .offset = 0x20000000, .length = 0x18000, .kind = .ram },
@@ -23350,7 +23350,7 @@ pub const STM32WBA55UG = MicroZig.Target{
     .preferred_format = .elf,
     .chip = .{
         .name = "STM32WBA55UG",
-        .cpu = MicroZig.cpus.cortex_m33,
+        .cpu = MicroZig.cpus.cortex_m33f,
         .memory_regions = &.{
             .{ .offset = 0x8000000, .length = 0x100000, .kind = .flash },
             .{ .offset = 0x20000000, .length = 0x20000, .kind = .ram },


### PR DESCRIPTION
This PR adds some logic to use the floating point version of a target if the core has an interrupt labeled "FPU". It also adds a target with the FPU features set and hard float abi for the M33 and M7 cores, and for the non-f M7 it sets the soft float abi.

Also makes the register defs path public in chips.zig so a user can specify their own target but still use the generated registers if they need to for whatever reason.

Addresses https://github.com/ZigEmbeddedGroup/microzig/issues/245#issue-2568813840

