### PR TITLE
pio: Assembler: fix issue in diag when tokenizer has index on newline

### DIFF
--- a/port/raspberrypi/rp2xxx/src/hal/pio/assembler.zig
+++ b/port/raspberrypi/rp2xxx/src/hal/pio/assembler.zig
@@ -99,7 +99,7 @@ fn format_compile_error(comptime message: []const u8, comptime source: []const u
     var line_it = std.mem.tokenize(u8, source, "\n\r");
     while (line_it.next()) |line| : (line_num += 1) {
         line_str = line_str ++ "\n" ++ line;
-        if (line_it.index > index) {
+        if (line_it.index >= index) {
             column = line.len - (line_it.index - index);
             line_str = line;
             break;


### PR DESCRIPTION
If the tokenizer index is at the newline at the end of a line and it initializes the diagnostics, the column calculation will underflow, since the line iterator index will point to the end of the next line, while the index will be the previous new line character, so the column will be calculated as -1.

This change simply allows the index to point to the newline, though in this case the diagnostic will point past the end of the line:

```zig
❯ zig build test --summary all
test
└─ run test
   └─ zig test Debug native 1 errors
src/hal/pio/assembler.zig:133:13: error: failed to assemble PIO code:

                                             mov osr, rxfifoy
                                                             ^
                                                             hello 155

            @compileError(format_compile_error(d.message.slice(), source, d.index));
            ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
src/hal/pio/assembler/comparison_tests.zig:57:47: note: called from here
    const output = comptime assembler.assemble(cpu, source, .{});
                            ~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~
```