### PR TITLE
Add cortex m7 register definitions

### DIFF
--- a/core/src/cpus/cortex_m.zig
+++ b/core/src/cpus/cortex_m.zig
@@ -22,16 +22,20 @@ const Core = enum {
     cortex_m7,
 };
 
-const core: type = blk: {
-    const cortex_m = std.meta.stringToEnum(Core, microzig.config.cpu_name) orelse @compileError(std.fmt.comptimePrint("Unrecognized Cortex-M core name: {s}", .{microzig.config.cpu_name}));
-    break :blk switch (cortex_m) {
-        .@"ARM Cortex-M0" => @import("cortex_m/m0"),
-        .@"ARM Cortex-M0+" => @import("cortex_m/m0plus.zig"),
-        .@"ARM Cortex-M3" => @import("cortex_m/m3.zig"),
-        .@"ARM Cortex-M33" => @import("cortex_m/m33.zig"),
-        .@"ARM Cortex-M4" => @import("cortex_m/m4.zig"),
-        .cortex_m7 => @import("cortex_m/m7.zig"),
-    };
+const cortex_m = std.meta.stringToEnum(Core, microzig.config.cpu_name) orelse @compileError(std.fmt.comptimePrint("Unrecognized Cortex-M core name: {s}", .{microzig.config.cpu_name}));
+
+const core: type = switch (cortex_m) {
+    .@"ARM Cortex-M0" => @import("cortex_m/m0"),
+    .@"ARM Cortex-M0+" => @import("cortex_m/m0plus.zig"),
+    .@"ARM Cortex-M3" => @import("cortex_m/m3.zig"),
+    .@"ARM Cortex-M33" => @import("cortex_m/m33.zig"),
+    .@"ARM Cortex-M4" => @import("cortex_m/m4.zig"),
+    .cortex_m7 => @import("cortex_m/m7.zig"),
+};
+
+pub const utils = switch (cortex_m) {
+    .cortex_m7 => @import("cortex_m/m7_utils.zig"),
+    else => void{},
 };
 
 const properties = microzig.chip.properties;

--- a/core/src/cpus/cortex_m.zig
+++ b/core/src/cpus/cortex_m.zig
@@ -48,7 +48,7 @@ pub const mpu: *volatile core.MemoryProtectionUnit = if (mpu_present)
 else
     @compileError("Cortex-M does not have an MPU");
 
-pub const dbg: if (@hasDecl(core, "DebugRegisters")) *volatile core.DebugRegisters else *volatile anyopaque = @ptrFromInt(dwt_base);
+pub const dbg: if (@hasDecl(core, "DebugRegisters")) *volatile core.DebugRegisters else *volatile anyopaque = @ptrFromInt(coredebug_base);
 
 pub const itm: if (@hasDecl(core, "ITM")) *volatile core.ITM else *volatile anyopaque = @ptrFromInt(itm_base);
 

--- a/core/src/cpus/cortex_m/m7.zig
+++ b/core/src/cpus/cortex_m/m7.zig
@@ -1,0 +1,301 @@
+const microzig = @import("microzig");
+const mmio = microzig.mmio;
+
+pub const SystemControlBlock = extern struct {
+    /// CPUID Base Register
+    CPUID: u32,
+    /// Interrupt Control and State Register
+    ICSR: mmio.Mmio(packed struct(u32) {
+        VECTACTIVE: u9,
+        reserved0: u2 = 0,
+        RETTOBASE: u1,
+        VECTPENDING: u9,
+        reserved1: u1 = 0,
+        ISRPENDING: u1,
+        ISRPREEMPT: u1,
+        reserved2: u1 = 0,
+        PENDSTCLR: u1,
+        PENDSTSET: u1,
+        PENDSVCLR: u1,
+        PENDSVSET: u1,
+        reserved3: u2 = 0,
+        NMIPENDSET: u1,
+    }),
+    /// Vector Table Offset Register
+    VTOR: u32,
+    /// Application Interrupt  and Reset Control Register
+    AIRCR: u32,
+    /// System Control Register
+    SCR: u32,
+    /// Configuration Control Register
+    CCR: mmio.Mmio(packed struct(u32) {
+        NONBASETHRDENA: u1,
+        USERSETMPEND: u1,
+        _reserved0: u1 = 0,
+        UNALIGN_TRP: u1,
+        DIV_0_TRP: u1,
+        _reserved1: u3 = 0,
+        BFHFNMIGN: u1,
+        STKALIGN: u1,
+        _padding: u22 = 0,
+    }),
+    /// System Handlers Priority Registers
+    SHP: [3]u8,
+    /// System Handler Contol and State Register
+    SHCSR: u32,
+    /// Configurable Fault Status Register
+    CFSR: u32,
+    /// MemManage Fault Status Register
+    MMSR: u32,
+    /// BusFault Status Register
+    BFSR: u32,
+    /// UsageFault Status Register
+    UFSR: u32,
+    /// HardFault Status Register
+    HFSR: u32,
+    /// MemManage Fault Address Register
+    MMAR: u32,
+    /// BusFault Address Register
+    BFAR: u32,
+    /// Auxiliary Fault Status Register not implemented
+    AFSR: u32,
+
+    /// Processor Feature Register
+    PFR: [2]u32,
+    /// Debug Feature Register
+    DFR: u32,
+    /// Auxilary Feature Register
+    ADR: u32,
+    /// Memory Model Feature Register
+    MMFR: [4]u32,
+    /// Instruction Set Attributes Register
+    ISAR: [5]u32,
+    RESERVED0: [5]u32,
+    /// Coprocessor Access Control Register
+    CPACR: u32,
+};
+
+pub const NestedVectorInterruptController = extern struct {
+    /// Interrupt Set-enable Registers
+    ISER: [7]u32,
+    _reserved0: [25]u32,
+    /// Interrupt Clear-enable Registers
+    ICER: [7]u32,
+    _reserved1: [25]u32,
+    /// Interrupt Set-pending Registers
+    ISPR: [7]u32,
+    _reserved2: [25]u32,
+    /// Interrupt Clear-pending Registers
+    ICPR: [7]u32,
+    _reserved3: [25]u32,
+    /// Interrupt Active Bit Registers
+    IABR: [7]u32,
+    _reserved4: [57]u32,
+    /// Interrupt Priority Registers
+    IP: [239]u8,
+    _reserved5: [2577]u8,
+    /// Software Trigger Interrupt Register
+    STIR: u32,
+};
+
+pub const MemoryProtectionUnit = extern struct {
+    /// MPU Type Register
+    TYPE: mmio.Mmio(packed struct(u32) {
+        SEPARATE: u1,
+        _reserved0: u7,
+        DREGION: u8,
+        IREGION: u8,
+        _reserved1: u8,
+    }),
+    /// MPU Control Register
+    CTRL: mmio.Mmio(packed struct(u32) {
+        ENABLE: u1,
+        HFNMIENA: u1,
+        PRIVDEFENA: u1,
+        padding: u29,
+    }),
+    /// MPU RNRber Register
+    RNR: mmio.Mmio(packed struct(u32) {
+        REGION: u8,
+        padding: u24,
+    }),
+    /// MPU Region Base Address Register
+    RBAR: RBAR,
+    /// MPU Region Attribute and Size Register
+    RASR: RASR,
+    /// MPU Alias 1 Region Base Address Register
+    RBAR_A1: RBAR,
+    /// MPU Alias 1 Region Attribute and Size Register
+    RASR_A1: RASR,
+    /// MPU Alias 2 Region Base Address Register
+    RBAR_A2: RBAR,
+    /// MPU Alias 2 Region Attribute and Size Register
+    RASR_A2: RASR,
+    /// MPU Alias 3 Region Base Address Register
+    RBAR_A3: RBAR,
+    /// MPU Alias 3 Region Attribute and Size Register
+    RASR_A3: RASR,
+
+    pub const RBAR = mmio.Mmio(packed struct(u32) {
+        REGION: u4,
+        VALID: u1,
+        ADDR: u27,
+    });
+
+    pub const RASR = mmio.Mmio(packed struct(u32) {
+        /// Region enable bit
+        ENABLE: u1,
+        /// Region Size
+        SIZE: u5,
+        _reserved0: u2,
+        /// Sub-Region Disable
+        SRD: u8,
+        /// ATTRS.B
+        B: u1,
+        /// ATTRS.C
+        C: u1,
+        /// ATTRS.S
+        S: u1,
+        /// ATTRS.TEX
+        TEX: u3,
+        _reserved1: u2,
+        /// ATTRS.AP
+        AP: u3,
+        /// ATTRS.XN
+        XN: u1,
+        padding: u4,
+    });
+};
+
+pub const DebugRegisters = extern struct {
+    /// Debyg Halting Control and Status Register
+    DHCSR: mmio.Mmio(packed struct {
+        _reserved_0: u6,
+        S_RESET_ST: u1,
+        S_RETIRE_ST: u1,
+        _reserved_1: u4,
+        S_LOCKUP: u1,
+        S_SLEEP: u1,
+        S_HALT: u1,
+        S_REGRDY: u1,
+        _reserved_2: u10,
+        C_SNAPSTALL: u1,
+        _reserved_3: u1,
+        C_MASKINTS: u1,
+        C_STEP: u1,
+        C_HALT: u1,
+        C_DEBUGEN: u1,
+    }),
+    /// Debug Core Register Selector Register
+    /// TODO: Reserved have values ? see armv7-m reference manual
+    DCRSR: mmio.Mmio(packed struct {
+        _reserved_0: u15,
+        REGWnR: u1,
+        _reserved_1: u9,
+        REGSEL: u7,
+    }),
+    /// Debug Core Register Data Register
+    DCRDR: mmio.Mmio(packed struct {
+        DBGTMP: u32,
+    }),
+    /// Debug exception and Monitor Control Register
+    DEMCR: mmio.Mmio(packed struct {
+        _reserved_0: u7,
+        TRCENA: u1,
+        _reserved_1: u4,
+        MON_REQ: u1,
+        MON_STEP: u1,
+        MON_PEND: u1,
+        MON_EN: u1,
+        _reserved_2: u5,
+        VC_HARDERR: u1,
+        VC_INTERR: u1,
+        VC_BUSERR: u1,
+        VC_STATERR: u1,
+        VC_CHKERR: u1,
+        VC_NOCPERR: u1,
+        VC_MMERR: u1,
+        _reserved_3: u3,
+        VC_CORERESET: u1,
+    }),
+};
+
+pub const ITM = extern struct {
+    /// Stimulus Port Registers (0-255)
+    STIM: [256]mmio.Mmio(packed union {
+        WRITE_U8: u8,
+        WRITE_U16: u16,
+        WRITE_U32: u32,
+        READ: packed struct(u32) {
+            FIFOREADY: u1,
+            _reserved: u31,
+        },
+    }),
+
+    _reserved0: [640]u32, // Padding to 0xE00
+
+    /// Trace Enable Registers (0-7)
+    TER: [8]mmio.Mmio(packed struct(u32) {
+        STIMENA: u32, // Enable bits for stimulus ports
+    }),
+
+    _reserved1: [10]u32, // Padding to 0xE40
+
+    /// Trace Privilege Register
+    TPR: mmio.Mmio(packed struct(u32) {
+        PRIVMASK: u32, // Privilege mask for stimulus ports
+    }),
+
+    _reserved2: [15]u32, // Padding to 0xE80
+
+    /// Trace Control Register
+    TCR: mmio.Mmio(packed struct(u32) {
+        ITMENA: u1, // ITM enable
+        TSENA: u1, // Local timestamp enable
+        SYNCENA: u1, // Sync packet enable
+        TXENA: u1, // DWT packet forwarding enable
+        SWOENA: u1, // Async clock enable
+        _reserved0: u3,
+        TSPrescale: u2, // Local timestamp prescaler
+        GTSFREQ: u2, // Global timestamp frequency
+        _reserved1: u4,
+        TraceBusID: u7, // Trace bus ID
+        BUSY: u1, // ITM busy flag
+        _reserved2: u8,
+    }),
+};
+
+pub const TPIU = extern struct {
+    /// Supported Parallel Port Sizes Register
+    SSPSR: mmio.Mmio(packed struct(u32) {
+        SWIDTH: u32,
+    }),
+    /// Current Parallel Port Size Register
+    CSPSR: mmio.Mmio(packed struct(u32) {
+        CWIDTH: u32,
+    }),
+    _reserved0: [2]u32,
+    /// Asynchronous Clock Prescaler Register
+    ACPR: mmio.Mmio(packed struct(u32) {
+        SWOSCALER: u16,
+        _padding: u16,
+    }),
+    _reserved1: [55]u32,
+    /// Selected Pin Protocol Register
+    SPPR: mmio.Mmio(packed struct(u32) {
+        TXMODE: u2,
+        _padding: u30,
+    }),
+    _reserved2: [524]u32,
+    /// TPIU Type Register
+    TYPE: mmio.Mmio(packed struct(u32) {
+        _reserved0: u6,
+        FIFOSZ: u3,
+        PTINVALID: u1,
+        MANCVALID: u1,
+        NRZVALID: u1,
+        _implementation_defined0: u4,
+        _padding: u16,
+    }),
+    _reserved3: [13]u32,
+};

--- a/core/src/cpus/cortex_m/m7_utils.zig
+++ b/core/src/cpus/cortex_m/m7_utils.zig
@@ -1,0 +1,59 @@
+const cpu = @import("../cortex_m.zig");
+
+pub fn initSWO(config: struct {
+    /// Implementation defined. In Hz
+    tpiu_clock: u32,
+    /// SWO output frequency. Used to calculate the prescaler.
+    swo_output_target_hz: u32 = 2_000_000,
+    /// Protocol for trace output from the TPIU
+    tx_mode: enum(u2) {
+        pararell_trace_port = 0b00,
+        swo_manchester_encoding = 0b01,
+        swo_nrz_encoding = 0b10,
+    } = .swo_nrz_encoding,
+    /// Stimulus port to enable
+    stim_port: u5 = 0,
+    /// Identifier for multi-source trace stream formatting.
+    /// If multi-source trace is in use, the debugger must write a non-zero value to this field.
+    trace_bus_id: u7 = 0,
+}) !void {
+    // Enable trace in core debug:
+    cpu.dbg.DEMCR.modify(.{ .TRCENA = 1 }); // Enable debugging & monitoring
+
+    // Enable ITM:
+    cpu.itm.TCR.modify(.{
+        .ITMENA = 1, // Enable ITM
+        .TXENA = 1, // Enable DWT packets
+        .TraceBusID = config.trace_bus_id, // Unique ID for multi-source trace
+    });
+
+    // Enable stimulus port 0:
+    cpu.itm.TER[config.stim_port].modify(.{ .STIMENA = 1 });
+
+    // Configure Serial Wire Output (SWO):
+    cpu.tpiu.SPPR.modify(.{ .TXMODE = @intFromEnum(config.tx_mode) });
+
+    // SWO output clock = Asynchronous_Reference_Clock/(SWOSCALAR +1)\
+    // SWOSCALAR = (Asynchronous_Reference_Clock)/(SWO output clock) - 1
+    if (config.swo_output_target_hz > config.tpiu_clock)
+        return error.SwoTargetFreqTooHigh; // would cause int underflow
+
+    cpu.tpiu.ACPR.modify(.{
+        .SWOSCALER = @as(u16, @intCast((config.tpiu_clock / config.swo_output_target_hz) - 1)),
+    });
+}
+
+pub fn writeByteITM(ch: u8, stim_port: u5) void {
+    // Wait until stimulus port is ready
+    while (cpu.itm.STIM[stim_port].read().READ.FIFOREADY == 0) {}
+
+    // Write character
+    const stim: *volatile u8 = @ptrCast(&cpu.itm.STIM[stim_port].raw);
+    stim.* = ch;
+}
+
+pub fn writeBytesITM(str: []const u8, stim_port: u5) void {
+    for (str) |ch| {
+        writeByteITM(ch, stim_port);
+    }
+}

--- a/core/src/cpus/cortex_m/m7_utils.zig
+++ b/core/src/cpus/cortex_m/m7_utils.zig
@@ -1,6 +1,6 @@
 const cpu = @import("../cortex_m.zig");
 
-pub fn initSWO(config: struct {
+pub fn init_swo(config: struct {
     /// Implementation defined. In Hz
     tpiu_clock: u32,
     /// SWO output frequency. Used to calculate the prescaler.
@@ -43,7 +43,7 @@ pub fn initSWO(config: struct {
     });
 }
 
-pub fn writeByteITM(ch: u8, stim_port: u5) void {
+pub fn write_byte_itm(ch: u8, stim_port: u5) void {
     // Wait until stimulus port is ready
     while (cpu.itm.STIM[stim_port].read().READ.FIFOREADY == 0) {}
 
@@ -52,8 +52,8 @@ pub fn writeByteITM(ch: u8, stim_port: u5) void {
     stim.* = ch;
 }
 
-pub fn writeBytesITM(str: []const u8, stim_port: u5) void {
+pub fn write_bytes_itm(str: []const u8, stim_port: u5) void {
     for (str) |ch| {
-        writeByteITM(ch, stim_port);
+        write_byte_itm(ch, stim_port);
     }
 }


### PR DESCRIPTION
This PR adds some basic cortex-m7 register definitions.

I verified that ITM, TPIU, and DBG work on an STM32f746ng-disco board with this sample code to write debug info through SWD:

```zig
const std = @import("std");
const microzig = @import("microzig");
const stm32 = microzig.hal;
const cpu = microzig.cpu;

pub fn initSWO() void {
    // Enable trace in core debug:
    cpu.dbg.DEMCR.modify(.{ .TRCENA = 1 }); // Enable debugging & monitoring

    // Enable ITM:
    cpu.itm.TCR.modify(.{
        .ITMENA = 1, // Enable ITM
        .SYNCENA = 1, // Enabe sync packets
        .TXENA = 1, // Enable DWT packets
        .TraceBusID = 1, // Unique ID for multi-source trace
    });

    // Enable stimulus port 0:
    cpu.itm.TER[0].modify(.{ .STIMENA = 1 });

    // Configure Serial Wire Output (SWO):
    cpu.tpiu.SPPR.modify(.{ .TXMODE = 0b10 }); // NZ mode
    cpu.tpiu.ACPR.modify(.{ .SWOSCALER = 7 }); // Set prescaler (for 2MHz output @16MHz)

}

// Helper function to write a byte to ITM stimulus port
pub fn writeITM(ch: u8) void {
    // Wait until stimulus port is ready
    while (cpu.itm.STIM[0].read().READ.FIFOREADY == 0) {}

    // Write character
    // cpu.itm.STIM[0].write(.{ .WRITE_U8 = ch });
    const stim: *volatile u8 = @ptrCast(&cpu.itm.STIM[0].raw);
    stim.* = ch;
}

pub fn writeBytes(str: []const u8) void {
    for (str) |ch| {
        writeITM(ch);
    }
}

pub fn main() void {
    initSWO();
    var fmt_buf: [1024]u8 = undefined;
    var i: u32 = 0;
    while (true) : (i += 1) {
        writeBytes(std.fmt.bufPrintZ(&fmt_buf, "({d}) Hello, SWD!\n", .{i}) catch {
            writeBytes("Buf print formatting error!\n");
            continue;
        });

        for (0..10_000) |_| {
            asm volatile ("nop");
        }
    }
}
```

Prints out what you would expect.

