### PR TITLE
Update gpio.zig

### DIFF
--- a/port/stmicro/stm32/src/hals/STM32F103/gpio.zig
+++ b/port/stmicro/stm32/src/hals/STM32F103/gpio.zig
@@ -81,12 +81,12 @@ pub const Pin = packed struct(u8) {
         const port = gpio.get_port();
         if (gpio.number <= 7) {
             const offset = @as(u5, gpio.number) << 2;
-            port.CR[0].raw &= ~(@as(u32, 0b1111) << offset);
-            port.CR[0].raw |= config << offset;
+            port.MODER.raw &= ~(@as(u32, 0b1111) << offset);
+            port.MODER.raw |= config << offset;
         } else {
             const offset = (@as(u5, gpio.number) - 8) << 2;
-            port.CR[1].raw &= ~(@as(u32, 0b1111) << offset);
-            port.CR[1].raw |= config << offset;
+            port.OTYPER.raw &= ~(@as(u32, 0b1111) << offset);
+            port.OTYPER.raw |= config << offset;
         }
     }
 


### PR DESCRIPTION
embassy-rs/stm32-data-generated from V1 -> V2 renames GPIO mode registers from len2 array of 4bit registers (CR[0],CR[1]) to two seperate 4bit registers (MODER, OTYPER).

I'm working on porting the F103 HAL to a G432 and came across this change when trying to get a blinky compiling. It compiles with this change, I'm hoping to get it running on the G432 today or tomorrow. I'll try and get it running on an F103 bluepill sometime by the middle of next week.