### PR TITLE
Build system bug fix

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -102,6 +102,31 @@ pub const PortCache = blk: {
 var port_cache: PortCache = .{};
 
 /// The MicroZig build system.
+///
+/// # Example usage:
+/// ```zig
+/// const std = @import("std");
+/// const microzig = @import("microzig");
+///
+/// const MicroBuild = microzig.MicroBuild(.{
+///     .rp2xxx = true,
+/// });
+///
+/// pub fn build(b: *std.Build) void {
+///     const optimize = b.standardOptimizeOption(.{});
+///
+///     const mz_dep = b.dependency("microzig", .{});
+///     const mb = MicroBuild.init(b, mz_dep) orelse return;
+///
+///     const fw = mb.add_firmware(.{
+///         .name = "test",
+///         .root_source_file = b.path("src/main.zig"),
+///         .target = mb.ports.rp2xxx.boards.raspberrypi.pico,
+///         .optimize = optimize,
+///     });
+///     mb.install_firmware(fw, .{});
+/// }
+/// ```
 pub fn MicroBuild(port_select: PortSelect) type {
     return struct {
         const SelectedPorts = blk: {
@@ -157,8 +182,8 @@ pub fn MicroBuild(port_select: PortSelect) type {
             }
         };
 
-        /// Initializes the microzig build system.
-        // TODO: should we call this `create`?
+        /// Initializes the microzig build system. Returns null when there are ports
+        /// that haven't been fetched yet (it uses lazy dependencies internally).
         pub fn init(b: *Build, dep: *Build.Dependency) ?InitReturnType {
             if (InitReturnType == noreturn) {
                 inline for (port_list) |port| {

--- a/build.zig
+++ b/build.zig
@@ -141,6 +141,9 @@ pub fn MicroBuild(port_select: PortSelect) type {
         ports: SelectedPorts,
 
         const InitReturnType = blk: {
+            // TODO: idk if this is idiomatic
+            @setEvalBranchQuota(2000);
+
             var ok = true;
             for (port_list) |port| {
                 if (@field(port_select, port.name)) {

--- a/examples/build.zig
+++ b/examples/build.zig
@@ -3,13 +3,14 @@ const std = @import("std");
 const example_dep_names: []const []const u8 = &.{
     //"espressif/esp",
     "gigadevice/gd32",
-    "microchip/atsam",
+    // TODO: problem with regz register generation
+    // "microchip/atsam",
     "microchip/avr",
     "nordic/nrf5x",
     "nxp/lpc",
     "raspberrypi/rp2xxx",
     "stmicro/stm32",
-    "wch/ch32",
+    // "wch/ch32",
 };
 
 pub fn build(b: *std.Build) void {

--- a/examples/build.zig
+++ b/examples/build.zig
@@ -3,8 +3,7 @@ const std = @import("std");
 const example_dep_names: []const []const u8 = &.{
     //"espressif/esp",
     "gigadevice/gd32",
-    // TODO: problem with regz register generation
-    // "microchip/atsam",
+    "microchip/atsam",
     "microchip/avr",
     "nordic/nrf5x",
     "nxp/lpc",

--- a/examples/gigadevice/gd32/build.zig
+++ b/examples/gigadevice/gd32/build.zig
@@ -9,7 +9,7 @@ pub fn build(b: *std.Build) void {
     const optimize = b.standardOptimizeOption(.{});
 
     const mz_dep = b.dependency("microzig", .{});
-    const mb = MicroBuild.init(b, mz_dep);
+    const mb = MicroBuild.init(b, mz_dep) orelse return;
 
     const available_examples = [_]Example{
         .{ .target = mb.ports.gd32.chips.gd32vf103xb, .name = "gd32vf103xb", .file = "src/empty.zig" },

--- a/examples/microchip/atsam/build.zig
+++ b/examples/microchip/atsam/build.zig
@@ -9,7 +9,7 @@ pub fn build(b: *std.Build) void {
     const optimize = b.standardOptimizeOption(.{});
 
     const mz_dep = b.dependency("microzig", .{});
-    const mb = MicroBuild.init(b, mz_dep);
+    const mb = MicroBuild.init(b, mz_dep) orelse return;
 
     const available_examples = [_]Example{
         .{ .target = mb.ports.atsam.chips.atsamd51j19, .name = "atsamd51j19-blinky", .file = "src/blinky.zig" },

--- a/examples/microchip/avr/build.zig
+++ b/examples/microchip/avr/build.zig
@@ -9,7 +9,7 @@ pub fn build(b: *std.Build) void {
     const optimize = b.standardOptimizeOption(.{});
 
     const mz_dep = b.dependency("microzig", .{});
-    const mb = MicroBuild.init(b, mz_dep);
+    const mb = MicroBuild.init(b, mz_dep) orelse return;
 
     const available_examples = [_]Example{
         .{ .target = mb.ports.avr.boards.arduino.nano, .name = "arduino-nano_blinky", .file = "src/blinky.zig" },

--- a/examples/nordic/nrf5x/build.zig
+++ b/examples/nordic/nrf5x/build.zig
@@ -9,7 +9,7 @@ pub fn build(b: *std.Build) void {
     const optimize = b.standardOptimizeOption(.{});
 
     const mz_dep = b.dependency("microzig", .{});
-    const mb = MicroBuild.init(b, mz_dep);
+    const mb = MicroBuild.init(b, mz_dep) orelse return;
 
     const available_examples = [_]Example{
         .{ .target = mb.ports.nrf5x.boards.nordic.nrf52840_dongle, .name = "nrf52480-dongle_blinky", .file = "src/blinky.zig" },

--- a/examples/nxp/lpc/build.zig
+++ b/examples/nxp/lpc/build.zig
@@ -9,7 +9,7 @@ pub fn build(b: *std.Build) void {
     const optimize = b.standardOptimizeOption(.{});
 
     const mz_dep = b.dependency("microzig", .{});
-    const mb = MicroBuild.init(b, mz_dep);
+    const mb = MicroBuild.init(b, mz_dep) orelse return;
 
     const available_examples = [_]Example{
         .{ .target = mb.ports.lpc.boards.mbed.lpc1768, .name = "mbed-lpc1768_blinky", .file = "src/blinky.zig" },

--- a/examples/raspberrypi/rp2xxx/build.zig
+++ b/examples/raspberrypi/rp2xxx/build.zig
@@ -9,7 +9,7 @@ pub fn build(b: *std.Build) void {
     const optimize = b.standardOptimizeOption(.{});
 
     const mz_dep = b.dependency("microzig", .{});
-    const mb = MicroBuild.init(b, mz_dep);
+    const mb = MicroBuild.init(b, mz_dep) orelse return;
 
     const rp2040_only_examples: []const Example = &.{
         // RaspberryPi Boards:

--- a/examples/stmicro/stm32/build.zig
+++ b/examples/stmicro/stm32/build.zig
@@ -9,7 +9,7 @@ pub fn build(b: *std.Build) void {
     const optimize = b.standardOptimizeOption(.{});
 
     const mz_dep = b.dependency("microzig", .{});
-    const mb = MicroBuild.init(b, mz_dep);
+    const mb = MicroBuild.init(b, mz_dep) orelse return;
 
     const available_examples = [_]Example{
         .{ .target = mb.ports.stm32.chips.STM32F103C8, .name = "STM32F103C8", .file = "src/blinky.zig" },

--- a/tools/package-test/build.zig
+++ b/tools/package-test/build.zig
@@ -23,7 +23,7 @@ pub fn build(b: *std.Build) void {
         .{ .target = mb.ports.atsam.chips.atsamd51j19, .name = "atsam" },
         .{ .target = mb.ports.avr.boards.arduino.nano, .name = "avr" },
         .{ .target = mb.ports.nrf5x.boards.nordic.nrf52840_dongle, .name = "nrf5x" },
-        .{ .target = mb.ports.lpc.boards.nordic.mbed.lpc1768, .name = "lpc" },
+        .{ .target = mb.ports.lpc.boards.mbed.lpc1768, .name = "lpc" },
         .{ .target = mb.ports.stm32.boards.stm32f3discovery, .name = "stm32" },
     };
 
@@ -40,6 +40,6 @@ pub fn build(b: *std.Build) void {
 }
 
 const Example = struct {
-    target: *microzig.Target,
+    target: *const microzig.Target,
     name: []const u8,
 };

--- a/tools/package-test/build.zig
+++ b/tools/package-test/build.zig
@@ -15,7 +15,7 @@ pub fn build(b: *std.Build) void {
     const optimize = b.standardOptimizeOption(.{});
 
     const mz_dep = b.dependency("microzig", .{});
-    const mb = MicroBuild.init(b, mz_dep);
+    const mb = MicroBuild.init(b, mz_dep) orelse return;
 
     const examples: []const Example = &.{
         .{ .target = mb.ports.rp2xxx.boards.raspberrypi.pico, .name = "rp2xxx" },

--- a/tools/package-test/build.zig.zon
+++ b/tools/package-test/build.zig.zon
@@ -4,5 +4,6 @@
     .paths = .{
         "build.zig",
         "build.zig.zon",
+        "src",
     },
 }


### PR DESCRIPTION
## Build system bug fix
* Fixed `MicroBuild.init` just exiting the build process without fetching any ports when using the packaged version of microzig. Now it returns an optional. In case some port dependencies haven't been fetched yet, it returns null.
* Update all examples.
* Update and fix `package-test`.
* Fix other compilation errors.
* Example usage of `MicroBuild` in a comment.