### PR TITLE
explicitly disable build-id for rp2xxx bootrom

### DIFF
--- a/port/raspberrypi/rp2xxx/build.zig
+++ b/port/raspberrypi/rp2xxx/build.zig
@@ -231,6 +231,7 @@ fn get_bootrom(b: *std.Build, chip: microzig.Chip, rom: BootROM) std.Build.LazyP
     });
 
     //rom_exe.linkage = .static;
+    rom_exe.build_id = .none;
     rom_exe.setLinkerScript(b.path(b.fmt("src/bootroms/{s}/shared/stage2.ld", .{chip.name})));
     rom_exe.addAssemblyFile(b.path(b.fmt("src/bootroms/{s}/{s}.S", .{ chip.name, @tagName(rom) })));
     rom_exe.entry = .{ .symbol_name = "_stage2_boot" };


### PR DESCRIPTION
currently compiling microzig with zig from the fedora repos for the rp2xxx results in an error because the bootrom is larger than expected

this is caused by a patch I added that makes `build-id` default to `.sha1` instead `.none` and unfortunately that also affects the bootrom, this PR explicitly sets it to `.none` again

