### PR TITLE
avr: update example to use core.experimental

### DIFF
--- a/examples/microchip/avr/build.zig
+++ b/examples/microchip/avr/build.zig
@@ -13,7 +13,7 @@ pub fn build(b: *std.Build) void {
 
     const available_examples = [_]Example{
         .{ .target = mb.ports.avr.boards.arduino.nano, .name = "arduino-nano_blinky", .file = "src/blinky.zig" },
-        .{ .target = mb.ports.avr.boards.arduino.uno_rev3, .name = "arduino-nano_blinky", .file = "src/blinky.zig" },
+        .{ .target = mb.ports.avr.boards.arduino.uno_rev3, .name = "arduino-uno_blinky", .file = "src/blinky.zig" },
     };
 
     for (available_examples) |example| {

--- a/examples/microchip/avr/src/blinky.zig
+++ b/examples/microchip/avr/src/blinky.zig
@@ -1,15 +1,17 @@
 const std = @import("std");
 const microzig = @import("microzig");
 
-// LED is PB5
-const port = microzig.chip.peripherals.PORTB;
+const led_pin = microzig.core.experimental.Pin("PB5");
 
 pub fn main() void {
-    port.DDRB |= (1 << 5);
-    port.PORTB |= 0x00;
+    const led = microzig.core.experimental.gpio.Gpio(led_pin, .{
+        .mode = .output,
+        .initial_state = .low,
+    });
+    led.init();
 
     while (true) {
-        microzig.core.experimental.debug.busy_sleep(1_000);
-        port.PINB |= (1 << 5);
+        microzig.core.experimental.debug.busy_sleep(20_000);
+        led.toggle();
     }
 }

--- a/port/microchip/avr/src/hals/ATmega328P.zig
+++ b/port/microchip/avr/src/hals/ATmega328P.zig
@@ -16,7 +16,7 @@ pub const clock = struct {
     };
 };
 
-pub fn parsePin(comptime spec: []const u8) type {
+pub fn parse_pin(comptime spec: []const u8) type {
     const invalid_format_msg = "The given pin '" ++ spec ++ "' has an invalid format. Pins must follow the format \"P{Port}{Pin}\" scheme.";
 
     if (spec.len != 3)
@@ -53,18 +53,17 @@ pub const gpio = struct {
         cpu.cbi(regs(pin).dir_addr, pin.pin);
     }
 
-    pub fn read(comptime pin: type) micro.gpio.State {
+    pub fn read(comptime pin: type) micro.core.experimental.gpio.State {
         return if ((regs(pin).pin.* & (1 << pin.pin)) != 0)
             .high
         else
             .low;
     }
 
-    pub fn write(comptime pin: type, state: micro.gpio.State) void {
-        if (state == .high) {
-            cpu.sbi(regs(pin).port_addr, pin.pin);
-        } else {
-            cpu.cbi(regs(pin).port_addr, pin.pin);
+    pub fn write(comptime pin: type, state: micro.core.experimental.gpio.State) void {
+        switch (state) {
+            .high => cpu.sbi(regs(pin).port_addr, pin.pin),
+            .low => cpu.cbi(regs(pin).port_addr, pin.pin),
         }
     }
 

--- a/port/microchip/avr/src/hals/ATmega32U4.zig
+++ b/port/microchip/avr/src/hals/ATmega32U4.zig
@@ -19,7 +19,7 @@ pub const clock = struct {
     };
 };
 
-pub fn parsePin(comptime spec: []const u8) type {
+pub fn parse_pin(comptime spec: []const u8) type {
     const invalid_format_msg = "The given pin '" ++ spec ++ "' has an invalid format. Pins must follow the format \"P{Port}{Pin}\" scheme.";
 
     if (spec.len != 3)
@@ -63,18 +63,17 @@ pub const gpio = struct {
         cpu.cbi(regs(pin).dir_addr, pin.pin);
     }
 
-    pub fn read(comptime pin: type) micro.gpio.State {
+    pub fn read(comptime pin: type) micro.core.experimental.gpio.State {
         return if ((regs(pin).pin.* & (1 << pin.pin)) != 0)
             .high
         else
             .low;
     }
 
-    pub fn write(comptime pin: type, state: micro.gpio.State) void {
-        if (state == .high) {
-            cpu.sbi(regs(pin).port_addr, pin.pin);
-        } else {
-            cpu.cbi(regs(pin).port_addr, pin.pin);
+    pub fn write(comptime pin: type, state: micro.core.experimental.gpio.State) void {
+        switch (state) {
+            .high => cpu.sbi(regs(pin).port_addr, pin.pin),
+            .low => cpu.cbi(regs(pin).port_addr, pin.pin),
         }
     }
 


### PR DESCRIPTION
This PR updates the avr example to use `core.experimental`.

In order for the code to compile and run, it needed minor adjustments.