### PR TITLE
rp2040: Fix extab section getting put before .text

### DIFF
--- a/port/raspberrypi/rp2xxx/rp2040.ld
+++ b/port/raspberrypi/rp2xxx/rp2040.ld
@@ -58,7 +58,7 @@ SECTIONS
       *(.bss*)
       microzig_bss_end = .;
   } > ram0
-  
+
   .flash_end :
   {
     microzig_flash_end = .;

--- a/port/raspberrypi/rp2xxx/rp2040.ld
+++ b/port/raspberrypi/rp2xxx/rp2040.ld
@@ -31,6 +31,10 @@ SECTIONS
      *(.rodata*)
   } > flash0
 
+  .ARM.extab : {
+      *(.ARM.extab* .gnu.linkonce.armextab.*)
+  } >flash0
+
   .ARM.exidx : {
       *(.ARM.exidx* .gnu.linkonce.armexidx.*)
   } >flash0

--- a/port/raspberrypi/rp2xxx/rp2350_arm.ld
+++ b/port/raspberrypi/rp2xxx/rp2350_arm.ld
@@ -34,6 +34,10 @@ SECTIONS
      *(.rodata*)
   } > flash0
 
+  .ARM.extab : {
+      *(.ARM.extab* .gnu.linkonce.armextab.*)
+  } >flash0
+
   .ARM.exidx : {
       *(.ARM.exidx* .gnu.linkonce.armexidx.*)
   } >flash0

--- a/port/raspberrypi/rp2xxx/src/bootroms/RP2040/shared/stage2.ld
+++ b/port/raspberrypi/rp2xxx/src/bootroms/RP2040/shared/stage2.ld
@@ -18,10 +18,13 @@ SECTIONS
     *(.rodata*)
   } > flash0
 
+  .ARM.extab : {
+      *(.ARM.extab* .gnu.linkonce.armextab.*)
+  } >flash0
+
   .ARM.exidx : {
       *(.ARM.exidx* .gnu.linkonce.armexidx.*)
   } >flash0
-
 
   .data :
   {


### PR DESCRIPTION
If building a target after #373 happened to create an `.ARM.extab*` section, it would be placed before `.text`, which would shift the vector table over and prevent the device from booting.

This would happen almost always in debug builds, but could occasionally happen on `--release=fast` builds as well.

Fix this by explicitly placing it after `.text`.

Should fix #373