### PR TITLE
Support I2C and SPI functions in the pins abstraction

### DIFF
--- a/port/raspberrypi/rp2xxx/src/hal/pins.zig
+++ b/port/raspberrypi/rp2xxx/src/hal/pins.zig
@@ -185,6 +185,32 @@ pub const Function = enum {
         };
     }
 
+    pub fn is_spi(function: Function) bool {
+        return switch (function) {
+            .SPI0_RX,
+            .SPI0_CSn,
+            .SPI0_SCK,
+            .SPI0_TX,
+            .SPI1_RX,
+            .SPI1_CSn,
+            .SPI1_SCK,
+            .SPI1_TX,
+            => true,
+            else => false,
+        };
+    }
+
+    pub fn is_i2c(function: Function) bool {
+        return switch (function) {
+            .I2C0_SDA,
+            .I2C0_SCL,
+            .I2C1_SDA,
+            .I2C1_SCL,
+            => true,
+            else => false
+        };
+    }
+
     pub fn pwm_slice(comptime function: Function) u32 {
         return switch (function) {
             .PWM0_A, .PWM0_B => 0,
@@ -502,6 +528,10 @@ pub const GlobalConfiguration = struct {
                     pin.set_function(.disabled);
                 } else if (comptime func.is_uart_tx() or func.is_uart_rx()) {
                     pin.set_function(.uart);
+                } else if (comptime func.is_spi()) {
+                    pin.set_function(.spi);
+                } else if (comptime func.is_i2c()) {
+                    pin.set_function(.i2c);
                 } else {
                     @compileError(std.fmt.comptimePrint("Unimplemented pin function. Please implement setting pin function {s} for GPIO {}", .{
                         @tagName(func),


### PR DESCRIPTION
Just got around to updating microzig to past @haydenridd's SPI and I2C re-writes. Formerly, the function and pull were set by the I2C interface.

=> https://github.com/ZigEmbeddedGroup/microzig/pull/213/files#diff-8a4efe08a401e079bae57d66c0dd3ef49a3839a6065c3c1058ac8a0eaf142623L110

Since that's no longer the case, I'd like to set the function in the pins interface. This Microzig patch lets me do that.

=> https://tildegit.org/matthias/Micromouse/src/branch/master/src/physical-bot.zig#L212

Arguably we could/should also set the direction and pull based off of these properties (previously the I2C interface used `set_pull(.up)` on both pins), but it's slightly less obvious how to do that correctly and doesn't seem to be necessary in my test.