### PR TITLE
adding NVIC registers for cortex m0+, fixing little bug with stringToEnum

### DIFF
--- a/core/src/cpus/cortex_m.zig
+++ b/core/src/cpus/cortex_m.zig
@@ -22,7 +22,7 @@ const Core = enum {
 };
 
 const core: type = blk: {
-    const cortex_m = std.meta.stringToEnum(microzig.config.cpu_name) orelse @panic(std.fmt.comptimePrint("Unrecognized Cortex-M core name: {s}", .{microzig.config.cpu_name}));
+    const cortex_m = std.meta.stringToEnum(Core, microzig.config.cpu_name) orelse @panic(std.fmt.comptimePrint("Unrecognized Cortex-M core name: {s}", .{microzig.config.cpu_name}));
     break :blk switch (cortex_m) {
         .@"ARM Cortex-M0" => @import("cortex_m/m0"),
         .@"ARM Cortex-M0+" => @import("cortex_m/m0plus.zig"),

--- a/core/src/cpus/cortex_m/m0plus.zig
+++ b/core/src/cpus/cortex_m/m0plus.zig
@@ -1,3 +1,20 @@
 pub const SystemControlBlock = @compileError("TODO");
-pub const NestedVectorInterruptController = @compileError("TODO");
+
+pub const NestedVectorInterruptController = extern struct {
+    /// Interrupt set registers.
+    ISER: u32,
+    _reserved0: [31]u32,
+    /// Interrupt clear enable registers.
+    ICER: u32,
+    _reserved1: [31]u32,
+    /// Interrupt set pending registers.
+    ISPR: u32,
+    _reserved2: [31]u32,
+    /// Interrupt clear pending registers.
+    ICPR: u32,
+    _reserved3: [31]u32,
+    /// Interrupt priority registers.
+    IPR: [28]u8,
+};
+
 pub const MemoryProtectionUnit = @compileError("TODO");


### PR DESCRIPTION
Hi! Am working on a hobby project with a stm32g030, and have just been trying to get interrupts working. Turns out I needed NVIC registers. This change adds the NVIC registers. I wrote it by hand; if it can be generated, that'd avoid any of my math mistakes!