### PR TITLE
cortex_m: Add core peripherals

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -281,7 +281,7 @@ pub fn MicroBuild(port_select: PortSelect) type {
             const b = mb.dep.builder;
 
             const target = options.target;
-            const zig_target = mb.dep.builder.resolveTargetQuery(target.chip.cpu);
+            const zig_target = b.resolveTargetQuery(target.chip.cpu);
             const cpu = Cpu.init(zig_target.result);
 
             // TODO: let the user override which ram section to use the stack on,
@@ -293,7 +293,7 @@ pub fn MicroBuild(port_select: PortSelect) type {
                 } else @panic("no ram memory region found for setting the end-of-stack address");
             };
 
-            const config = mb.dep.builder.addOptions();
+            const config = b.addOptions();
             config.addOption(bool, "has_hal", options.hal != null or target.hal != null);
             config.addOption(bool, "has_board", options.board != null or target.board != null);
 

--- a/core/src/cpus/cortex_m.zig
+++ b/core/src/cpus/cortex_m.zig
@@ -152,10 +152,6 @@ const scb_base = scs_base + 0x0D00;
 const mpu_base = scs_base + 0x0D90;
 
 const properties = microzig.chip.properties;
-
-// TODO: to actually check this. Afaik only cortex_m0 has it optional so maybe skip this check?
-const systick_present = true;
-
 // TODO: will have to standardize this with regz code generation
 const mpu_present = @hasDecl(properties, "__MPU_PRESENT") and std.mem.eql(u8, properties.__MPU_PRESENT, "1");
 
@@ -188,10 +184,7 @@ pub const peripherals = struct {
     pub const nvic: *volatile types.peripherals.NestedVectorInterruptController = @ptrFromInt(nvic_base);
 
     /// System Timer
-    pub const systick: *volatile types.peripherals.SysTick = if (systick_present)
-        @ptrFromInt(systick_base)
-    else
-        @compileError("This chip does not have a SysTick.");
+    pub const systick: *volatile types.peripherals.SysTick = @ptrFromInt(systick_base);
 
     /// Memory Protection Unit (MPU)
     pub const mpu: *volatile types.peripherals.MemoryProtectionUnit = if (mpu_present)
@@ -208,14 +201,14 @@ pub const types = struct {
         /// Nested Vector Interrupt Controller
         pub const NestedVectorInterruptController = core.NestedVectorInterruptController;
 
-        ///  System Timer
+        /// System Timer
         pub const SysTick = extern struct {
             ///  SysTick Control and Status Register
             CTRL: mmio.Mmio(packed struct(u32) {
                 ENABLE: u1,
                 TICKINT: u1,
                 CLKSOURCE: u1,
-                reserved16: u13,
+                reserved0: u13,
                 COUNTFLAG: u1,
                 padding: u15,
             }),
@@ -232,7 +225,7 @@ pub const types = struct {
             ///  SysTick Calibration Register
             CALIB: mmio.Mmio(packed struct(u32) {
                 TENMS: u24,
-                reserved30: u6,
+                reserved0: u6,
                 SKEW: u1,
                 NOREF: u1,
             }),

--- a/core/src/cpus/cortex_m/m0.zig
+++ b/core/src/cpus/cortex_m/m0.zig
@@ -1,3 +1,57 @@
-pub const SystemControlBlock = @compileError("TODO");
-pub const NestedVectorInterruptController = @compileError("TODO");
-pub const MemoryProtectionUnit = @compileError("TODO");
+const microzig = @import("microzig");
+const mmio = microzig.mmio;
+
+pub const SystemControlBlock = extern struct {
+    /// CPUID Base Register
+    CPUID: u32,
+    /// Interrupt Control and State Register
+    ICSR: mmio.Mmio(packed struct(u32) {
+        VECTACTIVE: u6,
+        reserved0: u6 = 0,
+        VECTPENDING: u6,
+        reserved1: u4 = 0,
+        ISRPENDING: u1,
+        reserved2: u2 = 0,
+        PENDSTCLR: u1,
+        PENDSTSET: u1,
+        PENDSVCLR: u1,
+        PENDSVSET: u1,
+        reserved3: u2 = 0,
+        NMIPENDSET: u1,
+    }),
+    reserved0: u32,
+    /// Application Interrupt  and Reset Control Register
+    AIRCR: u32,
+    /// System Control Register
+    SCR: u32,
+    /// Configuration Control Register
+    CCR: mmio.Mmio(packed struct(u32) {
+        reserved0: u3 = 0,
+        UNALIGN_TRP: u1,
+        reserved1: u5 = 0,
+        STKALIGN: u1,
+        padding: u22 = 0,
+    }),
+    reserved1: u32,
+    /// System Handlers Priority Register 2
+    SHPR2: u32,
+    /// System Handlers Priority Register 3
+    SHPR3: u32,
+};
+
+pub const NestedVectorInterruptController = extern struct {
+    // Interrupt Set-Enable Register
+    ISER: u32,
+    reserved0: [31]u32,
+    // Interrupt Clear-Enable Register
+    ICER: u32,
+    reserved1: [31]u32,
+    /// Interrupt Set-Pending Register
+    ISPR: u32,
+    reserved2: [31]u32,
+    /// Interrupt Clear-Pending Register
+    ICPR: u32,
+    reserved3: [95]u32,
+    /// Interrupt Priority Registers
+    IPR: [8]u32,
+};

--- a/core/src/cpus/cortex_m/m0.zig
+++ b/core/src/cpus/cortex_m/m0.zig
@@ -2,56 +2,165 @@ const microzig = @import("microzig");
 const mmio = microzig.mmio;
 
 pub const SystemControlBlock = extern struct {
-    /// CPUID Base Register
+    /// CPUID Base Register.
     CPUID: u32,
-    /// Interrupt Control and State Register
+    /// Interrupt Control and State Register.
     ICSR: mmio.Mmio(packed struct(u32) {
+        /// Contains the active exception number:
+        /// 0 = Thread mode
+        /// Nonzero = The exception number[a] of the currently active exception.
         VECTACTIVE: u6,
         reserved0: u6 = 0,
+        /// Indicates the exception number of the highest priority pending enabled exception:
+        /// 0 = no pending exceptions
+        /// Nonzero = the exception number of the highest priority pending enabled exception.
         VECTPENDING: u6,
         reserved1: u4 = 0,
+        /// Interrupt pending flag, excluding NMI and Faults:
+        /// 0 = interrupt not pending
+        /// 1 = interrupt pending.
         ISRPENDING: u1,
         reserved2: u2 = 0,
+        /// SysTick exception clear-pending bit.
+        ///
+        /// Write:
+        /// 0 = no effect
+        /// 1 = removes the pending state from the SysTick exception.
+        ///
+        /// This bit is WO. On a register read its value is Unknown.
+        /// If your device does not implement the SysTick timer, this bit is Reserved.
         PENDSTCLR: u1,
+        /// SysTick exception set-pending bit.
+        ///
+        /// Write:
+        /// 0 = no effect1 = changes SysTick exception state to pending.
+        /// Read:
+        /// 0 = SysTick exception is not pending
+        /// 1 = SysTick exception is pending.
+        ///
+        /// If your device does not implement the SysTick timer, this bit is Reserved.
         PENDSTSET: u1,
+        /// PendSV clear-pending bit.
+        ///
+        /// Write:
+        /// 0 = no effect
+        /// 1 = removes the pending state from the PendSV exception.
         PENDSVCLR: u1,
+        /// PendSV set-pending bit.
+        ///
+        /// Write:
+        /// 0 = no effect
+        /// 1 = changes PendSV exception state to pending.
+        /// Read:
+        /// 0 = PendSV exception is not pending
+        /// 1 = PendSV exception is pending.
+        ///
+        /// Writing 1 to this bit is the only way to set the PendSV exception state to pending.
         PENDSVSET: u1,
         reserved3: u2 = 0,
+        /// NMI set-pending bit.
+        ///
+        /// Write:
+        /// 0 = no effect
+        /// 1 = changes NMI exception state to pending.
+        /// Read:
+        /// 0 = NMI exception is not pending
+        /// 1 = NMI exception is pending.
+        ///
+        /// Because NMI is the highest-priority exception, normally the processor enters the NMI
+        /// exception handler as soon as it detects a write of 1 to this bit. Entering the handler
+        /// then clears this bit to 0. This means a read of this bit by the NMI exception handler
+        /// returns 1 only if the NMI signal is reasserted while the processor is executing that handler.
         NMIPENDSET: u1,
     }),
     reserved0: u32,
-    /// Application Interrupt  and Reset Control Register
-    AIRCR: u32,
-    /// System Control Register
-    SCR: u32,
-    /// Configuration Control Register
+    /// Application Interrupt and Reset Control Register.
+    AIRCR: mmio.Mmio(packed struct {
+        reserved0: u1,
+        /// Reserved for debug use. This bit reads as 0. When writing to the register you must
+        /// write 0 to this bit, otherwise behavior is Unpredictable.
+        VECTCLRACTIVE: u1,
+        /// System reset request:
+        /// 0 = no effect
+        /// 1 = requests a system level reset.
+        ///
+        /// This bit reads as 0.
+        SYSRESETREQ: u1,
+        reserved1: u12,
+        /// Data endianness implemented:
+        /// 0 = Little-endian
+        /// 1 = Big-endian.
+        ENDIANESS: u1,
+        /// Register key:
+        /// Reads as Unknown
+        /// On writes, write 0x05FA to VECTKEY, otherwise the write is ignored.
+        VECTKEY: u16,
+    }),
+    /// System Control Register.
+    SCR: mmio.Mmio(packed struct(u32) {
+        reserved0: u1,
+        /// Indicates sleep-on-exit when returning from Handler mode to Thread mode:
+        /// 0 = do not sleep when returning to Thread mode.
+        /// 1 = enter sleep, or deep sleep, on return from an ISR to Thread mode.
+        ///
+        /// Setting this bit to 1 enables an interrupt driven application to avoid returning
+        /// to an empty main application.
+        SLEEPONEXIT: u1,
+        /// Controls whether the processor uses sleep or deep sleep as its low power mode:
+        /// 0 = sleep
+        /// 1 = deep sleep.
+        ///
+        /// If your device does not support two sleep modes, the effect of changing the value
+        /// of this bit is implementation-defined.
+        SLEEPDEEP: u1,
+        reserved1: u1,
+        /// Send Event on Pending bit:
+        /// 0 = only enabled interrupts or events can wakeup the processor, disabled interrupts are excluded
+        /// 1 = enabled events and all interrupts, including disabled interrupts, can wakeup the processor.
+        ///
+        /// When an event or interrupt enters pending state, the event signal wakes up the processor from WFE.
+        /// If the processor is not waiting for an event, the event is registered and affects the next WFE.
+        ///
+        /// The processor also wakes up on execution of an SEV instruction or an external event.
+        SEVONPEND: u1,
+        reserved2: u17,
+    }),
+    /// Configuration Control Register.
     CCR: mmio.Mmio(packed struct(u32) {
         reserved0: u3 = 0,
+        /// Always reads as one, indicates that all unaligned accesses generate a HardFault.
         UNALIGN_TRP: u1,
         reserved1: u5 = 0,
+        /// Always reads as one, indicates 8-byte stack alignment on exception entry.
+        ///
+        /// On exception entry, the processor uses bit[9] of the stacked PSR to indicate the stack
+        /// alignment. On return from the exception it uses this stacked bit to restore the correct
+        /// stack alignment.
         STKALIGN: u1,
-        padding: u22 = 0,
+        reserved2: u22 = 0,
     }),
-    reserved1: u32,
-    /// System Handlers Priority Register 2
-    SHPR2: u32,
-    /// System Handlers Priority Register 3
-    SHPR3: u32,
+    /// System Handlers Priority Registers.
+    SHPR: [3]u32,
 };
 
 pub const NestedVectorInterruptController = extern struct {
-    // Interrupt Set-Enable Register
+    /// Interrupt Set-Enable Register.
     ISER: u32,
     reserved0: [31]u32,
-    // Interrupt Clear-Enable Register
+    /// Interrupt Clear-Enable Register.
     ICER: u32,
     reserved1: [31]u32,
-    /// Interrupt Set-Pending Register
+    /// Interrupt Set-Pending Register.
     ISPR: u32,
     reserved2: [31]u32,
-    /// Interrupt Clear-Pending Register
+    /// Interrupt Clear-Pending Register.
     ICPR: u32,
     reserved3: [95]u32,
-    /// Interrupt Priority Registers
+    /// Interrupt Priority Registers.
+    ///
+    /// Each priority field holds a priority value, 0-192. The lower the value, the greater the
+    /// priority of the corresponding interrupt. The processor implements only bits [7:6] of each
+    /// field, bits [5:0] read as zero and ignore writes. This means writing 255 to a priority
+    /// register saves value 192 to the register.
     IPR: [8]u32,
 };

--- a/core/src/cpus/cortex_m/m0plus.zig
+++ b/core/src/cpus/cortex_m/m0plus.zig
@@ -77,7 +77,7 @@ pub const SystemControlBlock = extern struct {
     VTOR: u32,
     /// Application Interrupt and Reset Control Register.
     AIRCR: mmio.Mmio(packed struct {
-        reserved0: u1,
+        reserved0: u1 = 0,
         /// Reserved for debug use. This bit reads as 0. When writing to the register you must
         /// write 0 to this bit, otherwise behavior is Unpredictable.
         VECTCLRACTIVE: u1,
@@ -87,7 +87,7 @@ pub const SystemControlBlock = extern struct {
         ///
         /// This bit reads as 0.
         SYSRESETREQ: u1,
-        reserved1: u12,
+        reserved1: u12 = 0,
         /// Data endianness implemented:
         /// 0 = Little-endian
         /// 1 = Big-endian.
@@ -99,7 +99,7 @@ pub const SystemControlBlock = extern struct {
     }),
     /// System Control Register.
     SCR: mmio.Mmio(packed struct(u32) {
-        reserved0: u1,
+        reserved0: u1 = 0,
         /// Indicates sleep-on-exit when returning from Handler mode to Thread mode:
         /// 0 = do not sleep when returning to Thread mode.
         /// 1 = enter sleep, or deep sleep, on return from an ISR to Thread mode.
@@ -114,7 +114,7 @@ pub const SystemControlBlock = extern struct {
         /// If your device does not support two sleep modes, the effect of changing the value
         /// of this bit is implementation-defined.
         SLEEPDEEP: u1,
-        reserved1: u1,
+        reserved1: u1 = 0,
         /// Send Event on Pending bit:
         /// 0 = only enabled interrupts or events can wakeup the processor, disabled interrupts are excluded
         /// 1 = enabled events and all interrupts, including disabled interrupts, can wakeup the processor.
@@ -124,7 +124,7 @@ pub const SystemControlBlock = extern struct {
         ///
         /// The processor also wakes up on execution of an SEV instruction or an external event.
         SEVONPEND: u1,
-        reserved2: u17,
+        reserved2: u17 = 0,
     }),
     /// Configuration Control Register.
     CCR: mmio.Mmio(packed struct(u32) {

--- a/core/src/cpus/cortex_m/m0plus.zig
+++ b/core/src/cpus/cortex_m/m0plus.zig
@@ -2,58 +2,167 @@ const microzig = @import("microzig");
 const mmio = microzig.mmio;
 
 pub const SystemControlBlock = extern struct {
-    /// CPUID Base Register
+    /// CPUID Base Register.
     CPUID: u32,
-    /// Interrupt Control And State Register
+    /// Interrupt Control and State Register.
     ICSR: mmio.Mmio(packed struct(u32) {
+        /// Contains the active exception number:
+        /// 0 = Thread mode
+        /// Nonzero = The exception number[a] of the currently active exception.
         VECTACTIVE: u6,
         reserved0: u6 = 0,
+        /// Indicates the exception number of the highest priority pending enabled exception:
+        /// 0 = no pending exceptions
+        /// Nonzero = the exception number of the highest priority pending enabled exception.
         VECTPENDING: u6,
         reserved1: u4 = 0,
+        /// Interrupt pending flag, excluding NMI and Faults:
+        /// 0 = interrupt not pending
+        /// 1 = interrupt pending.
         ISRPENDING: u1,
         reserved2: u2 = 0,
+        /// SysTick exception clear-pending bit.
+        ///
+        /// Write:
+        /// 0 = no effect
+        /// 1 = removes the pending state from the SysTick exception.
+        ///
+        /// This bit is WO. On a register read its value is Unknown.
+        /// If your device does not implement the SysTick timer, this bit is Reserved.
         PENDSTCLR: u1,
+        /// SysTick exception set-pending bit.
+        ///
+        /// Write:
+        /// 0 = no effect1 = changes SysTick exception state to pending.
+        /// Read:
+        /// 0 = SysTick exception is not pending
+        /// 1 = SysTick exception is pending.
+        ///
+        /// If your device does not implement the SysTick timer, this bit is Reserved.
         PENDSTSET: u1,
+        /// PendSV clear-pending bit.
+        ///
+        /// Write:
+        /// 0 = no effect
+        /// 1 = removes the pending state from the PendSV exception.
         PENDSVCLR: u1,
+        /// PendSV set-pending bit.
+        ///
+        /// Write:
+        /// 0 = no effect
+        /// 1 = changes PendSV exception state to pending.
+        /// Read:
+        /// 0 = PendSV exception is not pending
+        /// 1 = PendSV exception is pending.
+        ///
+        /// Writing 1 to this bit is the only way to set the PendSV exception state to pending.
         PENDSVSET: u1,
         reserved3: u2 = 0,
+        /// NMI set-pending bit.
+        ///
+        /// Write:
+        /// 0 = no effect
+        /// 1 = changes NMI exception state to pending.
+        /// Read:
+        /// 0 = NMI exception is not pending
+        /// 1 = NMI exception is pending.
+        ///
+        /// Because NMI is the highest-priority exception, normally the processor enters the NMI
+        /// exception handler as soon as it detects a write of 1 to this bit. Entering the handler
+        /// then clears this bit to 0. This means a read of this bit by the NMI exception handler
+        /// returns 1 only if the NMI signal is reasserted while the processor is executing that handler.
         NMIPENDSET: u1,
     }),
-    /// Vector Table Offset Register
+    /// Vector Table Offset Register.
     VTOR: u32,
-    /// Application Interrupt And Reset Control Register
-    AIRCR: u32,
-    /// System Control Register
-    SCR: u32,
-    /// Configuration Control Register
+    /// Application Interrupt and Reset Control Register.
+    AIRCR: mmio.Mmio(packed struct {
+        reserved0: u1,
+        /// Reserved for debug use. This bit reads as 0. When writing to the register you must
+        /// write 0 to this bit, otherwise behavior is Unpredictable.
+        VECTCLRACTIVE: u1,
+        /// System reset request:
+        /// 0 = no effect
+        /// 1 = requests a system level reset.
+        ///
+        /// This bit reads as 0.
+        SYSRESETREQ: u1,
+        reserved1: u12,
+        /// Data endianness implemented:
+        /// 0 = Little-endian
+        /// 1 = Big-endian.
+        ENDIANESS: u1,
+        /// Register key:
+        /// Reads as Unknown
+        /// On writes, write 0x05FA to VECTKEY, otherwise the write is ignored.
+        VECTKEY: u16,
+    }),
+    /// System Control Register.
+    SCR: mmio.Mmio(packed struct(u32) {
+        reserved0: u1,
+        /// Indicates sleep-on-exit when returning from Handler mode to Thread mode:
+        /// 0 = do not sleep when returning to Thread mode.
+        /// 1 = enter sleep, or deep sleep, on return from an ISR to Thread mode.
+        ///
+        /// Setting this bit to 1 enables an interrupt driven application to avoid returning
+        /// to an empty main application.
+        SLEEPONEXIT: u1,
+        /// Controls whether the processor uses sleep or deep sleep as its low power mode:
+        /// 0 = sleep
+        /// 1 = deep sleep.
+        ///
+        /// If your device does not support two sleep modes, the effect of changing the value
+        /// of this bit is implementation-defined.
+        SLEEPDEEP: u1,
+        reserved1: u1,
+        /// Send Event on Pending bit:
+        /// 0 = only enabled interrupts or events can wakeup the processor, disabled interrupts are excluded
+        /// 1 = enabled events and all interrupts, including disabled interrupts, can wakeup the processor.
+        ///
+        /// When an event or interrupt enters pending state, the event signal wakes up the processor from WFE.
+        /// If the processor is not waiting for an event, the event is registered and affects the next WFE.
+        ///
+        /// The processor also wakes up on execution of an SEV instruction or an external event.
+        SEVONPEND: u1,
+        reserved2: u17,
+    }),
+    /// Configuration Control Register.
     CCR: mmio.Mmio(packed struct(u32) {
         reserved0: u3 = 0,
+        /// Always reads as one, indicates that all unaligned accesses generate a HardFault.
         UNALIGN_TRP: u1,
         reserved1: u5 = 0,
+        /// Always reads as one, indicates 8-byte stack alignment on exception entry.
+        ///
+        /// On exception entry, the processor uses bit[9] of the stacked PSR to indicate the stack
+        /// alignment. On return from the exception it uses this stacked bit to restore the correct
+        /// stack alignment.
         STKALIGN: u1,
-        padding: u22 = 0,
+        reserved2: u22 = 0,
     }),
-    reserved0: u32,
-    /// System Handlers Priority Register 2
-    SHPR2: u32,
-    /// System Handlers Priority Register 3
-    SHPR3: u32,
+    /// System Handlers Priority Registers.
+    SHPR: [3]u32,
 };
 
 pub const NestedVectorInterruptController = extern struct {
-    // Interrupt Set-Enable Register
+    /// Interrupt Set-Enable Register.
     ISER: u32,
     reserved0: [31]u32,
-    // Interrupt Clear-Enable Register
+    /// Interrupt Clear-Enable Register.
     ICER: u32,
     reserved1: [31]u32,
-    /// Interrupt Set-Pending Register
+    /// Interrupt Set-Pending Register.
     ISPR: u32,
     reserved2: [31]u32,
-    /// Interrupt Clear-Pending Register
+    /// Interrupt Clear-Pending Register.
     ICPR: u32,
     reserved3: [95]u32,
-    /// Interrupt Priority Registers
+    /// Interrupt Priority Registers.
+    ///
+    /// Each priority field holds a priority value, 0-192. The lower the value, the greater the
+    /// priority of the corresponding interrupt. The processor implements only bits [7:6] of each
+    /// field, bits [5:0] read as zero and ignore writes. This means writing 255 to a priority
+    /// register saves value 192 to the register.
     IPR: [8]u32,
 };
 
@@ -67,7 +176,7 @@ pub const MemoryProtectionUnit = extern struct {
         DREGION: u8,
         /// Number of instruction regions supported by the MPU.
         IREGION: u8,
-        padding: u8,
+        reserved1: u8,
     }),
     /// MPU Control Register
     CTRL: mmio.Mmio(packed struct(u32) {
@@ -77,13 +186,13 @@ pub const MemoryProtectionUnit = extern struct {
         HFNMIENA: u1,
         /// Enables priviledged software access to default memory map.
         PRIVDEFENA: u1,
-        _reserved0: u29,
+        reserved0: u29 = 0,
     }),
     /// MPU Region Number Register
     RNR: mmio.Mmio(packed struct(u32) {
         /// Indicates the memory region accessed by MPU RBAR and PMU RLAR.
         REGION: u8,
-        _reserved0: u24,
+        reserved0: u24 = 0,
     }),
     /// MPU Region Base Address Register
     RBAR: mmio.Mmio(packed struct(u32) {
@@ -100,7 +209,7 @@ pub const MemoryProtectionUnit = extern struct {
         ENABLE: u1,
         /// Specifies the size of the MPU region. The minimum permitted value is 7 (b00111).
         SIZE: u5,
-        reserved0: u2,
+        reserved0: u2 = 0,
         /// Subregion disable bits.
         SRD: u3,
         /// Bufferable bit.
@@ -109,12 +218,12 @@ pub const MemoryProtectionUnit = extern struct {
         C: u1,
         /// Shareable bit.
         S: u1,
-        reserved1: u5,
+        reserved1: u5 = 0,
         /// Access permission field.
         AP: u3,
-        reserved2: u1,
+        reserved2: u1 = 0,
         /// Instruction access disable bit.
         XN: u1,
-        padding: u3,
+        reserved3: u3 = 0,
     }),
 };

--- a/core/src/cpus/cortex_m/m0plus.zig
+++ b/core/src/cpus/cortex_m/m0plus.zig
@@ -1,20 +1,120 @@
-pub const SystemControlBlock = @compileError("TODO");
+const micro = @import("microzig");
+const mmio = micro.mmio;
 
-pub const NestedVectorInterruptController = extern struct {
-    /// Interrupt set registers.
-    ISER: u32,
-    _reserved0: [31]u32,
-    /// Interrupt clear enable registers.
-    ICER: u32,
-    _reserved1: [31]u32,
-    /// Interrupt set pending registers.
-    ISPR: u32,
-    _reserved2: [31]u32,
-    /// Interrupt clear pending registers.
-    ICPR: u32,
-    _reserved3: [31]u32,
-    /// Interrupt priority registers.
-    IPR: [28]u8,
+pub const SystemControlBlock = extern struct {
+    /// CPUID Base Register
+    CPUID: u32,
+    /// Interrupt Control And State Register
+    ICSR: mmio.Mmio(packed struct(u32) {
+        VECTACTIVE: u6,
+        reserved0: u6 = 0,
+        VECTPENDING: u6,
+        reserved1: u4 = 0,
+        ISRPENDING: u1,
+        reserved2: u2 = 0,
+        PENDSTCLR: u1,
+        PENDSTSET: u1,
+        PENDSVCLR: u1,
+        PENDSVSET: u1,
+        reserved3: u2 = 0,
+        NMIPENDSET: u1,
+    }),
+    /// Vector Table Offset Register
+    VTOR: u32,
+    /// Application Interrupt And Reset Control Register
+    AIRCR: u32,
+    /// System Control Register
+    SCR: u32,
+    /// Configuration Control Register
+    CCR: mmio.Mmio(packed struct(u32) {
+        reserved0: u3 = 0,
+        UNALIGN_TRP: u1,
+        reserved1: u5 = 0,
+        STKALIGN: u1,
+        padding: u22 = 0,
+    }),
+    reserved0: u32,
+    /// System Handlers Priority Register 2
+    SHPR2: u32,
+    /// System Handlers Priority Register 3
+    SHPR3: u32,
 };
 
-pub const MemoryProtectionUnit = @compileError("TODO");
+pub const NestedVectorInterruptController = extern struct {
+    // Interrupt Set-Enable Register
+    ISER: u32,
+    reserved0: [31]u32,
+    // Interrupt Clear-Enable Register
+    ICER: u32,
+    reserved1: [31]u32,
+    /// Interrupt Set-Pending Register
+    ISPR: u32,
+    reserved2: [31]u32,
+    /// Interrupt Clear-Pending Register
+    ICPR: u32,
+    reserved3: [95]u32,
+    /// Interrupt Priority Registers
+    IPR: [8]u32,
+};
+
+pub const MemoryProtectionUnit = extern struct {
+    /// MPU Type Register
+    TYPE: mmio.Mmio(packed struct(u32) {
+        /// Indicates support for unified or separate instructions and data address regions.
+        SEPARATE: u1,
+        reserved0: u7,
+        /// Number of data regions supported by the MPU.
+        DREGION: u8,
+        /// Number of instruction regions supported by the MPU.
+        IREGION: u8,
+        padding: u8,
+    }),
+    /// MPU Control Register
+    CTRL: mmio.Mmio(packed struct(u32) {
+        /// Enables the MPU
+        ENABLE: u1,
+        /// Enables of operation of MPU during HardFault and MNIHandlers.
+        HFNMIENA: u1,
+        /// Enables priviledged software access to default memory map.
+        PRIVDEFENA: u1,
+        _reserved0: u29,
+    }),
+    /// MPU Region Number Register
+    RNR: mmio.Mmio(packed struct(u32) {
+        /// Indicates the memory region accessed by MPU RBAR and PMU RLAR.
+        REGION: u8,
+        _reserved0: u24,
+    }),
+    /// MPU Region Base Address Register
+    RBAR: mmio.Mmio(packed struct(u32) {
+        /// MPU region field.
+        REGION: u4,
+        /// MPU region number valid bit.
+        VALID: u1,
+        /// Region base address field.
+        ADDR: u27,
+    }),
+    /// MPU Attribute and Size Register
+    RASR: mmio.Mmio(packed struct(u32) {
+        /// Region enable bit.
+        ENABLE: u1,
+        /// Specifies the size of the MPU region. The minimum permitted value is 7 (b00111).
+        SIZE: u5,
+        reserved0: u2,
+        /// Subregion disable bits.
+        SRD: u3,
+        /// Bufferable bit.
+        B: u1,
+        /// Cacheable bit.
+        C: u1,
+        /// Shareable bit.
+        S: u1,
+        reserved1: u5,
+        /// Access permission field.
+        AP: u3,
+        reserved2: u1,
+        /// Instruction access disable bit.
+        XN: u1,
+        padding: u3,
+    }),
+};

--- a/core/src/cpus/cortex_m/m0plus.zig
+++ b/core/src/cpus/cortex_m/m0plus.zig
@@ -1,5 +1,5 @@
-const micro = @import("microzig");
-const mmio = micro.mmio;
+const microzig = @import("microzig");
+const mmio = microzig.mmio;
 
 pub const SystemControlBlock = extern struct {
     /// CPUID Base Register

--- a/core/src/cpus/cortex_m/m3.zig
+++ b/core/src/cpus/cortex_m/m3.zig
@@ -1,3 +1,166 @@
-pub const SystemControlBlock = @compileError("TODO");
-pub const NestedVectorInterruptController = @compileError("TODO");
-pub const MemoryProtectionUnit = @compileError("TODO");
+const micro = @import("microzig");
+const mmio = micro.mmio;
+
+pub const SystemControlBlock = extern struct {
+    /// CPUID Base Register
+    CPUID: u32,
+    /// Interrupt Control and State Register
+    ICSR: mmio.Mmio(packed struct(u32) {
+        VECTACTIVE: u9,
+        reserved0: u2 = 0,
+        RETTOBASE: u1,
+        VECTPENDING: u6,
+        reserved1: u4 = 0,
+        ISRPENDING: u1,
+        ISRPREEMPT: u1,
+        reserved2: u1 = 0,
+        PENDSTCLR: u1,
+        PENDSTSET: u1,
+        PENDSVCLR: u1,
+        PENDSVSET: u1,
+        reserved3: u2 = 0,
+        NMIPENDSET: u1,
+    }),
+    /// Vector Table Offset Register
+    VTOR: u32,
+    /// Application Interrupt  and Reset Control Register
+    AIRCR: u32,
+    /// System Control Register
+    SCR: u32,
+    /// Configuration Control Register
+    CCR: mmio.Mmio(packed struct(u32) {
+        NONBASETHRDENA: u1,
+        USERSETMPEND: u1,
+        reserved0: u1 = 0,
+        UNALIGN_TRP: u1,
+        DIV_0_TRP: u1,
+        reserved1: u3 = 0,
+        BFHFNMIGN: u1,
+        STKALIGN: u1,
+        padding: u22 = 0,
+    }),
+    /// System Handlers Priority Registers
+    SHP: [12]u8,
+    /// System Handler Control and State Register
+    SHCSR: u32,
+    /// Configurable Fault Status Register.
+    CFSR: mmio.Mmio(packed struct(u32) {
+        /// MemManage Fault Register.
+        MMFSR: u8,
+        /// BusFault Status Register.
+        BFSR: u8,
+        /// Usage Fault Status Register.
+        UFSR: u16,
+    }),
+    /// HardFault Status Register
+    HFSR: u32,
+    reserved1: u32,
+    /// MemManage Fault Address Register
+    MMFAR: u32,
+    /// BusFault Address Register
+    BFAR: u32,
+    /// Auxilary Feature Register
+    AFSR: u32,
+};
+
+pub const NestedVectorInterruptController = extern struct {
+    // Interrupt Set-Enable Registers
+    ISER: [8]u32,
+    reserved0: [24]u32,
+    // Interrupt Clear-Enable Registers
+    ICER: [8]u32,
+    reserved1: [24]u32,
+    /// Interrupt Set-Pending Registers
+    ISPR: [8]u32,
+    reserved2: [24]u32,
+    /// Interrupt Clear-Pending Registers
+    ICPR: [8]u32,
+    reserved3: [24]u32,
+    /// Interrupt Active Bit Registers
+    IABR: [8]u32,
+    reserved4: [56]u32,
+    /// Interrupt Priority Registers
+    IPR: [240]u8,
+    reserved5: [644]u32,
+    /// Software Trigger Interrupt Registers
+    STIR: u32,
+};
+
+pub const MemoryProtectionUnit = extern struct {
+    /// MPU Type Register
+    TYPE: mmio.Mmio(packed struct(u32) {
+        /// Indicates support for unified or separate instructions and data address regions.
+        SEPARATE: u1,
+        reserved0: u7,
+        /// Number of data regions supported by the MPU.
+        DREGION: u8,
+        /// Number of instruction regions supported by the MPU.
+        IREGION: u8,
+        padding: u8,
+    }),
+    /// MPU Control Register
+    CTRL: mmio.Mmio(packed struct(u32) {
+        /// Enables the MPU
+        ENABLE: u1,
+        /// Enables of operation of MPU during HardFault and MNIHandlers.
+        HFNMIENA: u1,
+        /// Enables priviledged software access to default memory map.
+        PRIVDEFENA: u1,
+        padding: u29,
+    }),
+    /// MPU Region Number Register
+    RNR: mmio.Mmio(packed struct(u32) {
+        /// Indicates the memory region accessed by MPU RBAR and PMU RLAR.
+        REGION: u8,
+        padding: u24,
+    }),
+    /// MPU Region Base Address Register
+    RBAR: RBAR,
+    /// MPU Region Attribute and Size Register
+    RASR: RASR,
+    /// MPU Alias 1 Region Base Address Register
+    RBAR_A1: RBAR,
+    /// MPU Alias 1 Region Attribute and Size Register
+    RASR_A1: RASR,
+    /// MPU Alias 2 Region Base Address Register
+    RBAR_A2: RBAR,
+    /// MPU Alias 2 Region Attribute and Size Register
+    RASR_A2: RASR,
+    /// MPU Alias 3 Region Base Address Register
+    RBAR_A3: RBAR,
+    /// MPU Alias 3 Region Attribute and Size Register
+    RASR_A3: RASR,
+
+    pub const RBAR = mmio.Mmio(packed struct(u32) {
+        /// MPU region field.
+        REGION: u4,
+        /// MPU region number valid bit.
+        VALID: u1,
+        /// Region base address field.
+        ADDR: u27,
+    });
+
+    pub const RASR = mmio.Mmio(packed struct(u32) {
+        /// Region enable bit.
+        ENABLE: u1,
+        /// Specifies the size of the MPU protection region.
+        SIZE: u5,
+        reserved0: u2,
+        /// Subregion disable bits.
+        SRD: u8,
+        /// Shareable bit.
+        S: u1,
+        /// Memory Access Attribute.
+        B: u1,
+        /// Memory Access Attribute.
+        C: u1,
+        /// Memory Access Attribute.
+        TEX: u3,
+        reserved1: u2,
+        /// Access permission field.
+        AP: u3,
+        /// Instruction access disable bit.
+        XN: u1,
+        padding: u3,
+    });
+};

--- a/core/src/cpus/cortex_m/m3.zig
+++ b/core/src/cpus/cortex_m/m3.zig
@@ -23,7 +23,7 @@ pub const SystemControlBlock = extern struct {
     }),
     /// Vector Table Offset Register
     VTOR: u32,
-    /// Application Interrupt  and Reset Control Register
+    /// Application Interrupt and Reset Control Register
     AIRCR: u32,
     /// System Control Register
     SCR: u32,
@@ -82,7 +82,7 @@ pub const NestedVectorInterruptController = extern struct {
     /// Interrupt Priority Registers
     IPR: [240]u8,
     reserved5: [644]u32,
-    /// Software Trigger Interrupt Registers
+    /// Software Trigger Interrupt Register
     STIR: u32,
 };
 

--- a/core/src/cpus/cortex_m/m3.zig
+++ b/core/src/cpus/cortex_m/m3.zig
@@ -37,7 +37,7 @@ pub const SystemControlBlock = extern struct {
         reserved1: u3 = 0,
         BFHFNMIGN: u1,
         STKALIGN: u1,
-        padding: u22 = 0,
+        reserved2: u22 = 0,
     }),
     /// System Handlers Priority Registers
     SHP: [12]u8,
@@ -91,12 +91,12 @@ pub const MemoryProtectionUnit = extern struct {
     TYPE: mmio.Mmio(packed struct(u32) {
         /// Indicates support for unified or separate instructions and data address regions.
         SEPARATE: u1,
-        reserved0: u7,
+        reserved0: u7 = 0,
         /// Number of data regions supported by the MPU.
         DREGION: u8,
         /// Number of instruction regions supported by the MPU.
         IREGION: u8,
-        padding: u8,
+        reserved1: u8 = 0,
     }),
     /// MPU Control Register
     CTRL: mmio.Mmio(packed struct(u32) {
@@ -106,13 +106,13 @@ pub const MemoryProtectionUnit = extern struct {
         HFNMIENA: u1,
         /// Enables priviledged software access to default memory map.
         PRIVDEFENA: u1,
-        padding: u29,
+        reserved0: u29 = 0,
     }),
     /// MPU Region Number Register
     RNR: mmio.Mmio(packed struct(u32) {
         /// Indicates the memory region accessed by MPU RBAR and PMU RLAR.
         REGION: u8,
-        padding: u24,
+        reserved0: u24 = 0,
     }),
     /// MPU Region Base Address Register
     RBAR: RBAR,
@@ -145,7 +145,7 @@ pub const MemoryProtectionUnit = extern struct {
         ENABLE: u1,
         /// Specifies the size of the MPU protection region.
         SIZE: u5,
-        reserved0: u2,
+        reserved0: u2 = 0,
         /// Subregion disable bits.
         SRD: u8,
         /// Shareable bit.
@@ -156,11 +156,11 @@ pub const MemoryProtectionUnit = extern struct {
         C: u1,
         /// Memory Access Attribute.
         TEX: u3,
-        reserved1: u2,
+        reserved1: u2 = 0,
         /// Access permission field.
         AP: u3,
         /// Instruction access disable bit.
         XN: u1,
-        padding: u3,
+        reserved2: u3 = 0,
     });
 };

--- a/core/src/cpus/cortex_m/m3.zig
+++ b/core/src/cpus/cortex_m/m3.zig
@@ -2,9 +2,9 @@ const microzig = @import("microzig");
 const mmio = microzig.mmio;
 
 pub const SystemControlBlock = extern struct {
-    /// CPUID Base Register
+    /// CPUID Base Register.
     CPUID: u32,
-    /// Interrupt Control and State Register
+    /// Interrupt Control and State Register.
     ICSR: mmio.Mmio(packed struct(u32) {
         VECTACTIVE: u9,
         reserved0: u2 = 0,
@@ -21,13 +21,29 @@ pub const SystemControlBlock = extern struct {
         reserved3: u2 = 0,
         NMIPENDSET: u1,
     }),
-    /// Vector Table Offset Register
+    /// Vector Table Offset Register.
     VTOR: u32,
-    /// Application Interrupt and Reset Control Register
-    AIRCR: u32,
-    /// System Control Register
-    SCR: u32,
-    /// Configuration Control Register
+    /// Application Interrupt and Reset Control Register.
+    AIRCR: mmio.Mmio(packed struct {
+        VECTRESET: u1,
+        VECTCLRACTIVE: u1,
+        SYSRESETREQ: u1,
+        reserved0: u5 = 0,
+        PRIGROUP: u3,
+        reserved1: u4 = 0,
+        ENDIANNESS: u1,
+        VECTKEY: u16,
+    }),
+    /// System Control Register.
+    SCR: mmio.Mmio(packed struct {
+        reserved0: u1 = 0,
+        SLEEPONEXIT: u1,
+        SLEEPDEEP: u1,
+        reserved1: u1 = 0,
+        SEVONPEND: u1,
+        reserved2: u27 = 0,
+    }),
+    /// Configuration Control Register.
     CCR: mmio.Mmio(packed struct(u32) {
         NONBASETHRDENA: u1,
         USERSETMPEND: u1,
@@ -39,9 +55,9 @@ pub const SystemControlBlock = extern struct {
         STKALIGN: u1,
         reserved2: u22 = 0,
     }),
-    /// System Handlers Priority Registers
-    SHP: [12]u8,
-    /// System Handler Control and State Register
+    /// System Handlers Priority Registers.
+    SHPR: [3]u32,
+    /// System Handler Control and State Register.
     SHCSR: u32,
     /// Configurable Fault Status Register.
     CFSR: mmio.Mmio(packed struct(u32) {
@@ -52,14 +68,14 @@ pub const SystemControlBlock = extern struct {
         /// Usage Fault Status Register.
         UFSR: u16,
     }),
-    /// HardFault Status Register
+    /// HardFault Status Register.
     HFSR: u32,
     reserved1: u32,
-    /// MemManage Fault Address Register
+    /// MemManage Fault Address Register.
     MMFAR: u32,
-    /// BusFault Address Register
+    /// BusFault Address Register.
     BFAR: u32,
-    /// Auxilary Feature Register
+    /// Auxilary Feature Register.
     AFSR: u32,
 };
 

--- a/core/src/cpus/cortex_m/m3.zig
+++ b/core/src/cpus/cortex_m/m3.zig
@@ -1,5 +1,5 @@
-const micro = @import("microzig");
-const mmio = micro.mmio;
+const microzig = @import("microzig");
+const mmio = microzig.mmio;
 
 pub const SystemControlBlock = extern struct {
     /// CPUID Base Register

--- a/core/src/cpus/cortex_m/m33.zig
+++ b/core/src/cpus/cortex_m/m33.zig
@@ -4,28 +4,6 @@ const microzig = @import("microzig");
 const mmio = microzig.mmio;
 
 pub const SystemControlBlock = extern struct {
-    /// Auxiliary Control Base Register.
-    ACTLR: mmio.Mmio(packed struct(u32) {
-        /// Disables interruption of multi-cycle instructions.
-        DISMCYCINT: u1,
-        _reserved0: u1,
-        /// Disables dual-issue functionality.
-        DISFOLD: u1,
-        _reserved1: u6 = 0,
-        /// Disables floating-point instructions completing out of order with respect to non-floating point.
-        /// instructions
-        DISOOFP: u1,
-        /// Disables FPU exception outputs.
-        FPEXCODIS: u1,
-        _reserved2: u1,
-        /// Disables ITM and DWT ATB flush.
-        DISITMATBFLUSH: u1,
-        _reserved3: u16,
-        /// Setting EXTEXCLALL allows external exclusive operations to be used in a configuration with no
-        /// MPU. This is because the default memory map does not include any shareable Normal memory.
-        EXTEXCLALL: u1,
-        _reserved4: u2 = 0,
-    }),
     /// CPUID Base Register.
     CPUID: u32,
     /// Interrupt Control and State Register.
@@ -38,28 +16,28 @@ pub const SystemControlBlock = extern struct {
     SCR: u32,
     /// Configuration and Control Register.
     CCR: mmio.Mmio(packed struct(u32) {
-        _reserved0: u1 = 0,
+        reserved0: u1 = 0,
         /// User set pending determines if unpriviledged access to the STIR generates a fault.
         USERSETMPEND: u1,
-        _reserved1: u1 = 0,
+        reserved1: u1 = 0,
         /// Unaligned trap controls trapping of unaligned word and half word accesses.
         UNALIGN_TRP: u1,
         /// Divide by zero trap controls generation of DIVBYZERO usage fault.
         DIV_0_TRP: u1,
-        _reserved2: u2 = 0,
+        reserved2: u3 = 0,
         /// Determines effect of precise bus faults running on handlers at requested priority less than 0.
         BFHFNMIGN: u1,
-        _reserved3: u1 = 0,
+        reserved3: u1 = 0,
         /// Controls effect of stack limit violation while executing at a requested priority less than 0.
         STKOFHFNMIGN: u1,
-        _reserved4: u5 = 0,
+        reserved4: u5 = 0,
         /// Read as zero/write ignored.
         DC: u1,
         /// Read as zero/write ignored.
         IC: u1,
         /// Read as zero/write ignored.
         BP: u1,
-        _reserved5: u12 = 0,
+        padding: u13 = 0,
     }),
     /// System Handler Priority Registers.
     SHPR: [12]u8,
@@ -76,14 +54,16 @@ pub const SystemControlBlock = extern struct {
     }),
     /// HardFault Status Register.
     HFSR: u32,
-    _reserved0: [2]u32,
+    reserved0: u32,
     /// MemManage Fault Address Register.
     MMFAR: u32,
     /// BusFault Address Register.
     BFAR: u32,
     /// Auxiliary Fault Status Register not implemented.
     _AFSR: u32,
-    _reserved1: [19]u32,
+    reserved1: [18]u32,
+    /// Coprocessor Access Control Register
+    CPACR: u32,
     /// Non-secure Access Control Register.
     NSACR: u32,
 };
@@ -91,25 +71,25 @@ pub const SystemControlBlock = extern struct {
 pub const NestedVectorInterruptController = extern struct {
     /// Interrupt set registers.
     ISER: [16]u32,
-    _reserved0: [2]u32,
+    reserved0: [16]u32,
     /// Interrupt clear enable registers.
     ICER: [16]u32,
-    _reserved1: [2]u32,
+    reserved1: [16]u32,
     /// Interrupt set pending registers.
     ISPR: [16]u32,
-    _reserved2: [2]u32,
+    reserved2: [16]u32,
     /// Interrupt clear pending registers.
     ICPR: [16]u32,
-    _reserved3: [2]u32,
+    reserved3: [16]u32,
     /// Interrupt active bit registers.
     IABR: [16]u32,
-    _reserved4: [2]u32,
+    reserved4: [16]u32,
     /// Interrupt target non-secure registers.
     ITNS: [16]u32,
-    _reserved5: [2]u32,
+    reserved5: [16]u32,
     /// Interrupt priority registers.
     IPR: [480]u8,
-    _reserved6: [73]u32,
+    reserved6: [584]u32,
     /// Software trigger interrupt register.
     STIR: u32,
 };
@@ -136,10 +116,10 @@ pub const MemoryProtectionUnit = extern struct {
     TYPE: mmio.Mmio(packed struct(u32) {
         /// Indicates support for unified or separate instructions and data address regions.
         SEPARATE: u1,
-        _reserved0: u7,
+        reserved0: u7,
         /// Number of data regions supported by the MPU.
         DREGION: u8,
-        _reserved1: u16,
+        reserved1: u16,
     }),
     /// MPU Control Register
     CTRL: mmio.Mmio(packed struct(u32) {
@@ -149,13 +129,13 @@ pub const MemoryProtectionUnit = extern struct {
         HFNMIENA: u1,
         /// Enables priviledged software access to default memory map.
         PRIVDEFENA: u1,
-        _reserved0: u29,
+        reserved0: u29,
     }),
     /// MPU Region Number Register
     RNR: mmio.Mmio(packed struct(u32) {
         /// Indicates the memory region accessed by MPU RBAR and PMU RLAR.
         REGION: u8,
-        _reserved0: u24,
+        reserved0: u24,
     }),
     /// MPU Region Base Address Register.
     RBAR: RBAR,
@@ -173,7 +153,7 @@ pub const MemoryProtectionUnit = extern struct {
     RLAR_A2: RLAR,
     /// MPU Region Base Address Register Alias 3.
     RLAR_A3: RLAR,
-    _reserved0: [20]u8,
+    reserved0: [20]u8,
     /// MPU Memory Addribute Indirection Register 0.
     MPU_MAIR0: u32,
     /// MPU Memory Addribute Indirection Register 1.
@@ -198,7 +178,7 @@ pub const MemoryProtectionUnit = extern struct {
         EN: u1,
         /// Attribue Index associates a set of attributes in the MPU MAIR0 and MPU MAIR1 fields.
         AttrIndx: u3,
-        _reserved0: u1,
+        reserved0: u1,
         /// Limit Address contains bits [31:5] of the upper inclusive limit of the selected MPU memory region. This
         /// value is postfixed with 0x1F to provide the limit address to be checked against.
         LIMIT: u27,

--- a/core/src/cpus/cortex_m/m33.zig
+++ b/core/src/cpus/cortex_m/m33.zig
@@ -37,7 +37,7 @@ pub const SystemControlBlock = extern struct {
         IC: u1,
         /// Read as zero/write ignored.
         BP: u1,
-        padding: u13 = 0,
+        reserved5: u13 = 0,
     }),
     /// System Handler Priority Registers.
     SHPR: [12]u8,
@@ -62,35 +62,35 @@ pub const SystemControlBlock = extern struct {
     /// Auxiliary Fault Status Register not implemented.
     _AFSR: u32,
     reserved1: [18]u32,
-    /// Coprocessor Access Control Register
+    /// Coprocessor Access Control Register.
     CPACR: u32,
     /// Non-secure Access Control Register.
     NSACR: u32,
 };
 
 pub const NestedVectorInterruptController = extern struct {
-    /// Interrupt set registers.
+    /// Interrupt Set Registers.
     ISER: [16]u32,
     reserved0: [16]u32,
-    /// Interrupt clear enable registers.
+    /// Interrupt Clear Enable Registers.
     ICER: [16]u32,
     reserved1: [16]u32,
-    /// Interrupt set pending registers.
+    /// Interrupt Set Pending Registers.
     ISPR: [16]u32,
     reserved2: [16]u32,
-    /// Interrupt clear pending registers.
+    /// Interrupt Clear Pending Registers.
     ICPR: [16]u32,
     reserved3: [16]u32,
-    /// Interrupt active bit registers.
+    /// Interrupt Active Bit Registers.
     IABR: [16]u32,
     reserved4: [16]u32,
-    /// Interrupt target non-secure registers.
+    /// Interrupt Target Non-secure Registers.
     ITNS: [16]u32,
     reserved5: [16]u32,
-    /// Interrupt priority registers.
+    /// Interrupt Priority Registers.
     IPR: [480]u8,
     reserved6: [584]u32,
-    /// Software trigger interrupt register.
+    /// Software Trigger Interrupt Register.
     STIR: u32,
 };
 
@@ -112,16 +112,16 @@ pub const SecurityAttributionUnit = extern struct {
 };
 
 pub const MemoryProtectionUnit = extern struct {
-    /// MPU Type Register
+    /// MPU Type Register.
     TYPE: mmio.Mmio(packed struct(u32) {
         /// Indicates support for unified or separate instructions and data address regions.
         SEPARATE: u1,
-        reserved0: u7,
+        reserved0: u7 = 0,
         /// Number of data regions supported by the MPU.
         DREGION: u8,
-        reserved1: u16,
+        reserved1: u16 = 0,
     }),
-    /// MPU Control Register
+    /// MPU Control Register.
     CTRL: mmio.Mmio(packed struct(u32) {
         /// Enables the MPU
         ENABLE: u1,
@@ -129,13 +129,13 @@ pub const MemoryProtectionUnit = extern struct {
         HFNMIENA: u1,
         /// Enables priviledged software access to default memory map.
         PRIVDEFENA: u1,
-        reserved0: u29,
+        reserved0: u29 = 0,
     }),
-    /// MPU Region Number Register
+    /// MPU Region Number Register.
     RNR: mmio.Mmio(packed struct(u32) {
         /// Indicates the memory region accessed by MPU RBAR and PMU RLAR.
         REGION: u8,
-        reserved0: u24,
+        reserved0: u24 = 0,
     }),
     /// MPU Region Base Address Register.
     RBAR: RBAR,
@@ -178,7 +178,7 @@ pub const MemoryProtectionUnit = extern struct {
         EN: u1,
         /// Attribue Index associates a set of attributes in the MPU MAIR0 and MPU MAIR1 fields.
         AttrIndx: u3,
-        reserved0: u1,
+        reserved0: u1 = 0,
         /// Limit Address contains bits [31:5] of the upper inclusive limit of the selected MPU memory region. This
         /// value is postfixed with 0x1F to provide the limit address to be checked against.
         LIMIT: u27,

--- a/core/src/cpus/cortex_m/m4.zig
+++ b/core/src/cpus/cortex_m/m4.zig
@@ -37,7 +37,7 @@ pub const SystemControlBlock = extern struct {
         reserved1: u3 = 0,
         BFHFNMIGN: u1,
         STKALIGN: u1,
-        padding: u22 = 0,
+        reserved2: u22 = 0,
     }),
     /// System Handlers Priority Registers
     SHP: [12]u8,
@@ -92,12 +92,12 @@ pub const MemoryProtectionUnit = extern struct {
     TYPE: mmio.Mmio(packed struct(u32) {
         /// Indicates support for unified or separate instructions and data address regions.
         SEPARATE: u1,
-        reserved0: u7,
+        reserved0: u7 = 0,
         /// Number of data regions supported by the MPU.
         DREGION: u8,
         /// Number of instruction regions supported by the MPU.
         IREGION: u8,
-        padding: u8,
+        reserved1: u8,
     }),
     /// MPU Control Register
     CTRL: mmio.Mmio(packed struct(u32) {
@@ -107,13 +107,13 @@ pub const MemoryProtectionUnit = extern struct {
         HFNMIENA: u1,
         /// Enables priviledged software access to default memory map.
         PRIVDEFENA: u1,
-        padding: u29,
+        reserved0: u29 = 0,
     }),
     /// MPU Region Number Register
     RNR: mmio.Mmio(packed struct(u32) {
         /// Indicates the memory region accessed by MPU RBAR and PMU RLAR.
         REGION: u8,
-        padding: u24,
+        reserved0: u24 = 0,
     }),
     /// MPU Region Base Address Register
     RBAR: RBAR,
@@ -146,7 +146,7 @@ pub const MemoryProtectionUnit = extern struct {
         ENABLE: u1,
         /// Specifies the size of the MPU protection region.
         SIZE: u5,
-        reserved0: u2,
+        reserved0: u2 = 0,
         /// Subregion disable bits.
         SRD: u8,
         /// Shareable bit.
@@ -157,11 +157,11 @@ pub const MemoryProtectionUnit = extern struct {
         C: u1,
         /// Memory Access Attribute.
         TEX: u3,
-        reserved1: u2,
+        reserved1: u2 = 0,
         /// Access permission field.
         AP: u3,
         /// Instruction access disable bit.
         XN: u1,
-        padding: u3,
+        reserved2: u3 = 0,
     });
 };

--- a/core/src/cpus/cortex_m/m4.zig
+++ b/core/src/cpus/cortex_m/m4.zig
@@ -9,8 +9,8 @@ pub const SystemControlBlock = extern struct {
         VECTACTIVE: u9,
         reserved0: u2 = 0,
         RETTOBASE: u1,
-        VECTPENDING: u9,
-        reserved1: u1 = 0,
+        VECTPENDING: u6,
+        reserved1: u4 = 0,
         ISRPENDING: u1,
         ISRPREEMPT: u1,
         reserved2: u1 = 0,
@@ -31,20 +31,27 @@ pub const SystemControlBlock = extern struct {
     CCR: mmio.Mmio(packed struct(u32) {
         NONBASETHRDENA: u1,
         USERSETMPEND: u1,
-        _reserved0: u1 = 0,
+        reserved0: u1 = 0,
         UNALIGN_TRP: u1,
         DIV_0_TRP: u1,
-        _reserved1: u3 = 0,
+        reserved1: u3 = 0,
         BFHFNMIGN: u1,
         STKALIGN: u1,
-        _padding: u22 = 0,
+        padding: u22 = 0,
     }),
     /// System Handlers Priority Registers
     SHP: [12]u8,
     /// System Handler Contol and State Register
     SHCSR: u32,
-    /// Configurable Fault Status Register
-    CFSR: u32,
+    /// Configurable Fault Status Register.
+    CFSR: mmio.Mmio(packed struct(u32) {
+        /// MemManage Fault Register.
+        MMFSR: u8,
+        /// BusFault Status Register.
+        BFSR: u8,
+        /// Usage Fault Status Register.
+        UFSR: u16,
+    }),
     /// HardFault Status Register
     HFSR: u32,
     /// Debug Fault Status Register
@@ -55,55 +62,56 @@ pub const SystemControlBlock = extern struct {
     BFAR: u32,
     /// Auxilary Feature Register
     AFSR: u32,
-    /// Processor Feature Register
-    PFR: [2]u32,
-    /// Debug Feature Register
-    DFR: u32,
-    /// Auxilary Feature Register
-    ADR: u32,
-    /// Memory Model Feature Register
-    MMFR: [4]u32,
-    /// Instruction Set Attributes Register
-    ISAR: [5]u32,
-    RESERVED0: [5]u32,
-    /// Coprocessor Access Control Register
-    CPACR: u32,
 };
 
 pub const NestedVectorInterruptController = extern struct {
+    /// Interrupt Set-Enable Registers
     ISER: [8]u32,
-    _reserved0: [24]u32,
+    reserved0: [24]u32,
+    /// Interrupt Clear-Enable Registers
     ICER: [8]u32,
-    _reserved1: [24]u32,
+    reserved1: [24]u32,
+    /// Interrupt Set-Pending Registers
     ISPR: [8]u32,
-    _reserved2: [24]u32,
+    reserved2: [24]u32,
+    /// Interrupt Clear-Pending Registers
     ICPR: [8]u32,
-    _reserved3: [24]u32,
+    reserved3: [24]u32,
+    /// Interrupt Active Bit Registers
     IABR: [8]u32,
-    _reserved4: [56]u32,
-    IP: [240]u8,
-    _reserved5: [644]u32,
+    reserved4: [56]u32,
+    /// Interrupt Priority Registers
+    IPR: [240]u8,
+    reserved5: [644]u32,
+    /// Software Trigger Interrupt Registers
     STIR: u32,
 };
 
 pub const MemoryProtectionUnit = extern struct {
     /// MPU Type Register
     TYPE: mmio.Mmio(packed struct(u32) {
+        /// Indicates support for unified or separate instructions and data address regions.
         SEPARATE: u1,
-        _reserved0: u7,
+        reserved0: u7,
+        /// Number of data regions supported by the MPU.
         DREGION: u8,
+        /// Number of instruction regions supported by the MPU.
         IREGION: u8,
-        _reserved1: u8,
+        padding: u8,
     }),
     /// MPU Control Register
     CTRL: mmio.Mmio(packed struct(u32) {
+        /// Enables the MPU
         ENABLE: u1,
+        /// Enables of operation of MPU during HardFault and MNIHandlers.
         HFNMIENA: u1,
+        /// Enables priviledged software access to default memory map.
         PRIVDEFENA: u1,
         padding: u29,
     }),
-    /// MPU RNRber Register
+    /// MPU Region Number Register
     RNR: mmio.Mmio(packed struct(u32) {
+        /// Indicates the memory region accessed by MPU RBAR and PMU RLAR.
         REGION: u8,
         padding: u24,
     }),
@@ -125,32 +133,35 @@ pub const MemoryProtectionUnit = extern struct {
     RASR_A3: RASR,
 
     pub const RBAR = mmio.Mmio(packed struct(u32) {
+        /// MPU region field.
         REGION: u4,
+        /// MPU region number valid bit.
         VALID: u1,
+        /// Region base address field.
         ADDR: u27,
     });
 
     pub const RASR = mmio.Mmio(packed struct(u32) {
-        /// Region enable bit
+        /// Region enable bit.
         ENABLE: u1,
-        /// Region Size
+        /// Specifies the size of the MPU protection region.
         SIZE: u5,
-        _reserved0: u2,
-        /// Sub-Region Disable
+        reserved0: u2,
+        /// Subregion disable bits.
         SRD: u8,
-        /// ATTRS.B
-        B: u1,
-        /// ATTRS.C
-        C: u1,
-        /// ATTRS.S
+        /// Shareable bit.
         S: u1,
-        /// ATTRS.TEX
+        /// Memory Access Attribute.
+        B: u1,
+        /// Memory Access Attribute.
+        C: u1,
+        /// Memory Access Attribute.
         TEX: u3,
-        _reserved1: u2,
-        /// ATTRS.AP
+        reserved1: u2,
+        /// Access permission field.
         AP: u3,
-        /// ATTRS.XN
+        /// Instruction access disable bit.
         XN: u1,
-        padding: u4,
+        padding: u3,
     });
 };

--- a/core/src/cpus/cortex_m/m4.zig
+++ b/core/src/cpus/cortex_m/m4.zig
@@ -23,7 +23,7 @@ pub const SystemControlBlock = extern struct {
     }),
     /// Vector Table Offset Register.
     VTOR: u32,
-    /// Application Interrupt  and Reset Control Register.
+    /// Application Interrupt and Reset Control Register.
     AIRCR: u32,
     /// System Control Register.
     SCR: u32,

--- a/core/src/cpus/cortex_m/m4.zig
+++ b/core/src/cpus/cortex_m/m4.zig
@@ -2,9 +2,9 @@ const microzig = @import("microzig");
 const mmio = microzig.mmio;
 
 pub const SystemControlBlock = extern struct {
-    /// CPUID Base Register
+    /// CPUID Base Register.
     CPUID: u32,
-    /// Interrupt Control and State Register
+    /// Interrupt Control and State Register.
     ICSR: mmio.Mmio(packed struct(u32) {
         VECTACTIVE: u9,
         reserved0: u2 = 0,
@@ -21,13 +21,13 @@ pub const SystemControlBlock = extern struct {
         reserved3: u2 = 0,
         NMIPENDSET: u1,
     }),
-    /// Vector Table Offset Register
+    /// Vector Table Offset Register.
     VTOR: u32,
-    /// Application Interrupt  and Reset Control Register
+    /// Application Interrupt  and Reset Control Register.
     AIRCR: u32,
-    /// System Control Register
+    /// System Control Register.
     SCR: u32,
-    /// Configuration Control Register
+    /// Configuration Control Register.
     CCR: mmio.Mmio(packed struct(u32) {
         NONBASETHRDENA: u1,
         USERSETMPEND: u1,
@@ -39,9 +39,9 @@ pub const SystemControlBlock = extern struct {
         STKALIGN: u1,
         reserved2: u22 = 0,
     }),
-    /// System Handlers Priority Registers
+    /// System Handlers Priority Registers.
     SHP: [12]u8,
-    /// System Handler Contol and State Register
+    /// System Handler Contol and State Register.
     SHCSR: u32,
     /// Configurable Fault Status Register.
     CFSR: mmio.Mmio(packed struct(u32) {
@@ -52,43 +52,43 @@ pub const SystemControlBlock = extern struct {
         /// Usage Fault Status Register.
         UFSR: u16,
     }),
-    /// HardFault Status Register
+    /// HardFault Status Register.
     HFSR: u32,
-    /// Debug Fault Status Register
+    /// Debug Fault Status Register.
     DFSR: u32,
-    /// MemManage Fault Address Register
+    /// MemManage Fault Address Register.
     MMFAR: u32,
-    /// BusFault Address Register
+    /// BusFault Address Register.
     BFAR: u32,
-    /// Auxilary Feature Register
+    /// Auxilary Feature Register.
     AFSR: u32,
 };
 
 pub const NestedVectorInterruptController = extern struct {
-    /// Interrupt Set-Enable Registers
+    /// Interrupt Set-Enable Registers.
     ISER: [8]u32,
     reserved0: [24]u32,
-    /// Interrupt Clear-Enable Registers
+    /// Interrupt Clear-Enable Registers.
     ICER: [8]u32,
     reserved1: [24]u32,
-    /// Interrupt Set-Pending Registers
+    /// Interrupt Set-Pending Registers.
     ISPR: [8]u32,
     reserved2: [24]u32,
-    /// Interrupt Clear-Pending Registers
+    /// Interrupt Clear-Pending Registers.
     ICPR: [8]u32,
     reserved3: [24]u32,
-    /// Interrupt Active Bit Registers
+    /// Interrupt Active Bit Registers.
     IABR: [8]u32,
     reserved4: [56]u32,
-    /// Interrupt Priority Registers
+    /// Interrupt Priority Registers.
     IPR: [240]u8,
     reserved5: [644]u32,
-    /// Software Trigger Interrupt Registers
+    /// Software Trigger Interrupt Registers.
     STIR: u32,
 };
 
 pub const MemoryProtectionUnit = extern struct {
-    /// MPU Type Register
+    /// MPU Type Register.
     TYPE: mmio.Mmio(packed struct(u32) {
         /// Indicates support for unified or separate instructions and data address regions.
         SEPARATE: u1,
@@ -99,9 +99,9 @@ pub const MemoryProtectionUnit = extern struct {
         IREGION: u8,
         reserved1: u8,
     }),
-    /// MPU Control Register
+    /// MPU Control Register.
     CTRL: mmio.Mmio(packed struct(u32) {
-        /// Enables the MPU
+        /// Enables the MPU.
         ENABLE: u1,
         /// Enables of operation of MPU during HardFault and MNIHandlers.
         HFNMIENA: u1,
@@ -109,27 +109,27 @@ pub const MemoryProtectionUnit = extern struct {
         PRIVDEFENA: u1,
         reserved0: u29 = 0,
     }),
-    /// MPU Region Number Register
+    /// MPU Region Number Register.
     RNR: mmio.Mmio(packed struct(u32) {
         /// Indicates the memory region accessed by MPU RBAR and PMU RLAR.
         REGION: u8,
         reserved0: u24 = 0,
     }),
-    /// MPU Region Base Address Register
+    /// MPU Region Base Address Register.
     RBAR: RBAR,
-    /// MPU Region Attribute and Size Register
+    /// MPU Region Attribute and Size Register.
     RASR: RASR,
-    /// MPU Alias 1 Region Base Address Register
+    /// MPU Alias 1 Region Base Address Register.
     RBAR_A1: RBAR,
-    /// MPU Alias 1 Region Attribute and Size Register
+    /// MPU Alias 1 Region Attribute and Size Register.
     RASR_A1: RASR,
-    /// MPU Alias 2 Region Base Address Register
+    /// MPU Alias 2 Region Base Address Register.
     RBAR_A2: RBAR,
-    /// MPU Alias 2 Region Attribute and Size Register
+    /// MPU Alias 2 Region Attribute and Size Register.
     RASR_A2: RASR,
-    /// MPU Alias 3 Region Base Address Register
+    /// MPU Alias 3 Region Base Address Register.
     RBAR_A3: RBAR,
-    /// MPU Alias 3 Region Attribute and Size Register
+    /// MPU Alias 3 Region Attribute and Size Register.
     RASR_A3: RASR,
 
     pub const RBAR = mmio.Mmio(packed struct(u32) {

--- a/core/src/cpus/cortex_m/m4.zig
+++ b/core/src/cpus/cortex_m/m4.zig
@@ -24,9 +24,25 @@ pub const SystemControlBlock = extern struct {
     /// Vector Table Offset Register.
     VTOR: u32,
     /// Application Interrupt and Reset Control Register.
-    AIRCR: u32,
+    AIRCR: mmio.Mmio(packed struct {
+        VECTRESET: u1,
+        VECTCLRACTIVE: u1,
+        SYSRESETREQ: u1,
+        reserved0: u5 = 0,
+        PRIGROUP: u3,
+        reserved1: u4 = 0,
+        ENDIANNESS: u1,
+        VECTKEY: u16,
+    }),
     /// System Control Register.
-    SCR: u32,
+    SCR: mmio.Mmio(packed struct {
+        reserved0: u1 = 0,
+        SLEEPONEXIT: u1,
+        SLEEPDEEP: u1,
+        reserved1: u1 = 0,
+        SEVONPEND: u1,
+        reserved2: u27 = 0,
+    }),
     /// Configuration Control Register.
     CCR: mmio.Mmio(packed struct(u32) {
         NONBASETHRDENA: u1,


### PR DESCRIPTION
## Add cortex-m core peripherals

* I added `NVIC`, `SCB`, `SysTick` and `MPU` to all cortex-m cpus.
** There are some comments missing in cortex-m3 and cortex-m4 in some registers.
** In cortex-m33 some registers are still u32. The same for some in cortex-m3 and cortex-m4.
* Minimal refactoring in build.zig.