### PR TITLE
[RP2xxx] Update pins helper to create pins as comptime-available data instead of zero-sized-types

### DIFF
--- a/examples/raspberrypi/rp2xxx/src/blinky.zig
+++ b/examples/raspberrypi/rp2xxx/src/blinky.zig
@@ -10,8 +10,10 @@ const pin_config = rp2xxx.pins.GlobalConfiguration{
     },
 };
 
+const pins = pin_config.pins();
+
 pub fn main() !void {
-    const pins = pin_config.apply();
+    pin_config.apply();
 
     while (true) {
         pins.led.toggle();

--- a/examples/raspberrypi/rp2xxx/src/rp2040_only/pwm.zig
+++ b/examples/raspberrypi/rp2xxx/src/rp2040_only/pwm.zig
@@ -11,8 +11,10 @@ const pin_config = rp2xxx.pins.GlobalConfiguration{
     .GPIO25 = .{ .name = "led", .function = .PWM4_B },
 };
 
+const pins = pin_config.pins();
+
 pub fn main() !void {
-    const pins = pin_config.apply();
+    pin_config.apply();
     pins.led.slice().set_wrap(100);
     pins.led.slice().enable();
 

--- a/port/raspberrypi/rp2xxx/src/hal/pins.zig
+++ b/port/raspberrypi/rp2xxx/src/hal/pins.zig
@@ -395,7 +395,7 @@ pub const GlobalConfiguration = struct {
                 if (pin_config.function == .SIO) {
                     pin_field.type = gpio.Pin;
                 } else if (pin_config.function.is_pwm()) {
-                    pin_field.type = pwm.RuntimePwm;
+                    pin_field.type = pwm.Pwm;
                 } else if (pin_config.function.is_adc()) {
                     // TODO
                     // pin_field.type = adc.Input;
@@ -427,7 +427,7 @@ pub const GlobalConfiguration = struct {
                 if (pin_config.function == .SIO) {
                     @field(ret, pin_config.name orelse field.name) = gpio.num(@intFromEnum(@field(Pin, field.name)));
                 } else if (pin_config.function.is_pwm()) {
-                    @field(ret, pin_config.name orelse field.name) = pwm.RuntimePwm {
+                    @field(ret, pin_config.name orelse field.name) = pwm.Pwm {
                         .slice_number = pin_config.function.pwm_slice(),
                         .channel = pin_config.function.pwm_channel(),
                     };

--- a/port/raspberrypi/rp2xxx/src/hal/pins.zig
+++ b/port/raspberrypi/rp2xxx/src/hal/pins.zig
@@ -397,8 +397,7 @@ pub const GlobalConfiguration = struct {
                 } else if (pin_config.function.is_pwm()) {
                     pin_field.type = pwm.Pwm;
                 } else if (pin_config.function.is_adc()) {
-                    // TODO
-                    // pin_field.type = adc.Input;
+                    pin_field.type = adc.Input;
                 } else {
                     continue;
                 }
@@ -431,16 +430,15 @@ pub const GlobalConfiguration = struct {
                         .slice_number = pin_config.function.pwm_slice(),
                         .channel = pin_config.function.pwm_channel(),
                     };
+                } else if (pin_config.function.is_adc()) {
+                    @field(ret, pin_config.name orelse field.name) = @as(adc.Input, @enumFromInt(switch(pin_config.function) {
+                        .ADC0 => 0,
+                        .ADC1 => 1,
+                        .ADC2 => 2,
+                        .ADC3 => 3,
+                        else => unreachable,
+                    }));
                 }
-
-                // TODO
-                // } else if (pin_config.function.is_adc()) {
-                //     switch (pin_config.function) {
-                //         .ADC0 => &adc.Input.ain0,
-                //         .ADC1 => &adc.Input.ain1,
-                //         .ADC2 => &adc.Input.ain2,
-                //         .ADC3 => &adc.Input.ain3,
-                //         else => unreachable,
             }
         }
 
@@ -506,7 +504,10 @@ pub const GlobalConfiguration = struct {
                 } else if (comptime func.is_pwm()) {
                     pin.set_function(.pwm);
                 } else if (comptime func.is_adc()) {
+                    // Matches adc.Input.configure_gpio_pin
                     pin.set_function(.disabled);
+                    pin.set_pull(.disabled);
+                    pin.set_input_enabled(false);
                 } else if (comptime func.is_uart_tx() or func.is_uart_rx()) {
                     pin.set_function(.uart);
                 } else if (comptime func.is_spi()) {
@@ -538,8 +539,8 @@ pub const GlobalConfiguration = struct {
         }
 
         if (has_adc) {
-            adc.init();
+            // FIXME: https://github.com/ZigEmbeddedGroup/microzig/issues/311
+            // adc.init();
         }
-
     }
 };

--- a/port/raspberrypi/rp2xxx/src/hal/pins.zig
+++ b/port/raspberrypi/rp2xxx/src/hal/pins.zig
@@ -338,95 +338,6 @@ const function_table = [@typeInfo(Function).Enum.fields.len][30]u1{
     single(29), // ADC3
 };
 
-pub fn GPIO(comptime num: u5, comptime direction: gpio.Direction) type {
-    return switch (direction) {
-        .in => struct {
-            const pin = gpio.num(num);
-
-            pub inline fn read(self: @This()) u1 {
-                _ = self;
-                return pin.read();
-            }
-        },
-        .out => struct {
-            const pin = gpio.num(num);
-
-            pub inline fn put(self: @This(), value: u1) void {
-                _ = self;
-                pin.put(value);
-            }
-
-            pub inline fn toggle(self: @This()) void {
-                _ = self;
-                pin.toggle();
-            }
-        },
-    };
-}
-
-pub fn Pins(comptime config: GlobalConfiguration) type {
-    comptime {
-        var fields: []const StructField = &.{};
-        for (@typeInfo(GlobalConfiguration).Struct.fields) |field| {
-            if (@field(config, field.name)) |pin_config| {
-                var pin_field = StructField{
-                    .is_comptime = false,
-                    .default_value = null,
-
-                    // initialized below:
-                    .name = undefined,
-                    .type = undefined,
-                    .alignment = undefined,
-                };
-
-                if (pin_config.function == .SIO) {
-                    pin_field.name = pin_config.name orelse field.name;
-                    pin_field.type = GPIO(@intFromEnum(@field(Pin, field.name)), pin_config.direction orelse .in);
-                } else if (pin_config.function.is_pwm()) {
-                    pin_field.name = pin_config.name orelse @tagName(pin_config.function);
-                    pin_field.type = pwm.Pwm(pin_config.function.pwm_slice(), pin_config.function.pwm_channel());
-                } else if (pin_config.function.is_adc()) {
-                    pin_field.name = pin_config.name orelse @tagName(pin_config.function);
-                    pin_field.type = adc.Input;
-                    pin_field.default_value = @as(?*const anyopaque, @ptrCast(switch (pin_config.function) {
-                        .ADC0 => &adc.Input.ain0,
-                        .ADC1 => &adc.Input.ain1,
-                        .ADC2 => &adc.Input.ain2,
-                        .ADC3 => &adc.Input.ain3,
-                        else => unreachable,
-                    }));
-                } else {
-                    continue;
-                }
-
-                // if (pin_field.default_value == null) {
-                //     if (@sizeOf(pin_field.field_type) > 0) {
-                //         pin_field.default_value = @ptrCast(?*const anyopaque, &pin_field.field_type{});
-                //     } else {
-                //         const Struct = struct {
-                //             magic_field: pin_field.field_type = .{},
-                //         };
-                //         pin_field.default_value = @typeInfo(Struct).Struct.fields[0].default_value;
-                //     }
-                // }
-
-                pin_field.alignment = @alignOf(field.type);
-
-                fields = fields ++ &[_]StructField{pin_field};
-            }
-        }
-
-        return @Type(.{
-            .Struct = .{
-                .layout = .auto,
-                .is_tuple = false,
-                .fields = fields,
-                .decls = &.{},
-            },
-        });
-    }
-}
-
 pub const GlobalConfiguration = struct {
     GPIO0: ?Pin.Configuration = null,
     GPIO1: ?Pin.Configuration = null,
@@ -466,7 +377,77 @@ pub const GlobalConfiguration = struct {
             @compileError(comptimePrint("{} {}", .{ pin_field_count, config_field_count }));
     }
 
-    pub fn apply(comptime config: GlobalConfiguration) Pins(config) {
+    pub fn PinsType(self: GlobalConfiguration) type {
+        var fields: []const StructField = &.{};
+        for (@typeInfo(GlobalConfiguration).Struct.fields) |field| {
+            if (@field(self, field.name)) |pin_config| {
+                var pin_field = StructField{
+                    .is_comptime = false,
+                    .default_value = null,
+
+                    // initialized below:
+                    .name = undefined,
+                    .type = undefined,
+                    .alignment = undefined,
+                };
+
+                pin_field.name = pin_config.name orelse field.name;
+                if (pin_config.function == .SIO) {
+                    pin_field.type = gpio.Pin;
+                } else if (pin_config.function.is_pwm()) {
+                    pin_field.type = pwm.RuntimePwm;
+                } else if (pin_config.function.is_adc()) {
+                    // TODO
+                    // pin_field.type = adc.Input;
+                } else {
+                    continue;
+                }
+
+                pin_field.alignment = @alignOf(field.type);
+
+                fields = fields ++ &[_]StructField{pin_field};
+            }
+        }
+
+        return @Type(.{
+            .Struct = .{
+                .layout = .auto,
+                .is_tuple = false,
+                .fields = fields,
+                .decls = &.{},
+            },
+        });
+    }
+
+    // Can be called at comptime or runtime
+    pub fn pins(comptime self: GlobalConfiguration) self.PinsType() {
+        var ret: self.PinsType() = undefined;
+        inline for (@typeInfo(GlobalConfiguration).Struct.fields) |field| {
+            if (@field(self, field.name)) |pin_config| {
+                if (pin_config.function == .SIO) {
+                    @field(ret, pin_config.name orelse field.name) = gpio.num(@intFromEnum(@field(Pin, field.name)));
+                } else if (pin_config.function.is_pwm()) {
+                    @field(ret, pin_config.name orelse field.name) = pwm.RuntimePwm {
+                        .slice_number = pin_config.function.pwm_slice(),
+                        .channel = pin_config.function.pwm_channel(),
+                    };
+                }
+
+                // TODO
+                // } else if (pin_config.function.is_adc()) {
+                //     switch (pin_config.function) {
+                //         .ADC0 => &adc.Input.ain0,
+                //         .ADC1 => &adc.Input.ain1,
+                //         .ADC2 => &adc.Input.ain2,
+                //         .ADC3 => &adc.Input.ain3,
+                //         else => unreachable,
+            }
+        }
+
+        return ret;
+    }
+
+    pub fn apply(comptime config: GlobalConfiguration) void {
         comptime var input_gpios: u32 = 0;
         comptime var output_gpios: u32 = 0;
         comptime var has_adc = false;
@@ -560,18 +541,5 @@ pub const GlobalConfiguration = struct {
             adc.init();
         }
 
-        // fields in the Pins(config) type should be zero sized, so we just
-        // default build them all (wasn't sure how to do that cleanly in
-        // `Pins()`
-        var ret: Pins(config) = undefined;
-        inline for (@typeInfo(Pins(config)).Struct.fields) |field| {
-            if (field.default_value) |default_value| {
-                @field(ret, field.name) = @as(*const field.field_type, @ptrCast(default_value)).*;
-            } else {
-                @field(ret, field.name) = .{};
-            }
-        }
-
-        return ret;
     }
 };

--- a/port/raspberrypi/rp2xxx/src/hal/pwm.zig
+++ b/port/raspberrypi/rp2xxx/src/hal/pwm.zig
@@ -15,6 +15,31 @@ fn get_regs(slice: u32) *volatile Regs {
 
 pub const Channel = enum(u1) { a, b };
 
+pub const Slice = enum (u32) {
+    _,
+
+    pub fn set_wrap(self: Slice, wrap: u16) void {
+        set_slice_wrap(@intFromEnum(self), wrap);
+    }
+
+    pub fn enable(self: Slice) void {
+        get_regs(@intFromEnum(self)).csr.modify(.{ .EN = 1 });
+    }
+
+    pub fn disable(self: Slice) void {
+        get_regs(@intFromEnum(self)).csr.modify(.{ .EN = 0 });
+    }
+
+    pub fn set_phase_correct(self: Slice, phase_correct: bool) void {
+        set_slice_phase_correct(@intFromEnum(self), phase_correct);
+    }
+
+    pub fn set_clk_div(self: Slice, integer: u8, fraction: u4) void {
+        set_slice_clk_div(@intFromEnum(self), integer, fraction);
+    }
+};
+
+
 // An instance of Pwm corresponds to one of the 16 total channels
 //  (There are eight slices and each has two channels)
 pub const Pwm = struct {
@@ -25,12 +50,8 @@ pub const Pwm = struct {
         set_channel_level(self.slice_number, self.channel, level);
     }
 
-    pub fn set_wrap(self: Pwm, wrap: u16) void {
-        set_slice_wrap(self.slice_number, wrap);
-    }
-
-    pub fn enable(self: Pwm) void {
-        get_regs(self.slice_number).csr.modify(.{ .EN = 1 });
+    pub fn slice(self: Pwm) Slice {
+        return @enumFromInt(self.slice_number);
     }
 };
 

--- a/port/raspberrypi/rp2xxx/src/hal/pwm.zig
+++ b/port/raspberrypi/rp2xxx/src/hal/pwm.zig
@@ -6,19 +6,47 @@ const log = std.log.scoped(.pwm);
 
 pub const Config = struct {};
 
-fn get_regs(comptime slice: u32) *volatile Regs {
+fn get_regs(slice: u32) *volatile Regs {
     @import("std").debug.assert(slice < 8);
     const PwmType = microzig.chip.types.peripherals.PWM;
     const reg_diff = comptime @offsetOf(PwmType, "CH1_CSR") - @offsetOf(PwmType, "CH0_CSR");
     return @as(*volatile Regs, @ptrFromInt(@intFromPtr(PWM) + reg_diff * slice));
 }
 
-pub fn Pwm(comptime slice_num: u32, comptime chan: Channel) type {
+// NOTE: There are 16 Channels, so this struct could be called Channel.
+//  Each slice has two channels, and so the channel field isn't storing enough information to
+//  uniquely identify a channel--its only storing which of the two channels for the current slice it is
+pub const RuntimePwm = struct {
+    slice_number: u32,
+    channel: Channel,
+
+    pub fn set_level(self: RuntimePwm, level: u16) void {
+        set_channel_level(self.slice_number, self.channel, level);
+    }
+
+    pub fn set_wrap(self: RuntimePwm, wrap: u16) void {
+        set_slice_wrap(self.slice_number, wrap);
+    }
+
+    pub fn enable(self: RuntimePwm) void {
+        get_regs(self.slice_number).csr.modify(.{ .EN = 1 });
+    }
+};
+
+// NOTE: What the frick is this
+pub fn instance(slice_number: u32, channel: Channel) RuntimePwm {
+    return RuntimePwm {
+        .slice_number = slice_number,
+        .channel = channel,
+    };
+}
+
+pub fn Pwm(slice_num: u32, chan: Channel) type {
     return struct {
         pub const slice_number = slice_num;
         pub const channel = chan;
 
-        pub inline fn set_level(_: @This(), level: u16) void {
+        pub fn set_level(_: @This(), level: u16) void {
             set_channel_level(slice_number, channel, level);
         }
 
@@ -32,23 +60,23 @@ pub fn Slice(comptime slice_num: u32) type {
     return struct {
         const slice_number = slice_num;
 
-        pub inline fn set_wrap(_: @This(), wrap: u16) void {
+        pub fn set_wrap(_: @This(), wrap: u16) void {
             set_slice_wrap(slice_number, wrap);
         }
 
-        pub inline fn enable(_: @This()) void {
+        pub fn enable(_: @This()) void {
             get_regs(slice_number).csr.modify(.{ .EN = 1 });
         }
 
-        pub inline fn disable(_: @This()) void {
+        pub fn disable(_: @This()) void {
             get_regs(slice_number).csr.modify(.{ .EN = 0 });
         }
 
-        pub inline fn set_phase_correct(_: @This(), phase_correct: bool) void {
+        pub fn set_phase_correct(_: @This(), phase_correct: bool) void {
             set_slice_phase_correct(slice_number, phase_correct);
         }
 
-        pub inline fn set_clk_div(_: @This(), integer: u8, fraction: u4) void {
+        pub fn set_clk_div(_: @This(), integer: u8, fraction: u4) void {
             set_slice_clk_div(slice_number, integer, fraction);
         }
     };
@@ -71,31 +99,31 @@ const Regs = extern struct {
     top: @TypeOf(PWM.CH0_TOP),
 };
 
-pub inline fn set_slice_phase_correct(comptime slice: u32, phase_correct: bool) void {
-    log.debug("PWM{} set phase correct: {}", .{ slice, phase_correct });
+pub fn set_slice_phase_correct(comptime slice: u32, phase_correct: bool) void {
+    // log.debug("PWM{} set phase correct: {}", .{ slice, phase_correct });
     get_regs(slice).csr.modify(.{
         .PH_CORRECT = @intFromBool(phase_correct),
     });
 }
 
-pub inline fn set_slice_clk_div(comptime slice: u32, integer: u8, fraction: u4) void {
-    log.debug("PWM{} set clk div: {}.{}", .{ slice, integer, fraction });
+pub fn set_slice_clk_div(comptime slice: u32, integer: u8, fraction: u4) void {
+    // log.debug("PWM{} set clk div: {}.{}", .{ slice, integer, fraction });
     get_regs(slice).div.modify(.{
         .INT = integer,
         .FRAC = fraction,
     });
 }
 
-pub inline fn set_slice_clk_div_mode(comptime slice: u32, mode: ClkDivMode) void {
-    log.debug("PWM{} set clk div mode: {}", .{ slice, mode });
+pub fn set_slice_clk_div_mode(comptime slice: u32, mode: ClkDivMode) void {
+    // log.debug("PWM{} set clk div mode: {}", .{ slice, mode });
     get_regs(slice).csr.modify(.{
         .DIVMODE = @intFromEnum(mode),
     });
 }
 
-pub inline fn set_channel_inversion(
-    comptime slice: u32,
-    comptime channel: Channel,
+pub fn set_channel_inversion(
+    slice: u32,
+    channel: Channel,
     invert: bool,
 ) void {
     switch (channel) {
@@ -108,17 +136,18 @@ pub inline fn set_channel_inversion(
     }
 }
 
-pub inline fn set_slice_wrap(comptime slice: u32, wrap: u16) void {
-    log.debug("PWM{} set wrap: {}", .{ slice, wrap });
+pub fn set_slice_wrap(slice: u32, wrap: u16) void {
+    // log.debug("PWM{} set wrap: {}", .{ slice, wrap });
     get_regs(slice).top.raw = wrap;
 }
 
-pub inline fn set_channel_level(
-    comptime slice: u32,
-    comptime channel: Channel,
+pub fn set_channel_level(
+    slice: u32,
+    channel: Channel,
     level: u16,
 ) void {
     log.debug("PWM{} {} set level: {}", .{ slice, channel, level });
+    // asm volatile ("" ::: "memory");
     switch (channel) {
         .a => get_regs(slice).cc.modify(.{ .A = level }),
         .b => get_regs(slice).cc.modify(.{ .B = level }),


### PR DESCRIPTION
**TL;DR:** Replaces `pins = pin_config.apply()` with `pins = comptime pin_config.pins(); pin_config.apply()`.

**Long version:**
This PR updates the "pin configuration helper," `pins.GlobalConfiguration`, to return a `pins` type which is more suitable for normal usage than the ad-hoc zero-sized-types previously created. For example, a `pins.led_a` could be saved into a runtime struct or passed to a struct initializer at comptime, just like a primitive Zig value. In order to make this possible, there are a couple of distinct changes being made:

1. For .sio-function pins, the resulting pin is now a `gpio.Pin`. This removes the previous ZSTs and unifies the API. As well as making these data that can be used at runtime.
2. For pwm-function pins, the Pwm type has been rewritten to be a runtime-compatible struct, instead of a zero-sized type. (Previously interacting with runtime-known Pwm pin numbers was impossible.)
3. Instead of having `pin_config.apply()` return the `pins` type, as was previously the case, `.apply()` now returns nothing and `pin_config.pins()` returns the `pins`. This was necessary in order to allow `pins` to exist as normal Zig data. (Since `apply` has to be called at runtime, only the type of the return value is known at `comptime`.)

The only breaking change for users is splitting calls to `apply()` into a new call to `pins()`. (See the change to the examples for an example of what that looks like.)

This represents a regression in that you will no longer get compile-errors for e.g. reading from an output pin. This is acceptable to me for the time being because it matches our philosophy for the rest of the HAL—configuration is the user's responsibility. However, I'm not opposed to changing the GPIO interface to be stricter, and I have a couple of ideas on how to do that. But fundamentally I think that change would need to happen to `gpio.Pin` (e.g. maybe it splits into `gpio.ReadPin` and `gpio.WritePin`)—I don't think it's tenable to have a split in the type system between a configured pin and an unconfigured pin.

I'm 99% sure that accessing an ADC-type pin on main right now doesn't work. Since the ADC code is old, it could really use a rewrite, so I've left it broken in this PR (replaced it with a TODO). I'm happy to update the pin configuration helper to support ADC if it's clear what we want to do with the HAL.