### PR TITLE
rp2xxx: hal: gpio: Fix rp2350 GPIO reg access

### DIFF
--- a/port/raspberrypi/rp2xxx/src/hal/gpio.zig
+++ b/port/raspberrypi/rp2xxx/src/hal/gpio.zig
@@ -417,8 +417,7 @@ pub const Pin = enum(u6) {
                     else
                         0;
                 } else {
-                    // TODO: regz inconsistencies
-                    return if ((SIO.GPIO_IN & gpio.mask()) != 0)
+                    return if ((SIO.GPIO_IN.raw & gpio.mask()) != 0)
                         1
                     else
                         0;


### PR DESCRIPTION
Discovered when moving my example in #359 out of the rp2400-only examples.

This must have been fixed recently.