### PR TITLE
Add regz and uf2 releases to the github deploy action

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -43,7 +43,7 @@ jobs:
 
       - name: Create Microzig Tarball
         run: |
-          tar -czf boxzer-out.tar.gz -C boxzer-out .
+          tar -czf microzig-packaged.tar.gz -C boxzer-out .
 
       - name: Create regz Tarballs
         run: |
@@ -61,4 +61,4 @@ jobs:
           artifactErrorsFailBuild: true
           draft: true
           generateReleaseNotes: true
-          artifacts: boxzer-out.tar.gz,zig-out/regz*.tar.gz,zig-out/uf2*.tar.gz
+          artifacts: microzig-packaged.tar.gz,zig-out/regz*.tar.gz,zig-out/uf2*.tar.gz

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -61,4 +61,4 @@ jobs:
           artifactErrorsFailBuild: true
           draft: true
           generateReleaseNotes: true
-          artifacts: boxzer-out.tar.gz,zig-out/regz*.tar.gz,uf2*.tar.gz
+          artifacts: boxzer-out.tar.gz,zig-out/regz*.tar.gz,zig-out/uf2*.tar.gz

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -50,7 +50,9 @@ jobs:
           draft: true
           generateReleaseNotes: true
 
-      - name: Create Tarball
+      - name: Create Microzig Tarball
+        run: |
+          tar -czf boxzer-out.tar.gz -C boxzer-out .
 
       - name: Create regz Tarballs
         run: |

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -34,12 +34,12 @@ jobs:
       - name: Release RegZ
         run: |
           zig build release-regz
-          find zig-out/* -type d -exec sh -c 'mv {} "$(dirname {})"/regz-"$(basename {})"' \;
+          find zig-out/* -type d -print0 | xargs -0 -I {} sh -c 'mv {} "$(dirname {})"/regz-"$(basename {})"'
 
       - name: Release Uf2
         run: |
           zig build release-uf2
-          find zig-out/* -type d -and -not -path "*regz*" -exec sh -c 'mv "{}" "$(dirname {})"/uf2-"$(basename {})"' \;
+          find zig-out/* -type d -and -not -path "*regz*" -print0 | xargs -0 -I {} sh -c 'mv {} "$(dirname {})"/uf2-"$(basename {})"'
 
       - name: Create Microzig Tarball
         run: |

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -43,7 +43,7 @@ jobs:
 
       - name: Create Microzig Tarball
         run: |
-          tar -czf microzig-packaged.tar.gz -C boxzer-out .
+          tar -czf boxzer-out.tar.gz -C boxzer-out .
 
       - name: Create regz Tarballs
         run: |
@@ -61,4 +61,4 @@ jobs:
           artifactErrorsFailBuild: true
           draft: true
           generateReleaseNotes: true
-          artifacts: microzig-packaged.tar.gz,zig-out/regz*.tar.gz,zig-out/uf2*.tar.gz
+          artifacts: boxzer-out.tar.gz,zig-out/regz*.tar.gz,zig-out/uf2*.tar.gz

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -31,6 +31,16 @@ jobs:
       - name: Assemble Packages
         run: zig build package -- https://microzig.tech/downloads/microzig
 
+      - name: Release RegZ
+        run: |
+          zig build release-regz
+          find zig-out/* -type d -exec sh -c 'mv {} "$(dirname {})"/regz-"$(basename {})"' \;
+
+      - name: Release Uf2
+        run: |
+          zig build release-uf2
+          find zig-out/* -type d -and -not -path "*regz*" -exec sh -c 'mv "{}" "$(dirname {})"/uf2-"$(basename {})"' \;
+
       - name: Create Release Draft
         uses: ncipollo/release-action@v1
         id: create_release
@@ -41,8 +51,14 @@ jobs:
           generateReleaseNotes: true
 
       - name: Create Tarball
+
+      - name: Create regz Tarballs
         run: |
-          tar -czvf boxzer-out.tar.gz -C boxzer-out .
+          find zig-out/regz* -type d -exec sh -c 'tar -czf "{}.tar.gz" -C {} .' \;
+
+      - name: Create uf2 Tarballs
+        run: |
+          find zig-out/uf2* -type d -exec sh -c 'tar -czf "{}.tar.gz" -C {} .' \;
 
       - name: Upload Artifact to Release
         uses: actions/upload-release-asset@v1

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -41,15 +41,6 @@ jobs:
           zig build release-uf2
           find zig-out/* -type d -and -not -path "*regz*" -exec sh -c 'mv "{}" "$(dirname {})"/uf2-"$(basename {})"' \;
 
-      - name: Create Release Draft
-        uses: ncipollo/release-action@v1
-        id: create_release
-        with:
-          tag: ${{ env.TAG_NAME }}
-          artifactErrorsFailBuild: true
-          draft: true
-          generateReleaseNotes: true
-
       - name: Create Microzig Tarball
         run: |
           tar -czf boxzer-out.tar.gz -C boxzer-out .
@@ -62,12 +53,12 @@ jobs:
         run: |
           find zig-out/uf2* -type d -exec sh -c 'tar -czf "{}.tar.gz" -C {} .' \;
 
-      - name: Upload Artifact to Release
-        uses: actions/upload-release-asset@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Create Release Draft
+        uses: ncipollo/release-action@v1
+        id: create_release
         with:
-          upload_url: ${{ steps.create_release.outputs.upload_url }}
-          asset_path: boxzer-out.tar.gz
-          asset_name: boxzer-out.tar.gz
-          asset_content_type: application/gzip
+          tag: ${{ env.TAG_NAME }}
+          artifactErrorsFailBuild: true
+          draft: true
+          generateReleaseNotes: true
+          artifacts: boxzer-out.tar.gz,zig-out/regz*.tar.gz,uf2*.tar.gz


### PR DESCRIPTION
regz and uf2 will now be added as artifacts to github releases

Edit: Tested and working on fork
~~Edit 2: Also currently has the change that renamed boxzer-out.tar.gz to microzig-packaged.tar.gz~~