### PR TITLE
rp2xxx: Make pio.Irq.get_irq_regs public

### DIFF
--- a/port/raspberrypi/rp2xxx/src/hal/pio.zig
+++ b/port/raspberrypi/rp2xxx/src/hal/pio.zig
@@ -234,7 +234,7 @@ pub const Pio = enum(u1) {
         return &sm_regs[@intFromEnum(sm)];
     }
 
-    fn get_irq_regs(self: Pio, irq: Irq) *volatile Irq.Regs {
+    pub fn get_irq_regs(self: Pio, irq: Irq) *volatile Irq.Regs {
         const pio_regs = self.get_regs();
         const irq_regs = @as(*volatile [2]Irq.Regs, @ptrCast(&pio_regs.IRQ0_INTE));
         return &irq_regs[@intFromEnum(irq)];


### PR DESCRIPTION
This is needed, for example, to wait on an interrupt from a Pio program.

See https://github.com/Grazfather/microzig/commit/9fba01b5ae818607d4b6ae85b0bbb04840ddba43.

I would be open to adding some method to actually just wait on an interrupt, but not sure what you might want that interface to look like.