### PR TITLE
rp2xxx: pio: Check for sideset/delay collisions

### DIFF
--- a/port/raspberrypi/rp2xxx/src/hal/pio/assembler/comparison_tests.zig
+++ b/port/raspberrypi/rp2xxx/src/hal/pio/assembler/comparison_tests.zig
@@ -41,6 +41,7 @@ fn pio_comparison(comptime source: []const u8) !void {
 }
 
 fn pio_comparison_chip(comptime chip: Chip, comptime source: []const u8) !void {
+    @setEvalBranchQuota(100_000);
     const output = comptime assembler.assemble(chip, source, .{});
     try std.testing.expect(output.programs.len > 0);
 
@@ -58,131 +59,105 @@ fn pio_comparison_chip(comptime chip: Chip, comptime source: []const u8) !void {
 }
 
 test "pio.comparison.addition" {
-    @setEvalBranchQuota(100_000);
     try pio_comparison(@embedFile("comparison_tests/addition.pio"));
 }
 
 test "pio.comparison.apa102" {
-    @setEvalBranchQuota(100_000);
     try pio_comparison(@embedFile("comparison_tests/apa102.pio"));
 }
 
 test "pio.comparison.blink" {
-    @setEvalBranchQuota(100_000);
     try pio_comparison(@embedFile("comparison_tests/blink.pio"));
 }
 
 test "pio.comparison.clocked_input" {
-    @setEvalBranchQuota(100_000);
     try pio_comparison(@embedFile("comparison_tests/clocked_input.pio"));
 }
 
 test "pio.comparison.differential_manchester" {
-    @setEvalBranchQuota(100_000);
     try pio_comparison(@embedFile("comparison_tests/differential_manchester.pio"));
 }
 
 test "pio.comparison.hello" {
-    @setEvalBranchQuota(100_000);
     try pio_comparison(@embedFile("comparison_tests/hello.pio"));
 }
 
 test "pio.comparison.hub75" {
-    @setEvalBranchQuota(100_000);
     try pio_comparison(@embedFile("comparison_tests/hub75.pio"));
 }
 
 test "pio.comparison.i2c" {
-    @setEvalBranchQuota(100_000);
     try pio_comparison(@embedFile("comparison_tests/i2c.pio"));
 }
 
 test "pio.comparison.irq" {
-    @setEvalBranchQuota(100_000);
     try pio_comparison_chip(.RP2350, @embedFile("comparison_tests/irq.pio"));
 }
 
 test "pio.comparison.manchester_encoding" {
-    @setEvalBranchQuota(100_000);
     try pio_comparison(@embedFile("comparison_tests/manchester_encoding.pio"));
 }
 
 test "pio.comparison.movrx" {
-    @setEvalBranchQuota(100_000);
     try pio_comparison_chip(.RP2350, @embedFile("comparison_tests/movrx.pio"));
 }
 
 test "pio.comparison.nec_carrier_burst" {
-    @setEvalBranchQuota(100_000);
     try pio_comparison(@embedFile("comparison_tests/nec_carrier_burst.pio"));
 }
 
 test "pio.comparison.nec_carrier_control" {
-    @setEvalBranchQuota(100_000);
     try pio_comparison(@embedFile("comparison_tests/nec_carrier_control.pio"));
 }
 
 test "pio.comparison.nec_receive" {
-    @setEvalBranchQuota(12_000);
     try pio_comparison(@embedFile("comparison_tests/nec_receive.pio"));
 }
 
 test "pio.comparison.pio_serialiser" {
-    @setEvalBranchQuota(3_000);
     try pio_comparison(@embedFile("comparison_tests/pio_serialiser.pio"));
 }
 
 test "pio.comparison.pwm" {
-    @setEvalBranchQuota(6_000);
     try pio_comparison(@embedFile("comparison_tests/pwm.pio"));
 }
 
 test "pio.comparison.quadrature_encoder" {
-    @setEvalBranchQuota(21_000);
     try pio_comparison(@embedFile("comparison_tests/quadrature_encoder.pio"));
 }
 
 test "pio.comparison.resistor_dac" {
-    @setEvalBranchQuota(3_000);
     try pio_comparison(@embedFile("comparison_tests/resistor_dac.pio"));
 }
 
 test "pio.comparison.spi" {
-    @setEvalBranchQuota(26_000);
     try pio_comparison(@embedFile("comparison_tests/spi.pio"));
 }
 
 test "pio.comparison.squarewave" {
-    @setEvalBranchQuota(3_000);
     try pio_comparison(@embedFile("comparison_tests/squarewave.pio"));
 }
 
 test "pio.comparison.squarewave_fast" {
-    @setEvalBranchQuota(3_000);
     try pio_comparison(@embedFile("comparison_tests/squarewave_fast.pio"));
 }
 
 test "pio.comparison.squarewave_wrap" {
-    @setEvalBranchQuota(3_000);
     try pio_comparison(@embedFile("comparison_tests/squarewave_wrap.pio"));
 }
 
 test "pio.comparison.st7789_lcd" {
-    @setEvalBranchQuota(6_000);
     try pio_comparison(@embedFile("comparison_tests/st7789_lcd.pio"));
 }
 
 test "pio.comparison.uart_rx" {
-    @setEvalBranchQuota(12_000);
     try pio_comparison(@embedFile("comparison_tests/uart_rx.pio"));
 }
 
 test "pio.comparison.uart_tx" {
-    @setEvalBranchQuota(7_000);
     try pio_comparison(@embedFile("comparison_tests/uart_tx.pio"));
 }
 
 test "pio.comparison.ws2812" {
-    @setEvalBranchQuota(12_000);
     try pio_comparison(@embedFile("comparison_tests/ws2812.pio"));
 }

--- a/port/raspberrypi/rp2xxx/src/hal/pio/assembler/encoder.zig
+++ b/port/raspberrypi/rp2xxx/src/hal/pio/assembler/encoder.zig
@@ -466,7 +466,6 @@ pub fn Encoder(comptime chip: Chip, comptime options: Options) type {
             delay_opt: ?u5,
         ) !u5 {
             const delay: u5 = if (delay_opt) |delay| delay else 0;
-            // const bits_needed = if (delay == 0) 0 else std.math.log2_int_ceil(u6, @as(u6, delay));
             const bits_needed = std.math.log2_int_ceil(u6, @as(u6, delay) + 1);
 
             return if (sideset_settings) |sideset|

--- a/port/raspberrypi/rp2xxx/src/hal/pio/assembler/encoder.zig
+++ b/port/raspberrypi/rp2xxx/src/hal/pio/assembler/encoder.zig
@@ -194,7 +194,15 @@ pub fn Encoder(comptime chip: Chip, comptime options: Options) type {
                         );
                     }
 
-                    return @as(T, @intCast(result));
+                    return std.math.cast(T, result) orelse blk: {
+                        diags.* = Diagnostics.init(
+                            index,
+                            "{s}'s value is too large to fit in {} bits",
+                            .{ expr_str, @bitSizeOf(T) },
+                        );
+
+                        break :blk error.TooBig;
+                    };
                 },
             };
         }

--- a/port/raspberrypi/rp2xxx/src/hal/pio/assembler/encoder.zig
+++ b/port/raspberrypi/rp2xxx/src/hal/pio/assembler/encoder.zig
@@ -470,7 +470,7 @@ pub fn Encoder(comptime chip: Chip, comptime options: Options) type {
 
             return if (sideset_settings) |sideset|
                 if (sideset.optional)
-                    if ((4 - bits_needed) < sideset.count)
+                    if ((4 - @as(i7, bits_needed)) < sideset.count)
                         error.SideSetDelayCollision
                     else if (side_set_opt) |side_set|
                         0x10 | (side_set << @as(u3, 4) - sideset.count) | delay
@@ -1131,6 +1131,13 @@ test "encode.error.sideset delay collision" {
         \\nop side 3 [31]
     );
     try expectError(error.SideSetDelayCollision, collision2);
+
+    const collision3 = encode_bounded_output(.RP2040,
+        \\.program sideset_delay_collision
+        \\.side_set 1 opt
+        \\nop side 3 [31]
+    );
+    try expectError(error.SideSetDelayCollision, collision3);
 
     _ = try encode_bounded_output(.RP2040,
         \\.program sideset_delay_collision

--- a/port/raspberrypi/rp2xxx/src/hal/pio/assembler/encoder.zig
+++ b/port/raspberrypi/rp2xxx/src/hal/pio/assembler/encoder.zig
@@ -188,21 +188,12 @@ pub fn Encoder(comptime chip: Chip, comptime options: Options) type {
                         diags.* = Diagnostics.init(
                             index,
                             "value of {} does not fit in a u{}",
-                            .{
-                                result, @bitSizeOf(T),
-                            },
+                            .{ result, @bitSizeOf(T) },
                         );
+                        return error.TooBig;
                     }
 
-                    return std.math.cast(T, result) orelse blk: {
-                        diags.* = Diagnostics.init(
-                            index,
-                            "{s}'s value is too large to fit in {} bits",
-                            .{ expr_str, @bitSizeOf(T) },
-                        );
-
-                        break :blk error.TooBig;
-                    };
+                    return @as(T, @intCast(result));
                 },
             };
         }

--- a/port/raspberrypi/rp2xxx/src/hal/pio/assembler/encoder.zig
+++ b/port/raspberrypi/rp2xxx/src/hal/pio/assembler/encoder.zig
@@ -466,17 +466,18 @@ pub fn Encoder(comptime chip: Chip, comptime options: Options) type {
             delay_opt: ?u5,
         ) !u5 {
             const delay: u5 = if (delay_opt) |delay| delay else 0;
+            // const bits_needed = if (delay == 0) 0 else std.math.log2_int_ceil(u6, @as(u6, delay));
             const bits_needed = std.math.log2_int_ceil(u6, @as(u6, delay) + 1);
 
             return if (sideset_settings) |sideset|
                 if (sideset.optional)
-                    if ((4 - @as(i7, bits_needed)) < sideset.count)
+                    if (sideset.count + bits_needed > 4)
                         error.SideSetDelayCollision
                     else if (side_set_opt) |side_set|
                         0x10 | (side_set << @as(u3, 4) - sideset.count) | delay
                     else
                         delay
-                else if ((5 - bits_needed) < sideset.count)
+                else if (sideset.count + bits_needed > 5)
                     error.SideSetDelayCollision
                 else
                     (side_set_opt.? << @as(u3, 5) - sideset.count) | delay

--- a/port/raspberrypi/rp2xxx/src/hal/pio/assembler/encoder.zig
+++ b/port/raspberrypi/rp2xxx/src/hal/pio/assembler/encoder.zig
@@ -1035,6 +1035,14 @@ test "encode.evaluate.bit reversal" {
     try expectEqual(@as(i128, 0x80000000), output.global_defines.get(0).value);
 }
 
+test "encode.evaluate.value size" {
+    const bits = encode_bounded_output(.RP2040,
+        \\.program sideset_delay_collision
+        \\nop [32]
+    );
+    try expectError(error.TooBig, bits);
+}
+
 test "encode.jmp.label" {
     const output = try encode_bounded_output(.RP2040,
         \\.program arst

--- a/port/raspberrypi/rp2xxx/src/hal/pio/assembler/encoder.zig
+++ b/port/raspberrypi/rp2xxx/src/hal/pio/assembler/encoder.zig
@@ -467,7 +467,7 @@ pub fn Encoder(comptime chip: Chip, comptime options: Options) type {
             delay_opt: ?u5,
         ) !u5 {
             const delay: u5 = if (delay_opt) |delay| delay else 0;
-            const bits_needed = std.math.log2_int_ceil(u64, delay + 1);
+            const bits_needed = std.math.log2_int_ceil(u6, @as(u6, delay) + 1);
 
             return if (sideset_settings) |sideset|
                 if (sideset.optional)
@@ -1122,6 +1122,11 @@ test "encode.error.sideset delay collision" {
         \\.program sideset_delay_collision
         \\.side_set 2
         \\nop side 3 [7]
+    );
+
+    _ = try encode_bounded_output(.RP2040,
+        \\.program sideset_delay_collision
+        \\nop [31]
     );
 }
 


### PR DESCRIPTION
Check that the number of bits required for the delay can fit in the bits leftover after sideset takes its own