### PR TITLE
fixing register so there is 32 bits

### DIFF
--- a/core/src/cpus/cortex_m/m0plus.zig
+++ b/core/src/cpus/cortex_m/m0plus.zig
@@ -124,7 +124,7 @@ pub const SystemControlBlock = extern struct {
         ///
         /// The processor also wakes up on execution of an SEV instruction or an external event.
         SEVONPEND: u1,
-        reserved2: u17,
+        reserved2: u27,
     }),
     /// Configuration Control Register.
     CCR: mmio.Mmio(packed struct(u32) {


### PR DESCRIPTION
Pretty simple one! The bits didn't add up to 32, and I was getting this error:
```
1:34: error: backing integer type 'u32' has bit size 32 but the struct fields have a total bit size of 22
    SCR: mmio.Mmio(packed struct(u32) {
```