### PR TITLE
Add microzig_flash_end to linker script

### DIFF
--- a/port/raspberrypi/rp2xxx/rp2040.ld
+++ b/port/raspberrypi/rp2xxx/rp2040.ld
@@ -54,6 +54,11 @@ SECTIONS
       *(.bss*)
       microzig_bss_end = .;
   } > ram0
+  
+  .flash_end :
+  {
+    microzig_flash_end = .;
+  } > flash0
 
   microzig_data_load_start = LOADADDR(.data);
 }

--- a/port/raspberrypi/rp2xxx/rp2350_arm.ld
+++ b/port/raspberrypi/rp2xxx/rp2350_arm.ld
@@ -52,6 +52,11 @@ SECTIONS
       *(.bss*)
       microzig_bss_end = .;
   } > ram0
+  
+  .flash_end :
+  {
+    microzig_flash_end = .;
+  } > flash0
 
   microzig_data_load_start = LOADADDR(.data);
 }

--- a/port/raspberrypi/rp2xxx/rp2350_riscv.ld
+++ b/port/raspberrypi/rp2xxx/rp2350_riscv.ld
@@ -48,6 +48,11 @@ SECTIONS
       *(.sbss*)
       microzig_bss_end = .;
   } > ram0
+  
+  .flash_end :
+  {
+    microzig_flash_end = .;
+  } > flash0
 
   microzig_data_load_start = LOADADDR(.data);
   PROVIDE(__global_pointer$ = microzig_data_start + 0x800);

--- a/tools/generate_linker_script.zig
+++ b/tools/generate_linker_script.zig
@@ -134,6 +134,11 @@ pub fn main() !void {
             \\      microzig_bss_end = .;
             \\  } > ram0
             \\
+            \\  .flash_end :
+            \\  {
+            \\      microzig_flash_end = .;
+            \\  } > flash0
+            \\
             \\  microzig_data_load_start = LOADADDR(.data);
             \\
         );


### PR DESCRIPTION
Linker script already exports microzig_flash_start but there was no microzig_flash_end. Both values are useful to caluclate avaliable flash size after program flash.