### PR TITLE
rp2xxx: hal: spi: Inline & pub-ify get_regs

### DIFF
--- a/port/raspberrypi/rp2xxx/src/hal/spi.zig
+++ b/port/raspberrypi/rp2xxx/src/hal/spi.zig
@@ -85,7 +85,7 @@ pub const ConfigError = error{
 pub const SPI = enum(u1) {
     _,
 
-    fn get_regs(spi: SPI) *volatile SpiRegs {
+    pub inline fn get_regs(spi: SPI) *volatile SpiRegs {
         return switch (@intFromEnum(spi)) {
             0 => SPI0_reg,
             1 => SPI1_reg,


### PR DESCRIPTION
It's already called by a bunch of inline functions, and there's good reason to expose it directly to clients.