### PR TITLE
Fixed RP2xxx usb reset register masks

### DIFF
--- a/port/raspberrypi/rp2xxx/src/hal/usb.zig
+++ b/port/raspberrypi/rp2xxx/src/hal/usb.zig
@@ -119,8 +119,12 @@ pub const F = struct {
         // already moved over to the 12MHz XOSC. We just need to make it x4 that
         // clock.
         //
+        // Creates a bitmask for the pll_usb bit
+        const bit_offset = @bitOffsetOf(resets.Mask, "pll_usb");
+        const raw_mask: u32 = 0 << bit_offset;
+        const mask: resets.Mask = @bitCast(raw_mask);
         // PLL_USB out of reset
-        resets.reset(.{ .pll_usb = true });
+        resets.reset(mask);
         // Configure it:
         //
         // RFDIV = 1
@@ -143,8 +147,12 @@ pub const F = struct {
     }
 
     pub fn usb_init_device(_: *usb.DeviceConfiguration) void {
+        // Creates a bitmask for the usbctrl bit
+        const bit_offset = @bitOffsetOf(resets.Mask, "usbctrl");
+        const raw_mask: u32 = 0 << bit_offset;
+        const mask: resets.Mask = @bitCast(raw_mask);
         // Bring USB out of reset
-        resets.reset(.{ .usbctrl = true });
+        resets.reset(mask);
 
         // Clear the control portion of DPRAM. This may not be necessary -- the
         // datasheet is ambiguous -- but the C examples do it, and so do we.

--- a/port/raspberrypi/rp2xxx/src/hal/usb.zig
+++ b/port/raspberrypi/rp2xxx/src/hal/usb.zig
@@ -119,12 +119,6 @@ pub const F = struct {
         // already moved over to the 12MHz XOSC. We just need to make it x4 that
         // clock.
         //
-        // Creates a bitmask for the pll_usb bit
-        const bit_offset = @bitOffsetOf(resets.Mask, "pll_usb");
-        const raw_mask: u32 = 0 << bit_offset;
-        const mask: resets.Mask = @bitCast(raw_mask);
-        // PLL_USB out of reset
-        resets.reset(mask);
         // Configure it:
         //
         // RFDIV = 1
@@ -147,13 +141,6 @@ pub const F = struct {
     }
 
     pub fn usb_init_device(_: *usb.DeviceConfiguration) void {
-        // Creates a bitmask for the usbctrl bit
-        const bit_offset = @bitOffsetOf(resets.Mask, "usbctrl");
-        const raw_mask: u32 = 0 << bit_offset;
-        const mask: resets.Mask = @bitCast(raw_mask);
-        // Bring USB out of reset
-        resets.reset(mask);
-
         // Clear the control portion of DPRAM. This may not be necessary -- the
         // datasheet is ambiguous -- but the C examples do it, and so do we.
         peripherals.USBCTRL_DPRAM.SETUP_PACKET_LOW.write_raw(0);


### PR DESCRIPTION
Before the rework on resets.zig the mask had all of the rp2xxx hal/resets.zig Mask had all of the values in the packed struct as false by default, so when reset.reset(.{pll_usb}) was run, it would make a bitmask for only that register. But now it makes a bitmask for every register and takes all pins out of reset mode.

I just made it so it gets the bit offset of the register and creates a bitmask for only the register in question. This should support rp2040 and rp2350, but currently is only tested with the usb cdc example on the rp2040.