### PR TITLE
Update CI workflow with job dependencies

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,6 +25,7 @@ jobs:
   unit-test-ports:
     name: Unit Test Ports
     runs-on: ${{ matrix.os }}
+    needs: build
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
@@ -115,6 +116,7 @@ jobs:
   build-examples:
     name: Build Examples
     runs-on: ubuntu-latest
+    needs: build
     strategy:
       matrix:
         example_dir:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,7 +5,6 @@ on:
   pull_request:
     branches: [main, zig-master]
 
-
 env:
   ZIG_VERSION: ${{ github.ref == 'refs/heads/zig-master' && 'master' || '0.13.0' }}
 
@@ -28,16 +27,8 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [
-          ubuntu-latest,
-          windows-latest,
-          macos-latest,
-        ]
-        port_dir: [
-          gigadevice/gd32,
-          raspberrypi/rp2xxx,
-          stmicro/stm32,
-        ]
+        os: [ubuntu-latest, windows-latest, macos-latest]
+        port_dir: [gigadevice/gd32, raspberrypi/rp2xxx, stmicro/stm32]
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -53,11 +44,7 @@ jobs:
     name: Unit Test Regz
     strategy:
       matrix:
-        os: [
-          ubuntu-latest,
-          windows-latest,
-          macos-latest,
-        ]
+        os: [ubuntu-latest, windows-latest, macos-latest]
     runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout
@@ -74,11 +61,7 @@ jobs:
     name: Unit Test UF2
     strategy:
       matrix:
-        os: [
-          ubuntu-latest,
-          windows-latest,
-          macos-latest,
-        ]
+        os: [ubuntu-latest, windows-latest, macos-latest]
     runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout
@@ -134,17 +117,18 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        example_dir: [
-          espressif/esp,
-          gigadevice/gd32,
-          microchip/avr,
-          microchip/atsam,
-          nordic/nrf5x,
-          nxp/lpc,
-          stmicro/stm32,
-          raspberrypi/rp2xxx,
-          wch/ch32v,
-        ]
+        example_dir:
+          [
+            espressif/esp,
+            gigadevice/gd32,
+            microchip/avr,
+            microchip/atsam,
+            nordic/nrf5x,
+            nxp/lpc,
+            stmicro/stm32,
+            raspberrypi/rp2xxx,
+            wch/ch32v,
+          ]
     steps:
       - name: Checkout
         uses: actions/checkout@v4


### PR DESCRIPTION
I added job dependencies to the ports unit tests job and the examples build job. Neither of these two make sense to run if the overall build failed.