### PR TITLE
build-system: Fix bug in `add_firmware`

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -244,10 +244,10 @@ pub fn MicroBuild(port_select: PortSelect) type {
             bundle_compiler_rt: ?bool = null,
 
             /// If set, overrides the `hal` property of the target.
-            hal: ?*HardwareAbstractionLayer = null,
+            hal: ?HardwareAbstractionLayer = null,
 
             /// If set, overrides the `board` property of the target.
-            board: ?*Board = null,
+            board: ?Board = null,
 
             /// If set, overrides the `linker_script` property of the target.
             linker_script: ?LazyPath = null,

--- a/build.zig
+++ b/build.zig
@@ -168,7 +168,6 @@ pub fn MicroBuild(port_select: PortSelect) type {
         ports: SelectedPorts,
 
         const InitReturnType = blk: {
-            // TODO: idk if this is idiomatic
             @setEvalBranchQuota(2000);
 
             var ok = true;


### PR DESCRIPTION
- Fix bug in `add_firmware` where `options.hal` or `options.board` are not actually overriding the `Target`.