### PR TITLE
rp2xxx: examples: Fix name of 'generic' examples

### DIFF
--- a/examples/raspberrypi/rp2xxx/build.zig
+++ b/examples/raspberrypi/rp2xxx/build.zig
@@ -47,8 +47,8 @@ pub fn build(b: *std.Build) void {
         .{ .name = "changing-system-clocks", .file = "src/changing_system_clocks.zig" },
         .{ .name = "custom-clock-config", .file = "src/custom_clock_config.zig" },
         .{ .name = "watchdog-timer", .file = "src/watchdog_timer.zig" },
-        .{ .name = "pico_stepper", .file = "src/stepper.zig" },
-        .{ .name = "pico_usb-cdc", .file = "src/usb_cdc.zig" },
+        .{ .name = "stepper", .file = "src/stepper.zig" },
+        .{ .name = "usb-cdc", .file = "src/usb_cdc.zig" },
     };
 
     var available_examples = std.ArrayList(Example).init(b.allocator);


### PR DESCRIPTION
The pico/pico2 part is added automatically for the chip-agnostic examples.

As it is, the files look like `pico2_pico_stepper.elf`