### PR TITLE
Enable 'unwind_tables' for all platforms (for #370)

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -462,6 +462,7 @@ pub fn MicroBuild(port_select: PortSelect) type {
                     .linkage = .static,
                     .root_source_file = mb.core_dep.path("src/start.zig"),
                     .strip = options.strip,
+                    .unwind_tables = true,
                 }),
                 .app_mod = app_mod,
                 .target = target,

--- a/tools/generate_linker_script.zig
+++ b/tools/generate_linker_script.zig
@@ -107,6 +107,10 @@ pub fn main() !void {
 
         switch (program_args.cpu_arch) {
             .arm, .thumb => try writer.writeAll(
+                \\  .ARM.extab : {
+                \\      *(.ARM.extab* .gnu.linkonce.armextab.*)
+                \\  } >flash0
+                \\
                 \\  .ARM.exidx : {
                 \\      *(.ARM.exidx* .gnu.linkonce.armexidx.*)
                 \\  } >flash0


### PR DESCRIPTION
For ARM-based embedded firmware this requires
explicit declaration of `ARM.extab` sections in linker.d, otherwise the exception tables can incorrectly end up in RAM. (See https://github.com/ziglang/zig/issues/22685.)

(The `.unwind_tables = true` line must be removed for Zig 0.14, which already has this enabled for basically all platforms.)

Implements part of #370 already on Zig 0.13.0.