### PR TITLE
support "extends" from embassy data.

### DIFF
--- a/port/stmicro/stm32/src/generate.zig
+++ b/port/stmicro/stm32/src/generate.zig
@@ -629,7 +629,7 @@ fn chip_file_less_than(_: void, lhs: std.json.Parsed(ChipFile), rhs: std.json.Pa
 }
 
 // General function to handle inheritance
-fn resolve_inheritance_recursivly(allocator: std.mem.Allocator, json_data: *std.json.Value, child_full_name: []const u8, accumulator: *std.json.ObjectMap) !void {
+fn resolve_inheritance_recursively(allocator: std.mem.Allocator, json_data: *std.json.Value, child_full_name: []const u8, accumulator: *std.json.ObjectMap) !void {
     const child = json_data.object.get(child_full_name).?;
     const list_name = get_section(child_full_name);
 
@@ -650,7 +650,7 @@ fn resolve_inheritance_recursivly(allocator: std.mem.Allocator, json_data: *std.
         }
 
         if (parent.value_ptr.object.contains("extends")) {
-            try resolve_inheritance_recursivly(allocator, json_data, parent.key_ptr.*, accumulator);
+            try resolve_inheritance_recursively(allocator, json_data, parent.key_ptr.*, accumulator);
         }
     }
 }
@@ -709,23 +709,23 @@ fn handle_extends(allocator: std.mem.Allocator, extends_allocator: std.mem.Alloc
 
             // Get child value and kind holder of inherting items
             var child = root_json.object.get(item_name).?;
-            const listName = get_section(item_name);
+            const list_name = get_section(item_name);
 
             // Add child items to dictionary so they are not overwritten.
             for (child.object.get(listName).?.array.items) |childItem| {
-                const itemName = childItem.object.get("name").?.string;
-                try arr.put(itemName, childItem);
+                const item_name = child_item.object.get("name").?.string;
+                try arr.put(item_name, childItem);
             }
 
             // Handle all parents and grandparents of the current child.
             try resolve_inheritance_recursivly(allocator, root_json, item_name, &arr);
 
             // Replacement items will go here and should be released via the arena extends allocator
-            var newList = std.json.Array.init(extends_allocator);
+            var new_list = std.json.Array.init(extends_allocator);
             for (arr.values()) |value| {
-                try newList.append(value);
+                try new_list.append(value);
             }
-            try child.object.put(listName, std.json.Value{ .array = newList });
+            try child.object.put(list_name, std.json.Value{ .array = newList });
         }
     }
 }

--- a/port/stmicro/stm32/src/generate.zig
+++ b/port/stmicro/stm32/src/generate.zig
@@ -671,7 +671,7 @@ fn get_parent(allocator: std.mem.Allocator, json_data: *std.json.Value, child_fu
 /// blocks inherit their "items"
 /// fieldsets inherit their "feilds"
 /// This picks the appropriate item based on its name.
-fn get_section(childFullName: []const u8) []const u8 {
+fn get_section(child_full_name: []const u8) []const u8 {
     const Item_t = struct {
         data_type: []const u8,
         section: []const u8,
@@ -683,7 +683,7 @@ fn get_section(childFullName: []const u8) []const u8 {
     };
 
     //Get Family name eg Block, Fieldset
-    var name_iterator = std.mem.splitScalar(u8, childFullName, '/');
+    var name_iterator = std.mem.splitScalar(u8, child_full_name, '/');
     const family_name = name_iterator.first();
 
     inline for (items) |item| {
@@ -717,10 +717,11 @@ fn handle_extends(allocator: std.mem.Allocator, extends_allocator: std.mem.Alloc
                 try arr.put(itemName, childItem);
             }
 
+            // Handle all parents and grandparents of the current child.
             try resolve_inheritance_recursivly(allocator, root_json, item_name, &arr);
 
+            // Replacement items will go here and should be released via the arena extends allocator
             var newList = std.json.Array.init(extends_allocator);
-
             for (arr.values()) |value| {
                 try newList.append(value);
             }

--- a/port/stmicro/stm32/src/generate.zig
+++ b/port/stmicro/stm32/src/generate.zig
@@ -712,20 +712,20 @@ fn handle_extends(allocator: std.mem.Allocator, extends_allocator: std.mem.Alloc
             const list_name = get_section(item_name);
 
             // Add child items to dictionary so they are not overwritten.
-            for (child.object.get(listName).?.array.items) |childItem| {
-                const item_name = child_item.object.get("name").?.string;
-                try arr.put(item_name, childItem);
+            for (child.object.get(list_name).?.array.items) |child_item| {
+                const child_item_name = child_item.object.get("name").?.string;
+                try arr.put(child_item_name, child_item);
             }
 
             // Handle all parents and grandparents of the current child.
-            try resolve_inheritance_recursivly(allocator, root_json, item_name, &arr);
+            try resolve_inheritance_recursively(allocator, root_json, item_name, &arr);
 
             // Replacement items will go here and should be released via the arena extends allocator
             var new_list = std.json.Array.init(extends_allocator);
             for (arr.values()) |value| {
                 try new_list.append(value);
             }
-            try child.object.put(list_name, std.json.Value{ .array = newList });
+            try child.object.put(list_name, std.json.Value{ .array = new_list });
         }
     }
 }


### PR DESCRIPTION
Attempted to support "extends" syntax in register json files.

The added functions aggregate the extends and injects them into the Json.Value parsed from the register files.

it works by traveling down the "extends" and bringing a dictionary with it adding new "items" or "fields" as it travels down the ancestor's lineage.

I expect I'll have to clean up some stuff. but I was just glad I could get it to work.

It does use a arena allocator for the json injections. so they can be cleaned up at the same time.