### PR TITLE
Combine .sbss section with .bss.

### DIFF
--- a/build/src/generate_linkerscript.zig
+++ b/build/src/generate_linkerscript.zig
@@ -131,6 +131,7 @@ pub fn main() !void {
             \\  {
             \\      microzig_bss_start = .;
             \\      *(.bss*)
+            \\      *(.sbss*)
             \\      microzig_bss_end = .;
             \\  } > ram0
             \\


### PR DESCRIPTION
The linker script doen't care the .sbss section and variables located in that section are not cleared by startup code. So, I would like to propose to include .sbss in .bss section.

Example code.

```zig
const std = @import("std");
const microzig = @import("microzig");

var a: bool = false;
pub fn main() void {
    while (true) {
        asm volatile ("nop");
        a = !a;
    }
}
```

I compiled it under examples/gigadevice/gd32 and this program makes following code.

```
0800001e <_start>:
 800001e:	1141                	addi	sp,sp,-16
 8000020:	c606                	sw	ra,12(sp)
 8000022:	20000537          	lui	a0,0x20000
 8000026:	00050513          	mv	a0,a0
 800002a:	200005b7          	lui	a1,0x20000
 800002e:	00058613          	mv	a2,a1
 8000032:	8e09                	sub	a2,a2,a0
 8000034:	4581                	li	a1,0
 8000036:	00000097          	auipc	ra,0x0
 800003a:	04c080e7          	jalr	76(ra) # 8000082 <memset>
```

The variable a is mapped on .sbss. However, the current linker script and start code consider only .bss section, and the variable a in .sbss is not cleared by startup code. Thus, I added a line to locate .sbss in .bss.


