### PR TITLE
core: Fix wrong cpu name for cortex m0 plus

### DIFF
--- a/core/src/core/usb/cdc.zig
+++ b/core/src/core/usb/cdc.zig
@@ -7,10 +7,10 @@ const DescType = types.DescType;
 const bos = utils.BosConfig;
 
 pub const DescSubType = enum(u8) {
-    Header         = 0x00,
+    Header = 0x00,
     CallManagement = 0x01,
-    ACM            = 0x02,
-    Union          = 0x06,
+    ACM = 0x02,
+    Union = 0x06,
 
     pub fn from_u16(v: u16) ?@This() {
         return std.meta.intToEnum(@This(), v) catch null;
@@ -18,19 +18,17 @@ pub const DescSubType = enum(u8) {
 };
 
 pub const CdcManagementRequestType = enum(u8) {
-    SetLineCoding       = 0x20,
-    GetLineCoding       = 0x21,
+    SetLineCoding = 0x20,
+    GetLineCoding = 0x21,
     SetControlLineState = 0x22,
-    SendBreak           = 0x23,
+    SendBreak = 0x23,
 
     pub fn from_u8(v: u8) ?@This() {
         return std.meta.intToEnum(@This(), v) catch null;
     }
 };
 
-pub const CdcCommSubClassType = enum(u8) {
-    AbstractControlModel = 2
-};
+pub const CdcCommSubClassType = enum(u8) { AbstractControlModel = 2 };
 
 pub const CdcHeaderDescriptor = extern struct {
     length: u8 = 5,
@@ -145,7 +143,7 @@ pub fn CdcClassDriver(comptime usb: anytype) type {
             return self.rx.readableLength();
         }
 
-        pub fn read(self: *@This(), dst: [] u8) usize {
+        pub fn read(self: *@This(), dst: []u8) usize {
             const read_count = self.rx.read(dst);
             self.prep_out_transaction();
             return read_count;
@@ -156,7 +154,7 @@ pub fn CdcClassDriver(comptime usb: anytype) type {
 
             if (write_count > 0) {
                 self.tx.writeAssumeCapacity(data[0..write_count]);
-            } else { 
+            } else {
                 return data[0..];
             }
 
@@ -189,12 +187,7 @@ pub fn CdcClassDriver(comptime usb: anytype) type {
         fn init(ptr: *anyopaque, device: types.UsbDevice) void {
             var self: *@This() = @ptrCast(@alignCast(ptr));
             self.device = device;
-            self.line_coding = .{ 
-                .bit_rate = 115200,
-                .stop_bits = 0,
-                .parity = 0,
-                .data_bits = 8
-            };
+            self.line_coding = .{ .bit_rate = 115200, .stop_bits = 0, .parity = 0, .data_bits = 8 };
         }
 
         fn open(ptr: *anyopaque, cfg: []const u8) !usize {
@@ -202,8 +195,10 @@ pub fn CdcClassDriver(comptime usb: anytype) type {
             var curr_cfg = cfg;
 
             if (bos.try_get_desc_as(types.InterfaceDescriptor, curr_cfg)) |desc_itf| {
-                if (desc_itf.interface_class != @intFromEnum(types.ClassCode.Cdc)) return types.DriverErrors.UnsupportedInterfaceClassType;
-                if (desc_itf.interface_subclass != @intFromEnum(CdcCommSubClassType.AbstractControlModel)) return types.DriverErrors.UnsupportedInterfaceSubClassType;
+                if (desc_itf.interface_class != @intFromEnum(types.ClassCode.Cdc))
+                    return types.DriverErrors.UnsupportedInterfaceClassType;
+                if (desc_itf.interface_subclass != @intFromEnum(CdcCommSubClassType.AbstractControlModel))
+                    return types.DriverErrors.UnsupportedInterfaceSubClassType;
             } else {
                 return types.DriverErrors.ExpectedInterfaceDescriptor;
             }
@@ -225,8 +220,12 @@ pub fn CdcClassDriver(comptime usb: anytype) type {
                     for (0..2) |_| {
                         if (bos.try_get_desc_as(types.EndpointDescriptor, curr_cfg)) |desc_ep| {
                             switch (types.Endpoint.dir_from_address(desc_ep.endpoint_address)) {
-                                .In => { self.ep_in = desc_ep.endpoint_address; },
-                                .Out => { self.ep_out = desc_ep.endpoint_address; },
+                                .In => {
+                                    self.ep_in = desc_ep.endpoint_address;
+                                },
+                                .Out => {
+                                    self.ep_out = desc_ep.endpoint_address;
+                                },
                             }
                             self.device.?.endpoint_open(curr_cfg[0..desc_ep.length]);
                             curr_cfg = bos.get_desc_next(curr_cfg);
@@ -249,7 +248,7 @@ pub fn CdcClassDriver(comptime usb: anytype) type {
                                 // HACK, we should handle data phase somehow to read sent line_coding
                                 self.device.?.control_ack(setup);
                             },
-                            else => {}
+                            else => {},
                         }
                     },
                     .GetLineCoding => {
@@ -262,7 +261,7 @@ pub fn CdcClassDriver(comptime usb: anytype) type {
                             .Setup => {
                                 self.device.?.control_ack(setup);
                             },
-                            else => {}
+                            else => {},
                         }
                     },
                     .SendBreak => {
@@ -270,9 +269,9 @@ pub fn CdcClassDriver(comptime usb: anytype) type {
                             .Setup => {
                                 self.device.?.control_ack(setup);
                             },
-                            else => {}
+                            else => {},
                         }
-                    }
+                    },
                 }
             }
 
@@ -289,7 +288,7 @@ pub fn CdcClassDriver(comptime usb: anytype) type {
 
             if (ep_addr == self.ep_in) {
                 if (self.write_flush() == 0) {
-                    // If there is no data left, a empty packet should be sent if 
+                    // If there is no data left, a empty packet should be sent if
                     // data len is multiple of EP Packet size and not zero
                     if (self.tx.readableLength() == 0 and data.len > 0 and data.len == usb.max_packet_size) {
                         self.device.?.endpoint_transfer(self.ep_in, &.{});
@@ -304,7 +303,7 @@ pub fn CdcClassDriver(comptime usb: anytype) type {
                 .fn_init = init,
                 .fn_open = open,
                 .fn_class_control = class_control,
-                .fn_transfer = transfer
+                .fn_transfer = transfer,
             };
         }
     };

--- a/core/src/cpus/cortex_m.zig
+++ b/core/src/cpus/cortex_m.zig
@@ -241,7 +241,7 @@ pub const types = struct {
                 /// 0 = external clock
                 /// 1 = processor clock.
                 CLKSOURCE: u1,
-                reserved0: u13 = 0,
+                reserved0: u13,
                 /// Returns 1 if timer counted to 0 since last time this was read.
                 COUNTFLAG: u1,
                 reserved1: u15,
@@ -250,21 +250,21 @@ pub const types = struct {
             LOAD: mmio.Mmio(packed struct(u32) {
                 /// Value to load into the VAL register when the counter is enabled and when it reaches 0.
                 RELOAD: u24,
-                reserved0: u8 = 0,
+                reserved0: u8,
             }),
             /// Current Value Register.
             VAL: mmio.Mmio(packed struct(u32) {
                 /// Reads return the current value of the SysTick counter.
                 /// A write of any value clears the field to 0, and also clears the CTRL.COUNTFLAG bit to 0.
                 CURRENT: u24,
-                reserved0: u8 = 0,
+                reserved0: u8,
             }),
             /// Calibration Register.
             CALIB: mmio.Mmio(packed struct(u32) {
                 /// Reload value for 10ms (100Hz) timing, subject to system clock skew errors. If the value
                 /// reads as zero, the calibration value is not known.
                 TENMS: u24,
-                reserved0: u6 = 0,
+                reserved0: u6,
                 /// Indicates whether the TENMS value is exact.
                 /// 0 = TENMS value is exact
                 /// 1 = TENMS value is inexact, or not given.

--- a/core/src/cpus/cortex_m.zig
+++ b/core/src/cpus/cortex_m.zig
@@ -157,7 +157,7 @@ const mpu_present = @hasDecl(properties, "__MPU_PRESENT") and std.mem.eql(u8, pr
 
 const Core = enum {
     cortex_m0,
-    cortex_m0p,
+    cortex_m0plus,
     cortex_m3,
     cortex_m33,
     cortex_m4,
@@ -170,7 +170,7 @@ const cortex_m = std.meta.stringToEnum(Core, microzig.config.cpu_name) orelse
 const core = blk: {
     break :blk switch (cortex_m) {
         .cortex_m0 => @import("cortex_m/m0"),
-        .cortex_m0p => @import("cortex_m/m0plus.zig"),
+        .cortex_m0plus => @import("cortex_m/m0plus.zig"),
         .cortex_m3 => @import("cortex_m/m3.zig"),
         .cortex_m33 => @import("cortex_m/m33.zig"),
         .cortex_m4 => @import("cortex_m/m4.zig"),
@@ -241,7 +241,7 @@ pub const types = struct {
                 /// 0 = external clock
                 /// 1 = processor clock.
                 CLKSOURCE: u1,
-                reserved0: u13,
+                reserved0: u13 = 0,
                 /// Returns 1 if timer counted to 0 since last time this was read.
                 COUNTFLAG: u1,
                 reserved1: u15,
@@ -250,21 +250,21 @@ pub const types = struct {
             LOAD: mmio.Mmio(packed struct(u32) {
                 /// Value to load into the VAL register when the counter is enabled and when it reaches 0.
                 RELOAD: u24,
-                reserved0: u8,
+                reserved0: u8 = 0,
             }),
             /// Current Value Register.
             VAL: mmio.Mmio(packed struct(u32) {
                 /// Reads return the current value of the SysTick counter.
                 /// A write of any value clears the field to 0, and also clears the CTRL.COUNTFLAG bit to 0.
                 CURRENT: u24,
-                reserved0: u8,
+                reserved0: u8 = 0,
             }),
             /// Calibration Register.
             CALIB: mmio.Mmio(packed struct(u32) {
                 /// Reload value for 10ms (100Hz) timing, subject to system clock skew errors. If the value
                 /// reads as zero, the calibration value is not known.
                 TENMS: u24,
-                reserved0: u6,
+                reserved0: u6 = 0,
                 /// Indicates whether the TENMS value is exact.
                 /// 0 = TENMS value is exact
                 /// 1 = TENMS value is inexact, or not given.
@@ -274,7 +274,7 @@ pub const types = struct {
                 /// Indicates whether the device provides a reference clock to the processor:
                 /// 0 = reference clock provided
                 /// 1 = no reference clock provided.
-                /// If your device does not provide a reference clock, the SYST_CSR.CLKSOURCE bit reads-as-one
+                /// If your device does not provide a reference clock, the CTRL.CLKSOURCE bit reads-as-one
                 /// and ignores writes.
                 NOREF: u1,
             }),

--- a/core/src/cpus/cortex_m/m0.zig
+++ b/core/src/cpus/cortex_m/m0.zig
@@ -10,17 +10,17 @@ pub const SystemControlBlock = extern struct {
         /// 0 = Thread mode
         /// Nonzero = The exception number[a] of the currently active exception.
         VECTACTIVE: u6,
-        reserved0: u6 = 0,
+        reserved0: u6,
         /// Indicates the exception number of the highest priority pending enabled exception:
         /// 0 = no pending exceptions
         /// Nonzero = the exception number of the highest priority pending enabled exception.
         VECTPENDING: u6,
-        reserved1: u4 = 0,
+        reserved1: u4,
         /// Interrupt pending flag, excluding NMI and Faults:
         /// 0 = interrupt not pending
         /// 1 = interrupt pending.
         ISRPENDING: u1,
-        reserved2: u2 = 0,
+        reserved2: u2,
         /// SysTick exception clear-pending bit.
         ///
         /// Write:
@@ -57,7 +57,7 @@ pub const SystemControlBlock = extern struct {
         ///
         /// Writing 1 to this bit is the only way to set the PendSV exception state to pending.
         PENDSVSET: u1,
-        reserved3: u2 = 0,
+        reserved3: u2,
         /// NMI set-pending bit.
         ///
         /// Write:
@@ -127,17 +127,17 @@ pub const SystemControlBlock = extern struct {
     }),
     /// Configuration Control Register.
     CCR: mmio.Mmio(packed struct(u32) {
-        reserved0: u3 = 0,
+        reserved0: u3,
         /// Always reads as one, indicates that all unaligned accesses generate a HardFault.
         UNALIGN_TRP: u1,
-        reserved1: u5 = 0,
+        reserved1: u5,
         /// Always reads as one, indicates 8-byte stack alignment on exception entry.
         ///
         /// On exception entry, the processor uses bit[9] of the stacked PSR to indicate the stack
         /// alignment. On return from the exception it uses this stacked bit to restore the correct
         /// stack alignment.
         STKALIGN: u1,
-        reserved2: u22 = 0,
+        reserved2: u22,
     }),
     /// System Handlers Priority Registers.
     SHPR: [3]u32,

--- a/core/src/cpus/cortex_m/m0plus.zig
+++ b/core/src/cpus/cortex_m/m0plus.zig
@@ -10,17 +10,17 @@ pub const SystemControlBlock = extern struct {
         /// 0 = Thread mode
         /// Nonzero = The exception number[a] of the currently active exception.
         VECTACTIVE: u6,
-        reserved0: u6 = 0,
+        reserved0: u6,
         /// Indicates the exception number of the highest priority pending enabled exception:
         /// 0 = no pending exceptions
         /// Nonzero = the exception number of the highest priority pending enabled exception.
         VECTPENDING: u6,
-        reserved1: u4 = 0,
+        reserved1: u4,
         /// Interrupt pending flag, excluding NMI and Faults:
         /// 0 = interrupt not pending
         /// 1 = interrupt pending.
         ISRPENDING: u1,
-        reserved2: u2 = 0,
+        reserved2: u2,
         /// SysTick exception clear-pending bit.
         ///
         /// Write:
@@ -57,7 +57,7 @@ pub const SystemControlBlock = extern struct {
         ///
         /// Writing 1 to this bit is the only way to set the PendSV exception state to pending.
         PENDSVSET: u1,
-        reserved3: u2 = 0,
+        reserved3: u2,
         /// NMI set-pending bit.
         ///
         /// Write:
@@ -77,7 +77,7 @@ pub const SystemControlBlock = extern struct {
     VTOR: u32,
     /// Application Interrupt and Reset Control Register.
     AIRCR: mmio.Mmio(packed struct {
-        reserved0: u1 = 0,
+        reserved0: u1,
         /// Reserved for debug use. This bit reads as 0. When writing to the register you must
         /// write 0 to this bit, otherwise behavior is Unpredictable.
         VECTCLRACTIVE: u1,
@@ -87,7 +87,7 @@ pub const SystemControlBlock = extern struct {
         ///
         /// This bit reads as 0.
         SYSRESETREQ: u1,
-        reserved1: u12 = 0,
+        reserved1: u12,
         /// Data endianness implemented:
         /// 0 = Little-endian
         /// 1 = Big-endian.
@@ -99,7 +99,7 @@ pub const SystemControlBlock = extern struct {
     }),
     /// System Control Register.
     SCR: mmio.Mmio(packed struct(u32) {
-        reserved0: u1 = 0,
+        reserved0: u1,
         /// Indicates sleep-on-exit when returning from Handler mode to Thread mode:
         /// 0 = do not sleep when returning to Thread mode.
         /// 1 = enter sleep, or deep sleep, on return from an ISR to Thread mode.
@@ -114,7 +114,7 @@ pub const SystemControlBlock = extern struct {
         /// If your device does not support two sleep modes, the effect of changing the value
         /// of this bit is implementation-defined.
         SLEEPDEEP: u1,
-        reserved1: u1 = 0,
+        reserved1: u1,
         /// Send Event on Pending bit:
         /// 0 = only enabled interrupts or events can wakeup the processor, disabled interrupts are excluded
         /// 1 = enabled events and all interrupts, including disabled interrupts, can wakeup the processor.
@@ -124,21 +124,21 @@ pub const SystemControlBlock = extern struct {
         ///
         /// The processor also wakes up on execution of an SEV instruction or an external event.
         SEVONPEND: u1,
-        reserved2: u17 = 0,
+        reserved2: u17,
     }),
     /// Configuration Control Register.
     CCR: mmio.Mmio(packed struct(u32) {
-        reserved0: u3 = 0,
+        reserved0: u3,
         /// Always reads as one, indicates that all unaligned accesses generate a HardFault.
         UNALIGN_TRP: u1,
-        reserved1: u5 = 0,
+        reserved1: u5,
         /// Always reads as one, indicates 8-byte stack alignment on exception entry.
         ///
         /// On exception entry, the processor uses bit[9] of the stacked PSR to indicate the stack
         /// alignment. On return from the exception it uses this stacked bit to restore the correct
         /// stack alignment.
         STKALIGN: u1,
-        reserved2: u22 = 0,
+        reserved2: u22,
     }),
     /// System Handlers Priority Registers.
     SHPR: [3]u32,
@@ -186,13 +186,13 @@ pub const MemoryProtectionUnit = extern struct {
         HFNMIENA: u1,
         /// Enables priviledged software access to default memory map.
         PRIVDEFENA: u1,
-        reserved0: u29 = 0,
+        reserved0: u29,
     }),
     /// MPU Region Number Register
     RNR: mmio.Mmio(packed struct(u32) {
         /// Indicates the memory region accessed by MPU RBAR and PMU RLAR.
         REGION: u8,
-        reserved0: u24 = 0,
+        reserved0: u24,
     }),
     /// MPU Region Base Address Register
     RBAR: mmio.Mmio(packed struct(u32) {
@@ -209,7 +209,7 @@ pub const MemoryProtectionUnit = extern struct {
         ENABLE: u1,
         /// Specifies the size of the MPU region. The minimum permitted value is 7 (b00111).
         SIZE: u5,
-        reserved0: u2 = 0,
+        reserved0: u2,
         /// Subregion disable bits.
         SRD: u3,
         /// Bufferable bit.
@@ -218,12 +218,12 @@ pub const MemoryProtectionUnit = extern struct {
         C: u1,
         /// Shareable bit.
         S: u1,
-        reserved1: u5 = 0,
+        reserved1: u5,
         /// Access permission field.
         AP: u3,
-        reserved2: u1 = 0,
+        reserved2: u1,
         /// Instruction access disable bit.
         XN: u1,
-        reserved3: u3 = 0,
+        reserved3: u3,
     }),
 };

--- a/core/src/cpus/cortex_m/m3.zig
+++ b/core/src/cpus/cortex_m/m3.zig
@@ -7,18 +7,18 @@ pub const SystemControlBlock = extern struct {
     /// Interrupt Control and State Register.
     ICSR: mmio.Mmio(packed struct(u32) {
         VECTACTIVE: u9,
-        reserved0: u2 = 0,
+        reserved0: u2,
         RETTOBASE: u1,
         VECTPENDING: u6,
-        reserved1: u4 = 0,
+        reserved1: u4,
         ISRPENDING: u1,
         ISRPREEMPT: u1,
-        reserved2: u1 = 0,
+        reserved2: u1,
         PENDSTCLR: u1,
         PENDSTSET: u1,
         PENDSVCLR: u1,
         PENDSVSET: u1,
-        reserved3: u2 = 0,
+        reserved3: u2,
         NMIPENDSET: u1,
     }),
     /// Vector Table Offset Register.
@@ -28,32 +28,32 @@ pub const SystemControlBlock = extern struct {
         VECTRESET: u1,
         VECTCLRACTIVE: u1,
         SYSRESETREQ: u1,
-        reserved0: u5 = 0,
+        reserved0: u5,
         PRIGROUP: u3,
-        reserved1: u4 = 0,
+        reserved1: u4,
         ENDIANNESS: u1,
         VECTKEY: u16,
     }),
     /// System Control Register.
     SCR: mmio.Mmio(packed struct {
-        reserved0: u1 = 0,
+        reserved0: u1,
         SLEEPONEXIT: u1,
         SLEEPDEEP: u1,
-        reserved1: u1 = 0,
+        reserved1: u1,
         SEVONPEND: u1,
-        reserved2: u27 = 0,
+        reserved2: u27,
     }),
     /// Configuration Control Register.
     CCR: mmio.Mmio(packed struct(u32) {
         NONBASETHRDENA: u1,
         USERSETMPEND: u1,
-        reserved0: u1 = 0,
+        reserved0: u1,
         UNALIGN_TRP: u1,
         DIV_0_TRP: u1,
-        reserved1: u3 = 0,
+        reserved1: u3,
         BFHFNMIGN: u1,
         STKALIGN: u1,
-        reserved2: u22 = 0,
+        reserved2: u22,
     }),
     /// System Handlers Priority Registers.
     SHPR: [3]u32,
@@ -107,12 +107,12 @@ pub const MemoryProtectionUnit = extern struct {
     TYPE: mmio.Mmio(packed struct(u32) {
         /// Indicates support for unified or separate instructions and data address regions.
         SEPARATE: u1,
-        reserved0: u7 = 0,
+        reserved0: u7,
         /// Number of data regions supported by the MPU.
         DREGION: u8,
         /// Number of instruction regions supported by the MPU.
         IREGION: u8,
-        reserved1: u8 = 0,
+        reserved1: u8,
     }),
     /// MPU Control Register
     CTRL: mmio.Mmio(packed struct(u32) {
@@ -122,13 +122,13 @@ pub const MemoryProtectionUnit = extern struct {
         HFNMIENA: u1,
         /// Enables priviledged software access to default memory map.
         PRIVDEFENA: u1,
-        reserved0: u29 = 0,
+        reserved0: u29,
     }),
     /// MPU Region Number Register
     RNR: mmio.Mmio(packed struct(u32) {
         /// Indicates the memory region accessed by MPU RBAR and PMU RLAR.
         REGION: u8,
-        reserved0: u24 = 0,
+        reserved0: u24,
     }),
     /// MPU Region Base Address Register
     RBAR: RBAR,
@@ -161,7 +161,7 @@ pub const MemoryProtectionUnit = extern struct {
         ENABLE: u1,
         /// Specifies the size of the MPU protection region.
         SIZE: u5,
-        reserved0: u2 = 0,
+        reserved0: u2,
         /// Subregion disable bits.
         SRD: u8,
         /// Shareable bit.
@@ -172,11 +172,11 @@ pub const MemoryProtectionUnit = extern struct {
         C: u1,
         /// Memory Access Attribute.
         TEX: u3,
-        reserved1: u2 = 0,
+        reserved1: u2,
         /// Access permission field.
         AP: u3,
         /// Instruction access disable bit.
         XN: u1,
-        reserved2: u3 = 0,
+        reserved2: u3,
     });
 };

--- a/core/src/cpus/cortex_m/m33.zig
+++ b/core/src/cpus/cortex_m/m33.zig
@@ -16,28 +16,28 @@ pub const SystemControlBlock = extern struct {
     SCR: u32,
     /// Configuration and Control Register.
     CCR: mmio.Mmio(packed struct(u32) {
-        reserved0: u1 = 0,
+        reserved0: u1,
         /// User set pending determines if unpriviledged access to the STIR generates a fault.
         USERSETMPEND: u1,
-        reserved1: u1 = 0,
+        reserved1: u1,
         /// Unaligned trap controls trapping of unaligned word and half word accesses.
         UNALIGN_TRP: u1,
         /// Divide by zero trap controls generation of DIVBYZERO usage fault.
         DIV_0_TRP: u1,
-        reserved2: u3 = 0,
+        reserved2: u3,
         /// Determines effect of precise bus faults running on handlers at requested priority less than 0.
         BFHFNMIGN: u1,
-        reserved3: u1 = 0,
+        reserved3: u1,
         /// Controls effect of stack limit violation while executing at a requested priority less than 0.
         STKOFHFNMIGN: u1,
-        reserved4: u5 = 0,
+        reserved4: u5,
         /// Read as zero/write ignored.
         DC: u1,
         /// Read as zero/write ignored.
         IC: u1,
         /// Read as zero/write ignored.
         BP: u1,
-        reserved5: u13 = 0,
+        reserved5: u13,
     }),
     /// System Handler Priority Registers.
     SHPR: [12]u8,
@@ -116,10 +116,10 @@ pub const MemoryProtectionUnit = extern struct {
     TYPE: mmio.Mmio(packed struct(u32) {
         /// Indicates support for unified or separate instructions and data address regions.
         SEPARATE: u1,
-        reserved0: u7 = 0,
+        reserved0: u7,
         /// Number of data regions supported by the MPU.
         DREGION: u8,
-        reserved1: u16 = 0,
+        reserved1: u16,
     }),
     /// MPU Control Register.
     CTRL: mmio.Mmio(packed struct(u32) {
@@ -129,13 +129,13 @@ pub const MemoryProtectionUnit = extern struct {
         HFNMIENA: u1,
         /// Enables priviledged software access to default memory map.
         PRIVDEFENA: u1,
-        reserved0: u29 = 0,
+        reserved0: u29,
     }),
     /// MPU Region Number Register.
     RNR: mmio.Mmio(packed struct(u32) {
         /// Indicates the memory region accessed by MPU RBAR and PMU RLAR.
         REGION: u8,
-        reserved0: u24 = 0,
+        reserved0: u24,
     }),
     /// MPU Region Base Address Register.
     RBAR: RBAR,
@@ -178,7 +178,7 @@ pub const MemoryProtectionUnit = extern struct {
         EN: u1,
         /// Attribue Index associates a set of attributes in the MPU MAIR0 and MPU MAIR1 fields.
         AttrIndx: u3,
-        reserved0: u1 = 0,
+        reserved0: u1,
         /// Limit Address contains bits [31:5] of the upper inclusive limit of the selected MPU memory region. This
         /// value is postfixed with 0x1F to provide the limit address to be checked against.
         LIMIT: u27,

--- a/core/src/cpus/cortex_m/m4.zig
+++ b/core/src/cpus/cortex_m/m4.zig
@@ -7,18 +7,18 @@ pub const SystemControlBlock = extern struct {
     /// Interrupt Control and State Register.
     ICSR: mmio.Mmio(packed struct(u32) {
         VECTACTIVE: u9,
-        reserved0: u2 = 0,
+        reserved0: u2,
         RETTOBASE: u1,
         VECTPENDING: u6,
-        reserved1: u4 = 0,
+        reserved1: u4,
         ISRPENDING: u1,
         ISRPREEMPT: u1,
-        reserved2: u1 = 0,
+        reserved2: u1,
         PENDSTCLR: u1,
         PENDSTSET: u1,
         PENDSVCLR: u1,
         PENDSVSET: u1,
-        reserved3: u2 = 0,
+        reserved3: u2,
         NMIPENDSET: u1,
     }),
     /// Vector Table Offset Register.
@@ -28,32 +28,32 @@ pub const SystemControlBlock = extern struct {
         VECTRESET: u1,
         VECTCLRACTIVE: u1,
         SYSRESETREQ: u1,
-        reserved0: u5 = 0,
+        reserved0: u5,
         PRIGROUP: u3,
-        reserved1: u4 = 0,
+        reserved1: u4,
         ENDIANNESS: u1,
         VECTKEY: u16,
     }),
     /// System Control Register.
     SCR: mmio.Mmio(packed struct {
-        reserved0: u1 = 0,
+        reserved0: u1,
         SLEEPONEXIT: u1,
         SLEEPDEEP: u1,
-        reserved1: u1 = 0,
+        reserved1: u1,
         SEVONPEND: u1,
-        reserved2: u27 = 0,
+        reserved2: u27,
     }),
     /// Configuration Control Register.
     CCR: mmio.Mmio(packed struct(u32) {
         NONBASETHRDENA: u1,
         USERSETMPEND: u1,
-        reserved0: u1 = 0,
+        reserved0: u1,
         UNALIGN_TRP: u1,
         DIV_0_TRP: u1,
-        reserved1: u3 = 0,
+        reserved1: u3,
         BFHFNMIGN: u1,
         STKALIGN: u1,
-        reserved2: u22 = 0,
+        reserved2: u22,
     }),
     /// System Handlers Priority Registers.
     SHP: [12]u8,
@@ -108,7 +108,7 @@ pub const MemoryProtectionUnit = extern struct {
     TYPE: mmio.Mmio(packed struct(u32) {
         /// Indicates support for unified or separate instructions and data address regions.
         SEPARATE: u1,
-        reserved0: u7 = 0,
+        reserved0: u7,
         /// Number of data regions supported by the MPU.
         DREGION: u8,
         /// Number of instruction regions supported by the MPU.
@@ -123,13 +123,13 @@ pub const MemoryProtectionUnit = extern struct {
         HFNMIENA: u1,
         /// Enables priviledged software access to default memory map.
         PRIVDEFENA: u1,
-        reserved0: u29 = 0,
+        reserved0: u29,
     }),
     /// MPU Region Number Register.
     RNR: mmio.Mmio(packed struct(u32) {
         /// Indicates the memory region accessed by MPU RBAR and PMU RLAR.
         REGION: u8,
-        reserved0: u24 = 0,
+        reserved0: u24,
     }),
     /// MPU Region Base Address Register.
     RBAR: RBAR,
@@ -162,7 +162,7 @@ pub const MemoryProtectionUnit = extern struct {
         ENABLE: u1,
         /// Specifies the size of the MPU protection region.
         SIZE: u5,
-        reserved0: u2 = 0,
+        reserved0: u2,
         /// Subregion disable bits.
         SRD: u8,
         /// Shareable bit.
@@ -173,11 +173,11 @@ pub const MemoryProtectionUnit = extern struct {
         C: u1,
         /// Memory Access Attribute.
         TEX: u3,
-        reserved1: u2 = 0,
+        reserved1: u2,
         /// Access permission field.
         AP: u3,
         /// Instruction access disable bit.
         XN: u1,
-        reserved2: u3 = 0,
+        reserved2: u3,
     });
 };

--- a/core/src/cpus/cortex_m/m7.zig
+++ b/core/src/cpus/cortex_m/m7.zig
@@ -7,23 +7,23 @@ pub const SystemControlBlock = extern struct {
     /// Interrupt Control and State Register
     ICSR: mmio.Mmio(packed struct(u32) {
         VECTACTIVE: u9,
-        reserved0: u2 = 0,
+        reserved0: u2,
         RETTOBASE: u1,
         VECTPENDING: u9,
-        reserved1: u1 = 0,
+        reserved1: u1,
         ISRPENDING: u1,
         ISRPREEMPT: u1,
-        reserved2: u1 = 0,
+        reserved2: u1,
         PENDSTCLR: u1,
         PENDSTSET: u1,
         PENDSVCLR: u1,
         PENDSVSET: u1,
-        reserved3: u2 = 0,
+        reserved3: u2,
         NMIPENDSET: u1,
     }),
     /// Vector Table Offset Register
     VTOR: u32,
-    /// Application Interrupt  and Reset Control Register
+    /// Application Interrupt and Reset Control Register
     AIRCR: u32,
     /// System Control Register
     SCR: u32,
@@ -31,13 +31,13 @@ pub const SystemControlBlock = extern struct {
     CCR: mmio.Mmio(packed struct(u32) {
         NONBASETHRDENA: u1,
         USERSETMPEND: u1,
-        _reserved0: u1 = 0,
+        reserved0: u1,
         UNALIGN_TRP: u1,
         DIV_0_TRP: u1,
-        _reserved1: u3 = 0,
+        reserved1: u3,
         BFHFNMIGN: u1,
         STKALIGN: u1,
-        _padding: u22 = 0,
+        padding: u22,
     }),
     /// System Handlers Priority Registers
     SHP: [3]u8,
@@ -78,22 +78,22 @@ pub const SystemControlBlock = extern struct {
 pub const NestedVectorInterruptController = extern struct {
     /// Interrupt Set-enable Registers
     ISER: [7]u32,
-    _reserved0: [25]u32,
+    reserved0: [25]u32,
     /// Interrupt Clear-enable Registers
     ICER: [7]u32,
-    _reserved1: [25]u32,
+    reserved1: [25]u32,
     /// Interrupt Set-pending Registers
     ISPR: [7]u32,
-    _reserved2: [25]u32,
+    reserved2: [25]u32,
     /// Interrupt Clear-pending Registers
     ICPR: [7]u32,
-    _reserved3: [25]u32,
+    reserved3: [25]u32,
     /// Interrupt Active Bit Registers
     IABR: [7]u32,
-    _reserved4: [57]u32,
+    reserved4: [57]u32,
     /// Interrupt Priority Registers
     IP: [239]u8,
-    _reserved5: [2577]u8,
+    reserved5: [2577]u8,
     /// Software Trigger Interrupt Register
     STIR: u32,
 };
@@ -102,10 +102,10 @@ pub const MemoryProtectionUnit = extern struct {
     /// MPU Type Register
     TYPE: mmio.Mmio(packed struct(u32) {
         SEPARATE: u1,
-        _reserved0: u7,
+        reserved0: u7,
         DREGION: u8,
         IREGION: u8,
-        _reserved1: u8,
+        reserved1: u8,
     }),
     /// MPU Control Register
     CTRL: mmio.Mmio(packed struct(u32) {
@@ -147,7 +147,7 @@ pub const MemoryProtectionUnit = extern struct {
         ENABLE: u1,
         /// Region Size
         SIZE: u5,
-        _reserved0: u2,
+        reserved0: u2,
         /// Sub-Region Disable
         SRD: u8,
         /// ATTRS.B
@@ -158,7 +158,7 @@ pub const MemoryProtectionUnit = extern struct {
         S: u1,
         /// ATTRS.TEX
         TEX: u3,
-        _reserved1: u2,
+        reserved1: u2,
         /// ATTRS.AP
         AP: u3,
         /// ATTRS.XN
@@ -170,17 +170,17 @@ pub const MemoryProtectionUnit = extern struct {
 pub const DebugRegisters = extern struct {
     /// Debyg Halting Control and Status Register
     DHCSR: mmio.Mmio(packed struct {
-        _reserved_0: u6,
+        reserved0: u6,
         S_RESET_ST: u1,
         S_RETIRE_ST: u1,
-        _reserved_1: u4,
+        reserved1: u4,
         S_LOCKUP: u1,
         S_SLEEP: u1,
         S_HALT: u1,
         S_REGRDY: u1,
-        _reserved_2: u10,
+        reserved2: u10,
         C_SNAPSTALL: u1,
-        _reserved_3: u1,
+        reserved3: u1,
         C_MASKINTS: u1,
         C_STEP: u1,
         C_HALT: u1,
@@ -189,9 +189,9 @@ pub const DebugRegisters = extern struct {
     /// Debug Core Register Selector Register
     /// TODO: Reserved have values ? see armv7-m reference manual
     DCRSR: mmio.Mmio(packed struct {
-        _reserved_0: u15,
+        reserved0: u15,
         REGWnR: u1,
-        _reserved_1: u9,
+        reserved1: u9,
         REGSEL: u7,
     }),
     /// Debug Core Register Data Register
@@ -200,14 +200,14 @@ pub const DebugRegisters = extern struct {
     }),
     /// Debug exception and Monitor Control Register
     DEMCR: mmio.Mmio(packed struct {
-        _reserved_0: u7,
+        reserved0: u7,
         TRCENA: u1,
-        _reserved_1: u4,
+        reserved1: u4,
         MON_REQ: u1,
         MON_STEP: u1,
         MON_PEND: u1,
         MON_EN: u1,
-        _reserved_2: u5,
+        reserved2: u5,
         VC_HARDERR: u1,
         VC_INTERR: u1,
         VC_BUSERR: u1,
@@ -215,7 +215,7 @@ pub const DebugRegisters = extern struct {
         VC_CHKERR: u1,
         VC_NOCPERR: u1,
         VC_MMERR: u1,
-        _reserved_3: u3,
+        reserved3: u3,
         VC_CORERESET: u1,
     }),
 };
@@ -228,25 +228,25 @@ pub const ITM = extern struct {
         WRITE_U32: u32,
         READ: packed struct(u32) {
             FIFOREADY: u1,
-            _reserved: u31,
+            reserved: u31,
         },
     }),
 
-    _reserved0: [640]u32, // Padding to 0xE00
+    reserved0: [640]u32, // Padding to 0xE00
 
     /// Trace Enable Registers (0-7)
     TER: [8]mmio.Mmio(packed struct(u32) {
         STIMENA: u32, // Enable bits for stimulus ports
     }),
 
-    _reserved1: [10]u32, // Padding to 0xE40
+    reserved1: [10]u32, // Padding to 0xE40
 
     /// Trace Privilege Register
     TPR: mmio.Mmio(packed struct(u32) {
         PRIVMASK: u32, // Privilege mask for stimulus ports
     }),
 
-    _reserved2: [15]u32, // Padding to 0xE80
+    reserved2: [15]u32, // Padding to 0xE80
 
     /// Trace Control Register
     TCR: mmio.Mmio(packed struct(u32) {
@@ -255,13 +255,13 @@ pub const ITM = extern struct {
         SYNCENA: u1, // Sync packet enable
         TXENA: u1, // DWT packet forwarding enable
         SWOENA: u1, // Async clock enable
-        _reserved0: u3,
+        reserved0: u3,
         TSPrescale: u2, // Local timestamp prescaler
         GTSFREQ: u2, // Global timestamp frequency
-        _reserved1: u4,
+        reserved1: u4,
         TraceBusID: u7, // Trace bus ID
         BUSY: u1, // ITM busy flag
-        _reserved2: u8,
+        reserved2: u8,
     }),
 };
 
@@ -274,28 +274,28 @@ pub const TPIU = extern struct {
     CSPSR: mmio.Mmio(packed struct(u32) {
         CWIDTH: u32,
     }),
-    _reserved0: [2]u32,
+    reserved0: [2]u32,
     /// Asynchronous Clock Prescaler Register
     ACPR: mmio.Mmio(packed struct(u32) {
         SWOSCALER: u16,
-        _padding: u16,
+        padding: u16,
     }),
-    _reserved1: [55]u32,
+    reserved1: [55]u32,
     /// Selected Pin Protocol Register
     SPPR: mmio.Mmio(packed struct(u32) {
         TXMODE: u2,
-        _padding: u30,
+        padding: u30,
     }),
-    _reserved2: [524]u32,
+    reserved2: [524]u32,
     /// TPIU Type Register
     TYPE: mmio.Mmio(packed struct(u32) {
-        _reserved0: u6,
+        reserved0: u6,
         FIFOSZ: u3,
         PTINVALID: u1,
         MANCVALID: u1,
         NRZVALID: u1,
-        _implementation_defined0: u4,
-        _padding: u16,
+        implementation_defined0: u4,
+        padding: u16,
     }),
-    _reserved3: [13]u32,
+    reserved3: [13]u32,
 };

--- a/examples/raspberrypi/rp2xxx/src/rp2040_only/usb_cdc.zig
+++ b/examples/raspberrypi/rp2xxx/src/rp2040_only/usb_cdc.zig
@@ -143,6 +143,6 @@ pub fn usb_cdc_read() []const u8 {
         total_read += len;
         if (len == 0) break;
     }
-        
+
     return usb_rx_buff[0..total_read];
 }


### PR DESCRIPTION
- replace wrong cortex m0 plus cpu name
- don't set reserved fields by default to 0
- remove underscores of reserved bits (to look more similar to what `regz` generates)