### PR TITLE
import microzig as microzig

### DIFF
--- a/core/src/core/experimental/gpio.zig
+++ b/core/src/core/experimental/gpio.zig
@@ -1,5 +1,5 @@
 const std = @import("std");
-const micro = @import("microzig");
+const microzig = @import("microzig");
 const hal = @import("hal");
 
 pub const Mode = enum {

--- a/core/src/core/experimental/gpio.zig
+++ b/core/src/core/experimental/gpio.zig
@@ -1,5 +1,4 @@
 const std = @import("std");
-const microzig = @import("microzig");
 const hal = @import("hal");
 
 pub const Mode = enum {

--- a/core/test/programs/blinky.zig
+++ b/core/test/programs/blinky.zig
@@ -1,27 +1,27 @@
-const micro = @import("microzig");
+const microzig = @import("microzig");
 
 // Configures the led_pin to a hardware pin
-const led_pin = if (micro.config.has_board)
-    switch (micro.config.board_name) {
-        .@"Arduino Nano" => micro.Pin("D13"),
-        .@"Arduino Uno" => micro.Pin("D13"),
-        .@"mbed LPC1768" => micro.Pin("LED-1"),
-        .STM32F3DISCOVERY => micro.Pin("LD3"),
-        .STM32F4DISCOVERY => micro.Pin("LD5"),
-        .STM32F429IDISCOVERY => micro.Pin("LD4"),
-        .@"Longan Nano" => micro.Pin("PA2"),
+const led_pin = if (microzig.config.has_board)
+    switch (microzig.config.board_name) {
+        .@"Arduino Nano" => microzig.Pin("D13"),
+        .@"Arduino Uno" => microzig.Pin("D13"),
+        .@"mbed LPC1768" => microzig.Pin("LED-1"),
+        .STM32F3DISCOVERY => microzig.Pin("LD3"),
+        .STM32F4DISCOVERY => microzig.Pin("LD5"),
+        .STM32F429IDISCOVERY => microzig.Pin("LD4"),
+        .@"Longan Nano" => microzig.Pin("PA2"),
         else => @compileError("unknown board"),
     }
-else switch (micro.config.chip_name) {
-    .ATmega328p => micro.Pin("PB5"),
-    .@"NXP LPC1768" => micro.Pin("P1.18"),
-    .STM32F103x8 => micro.Pin("PC13"),
-    .GD32VF103x8 => micro.Pin("PA2"),
+else switch (microzig.config.chip_name) {
+    .ATmega328p => microzig.Pin("PB5"),
+    .@"NXP LPC1768" => microzig.Pin("P1.18"),
+    .STM32F103x8 => microzig.Pin("PC13"),
+    .GD32VF103x8 => microzig.Pin("PA2"),
     else => @compileError("unknown chip"),
 };
 
 pub fn main() void {
-    const led = micro.Gpio(led_pin, .{
+    const led = microzig.Gpio(led_pin, .{
         .mode = .output,
         .initial_state = .low,
     });

--- a/core/test/programs/interrupt.zig
+++ b/core/test/programs/interrupt.zig
@@ -1,4 +1,4 @@
-const micro = @import("microzig");
+const microzig = @import("microzig");
 const builtin = @import("builtin");
 
 pub const interrupts = switch (builtin.cpu.arch) {

--- a/core/test/programs/interrupt.zig
+++ b/core/test/programs/interrupt.zig
@@ -1,4 +1,3 @@
-const microzig = @import("microzig");
 const builtin = @import("builtin");
 
 pub const interrupts = switch (builtin.cpu.arch) {

--- a/core/test/programs/uart-sync.zig
+++ b/core/test/programs/uart-sync.zig
@@ -1,49 +1,49 @@
-const micro = @import("microzig");
+const microzig = @import("microzig");
 
 // Configures the led_pin and uart index
-const cfg = if (micro.config.has_board)
-    switch (micro.config.board_name) {
+const cfg = if (microzig.config.has_board)
+    switch (microzig.config.board_name) {
         .@"mbed LPC1768" => .{
-            .led_pin = micro.Pin("LED-1"),
+            .led_pin = microzig.Pin("LED-1"),
             .uart_idx = 1,
             .pins = .{},
         },
         .STM32F3DISCOVERY => .{
-            .led_pin = micro.Pin("LD3"),
+            .led_pin = microzig.Pin("LD3"),
             .uart_idx = 1,
             .pins = .{},
         },
         .STM32F4DISCOVERY => .{
-            .led_pin = micro.Pin("LD5"),
+            .led_pin = microzig.Pin("LD5"),
             .uart_idx = 2,
-            .pins = .{ .tx = micro.Pin("PA2"), .rx = micro.Pin("PA3") },
+            .pins = .{ .tx = microzig.Pin("PA2"), .rx = microzig.Pin("PA3") },
         },
         .@"Longan Nano" => .{
-            .led_pin = micro.Pin("PA2"),
+            .led_pin = microzig.Pin("PA2"),
             .uart_idx = 1,
             .pins = .{ .tx = null, .rx = null },
         },
         .@"Arduino Uno" => .{
-            .led_pin = micro.Pin("D13"),
+            .led_pin = microzig.Pin("D13"),
             .uart_idx = 0,
             .pins = .{},
         },
         else => @compileError("unknown board"),
     }
-else switch (micro.config.chip_name) {
-    .@"NXP LPC1768" => .{ .led_pin = micro.Pin("P1.18"), .uart_idx = 1, .pins = .{} },
-    .GD32VF103x8 => .{ .led_pin = micro.Pin("PA2"), .uart_idx = 1, .pins = .{} },
+else switch (microzig.config.chip_name) {
+    .@"NXP LPC1768" => .{ .led_pin = microzig.Pin("P1.18"), .uart_idx = 1, .pins = .{} },
+    .GD32VF103x8 => .{ .led_pin = microzig.Pin("PA2"), .uart_idx = 1, .pins = .{} },
     else => @compileError("unknown chip"),
 };
 
 pub fn main() !void {
-    const led = micro.Gpio(cfg.led_pin, .{
+    const led = microzig.Gpio(cfg.led_pin, .{
         .mode = .output,
         .initial_state = .low,
     });
     led.init();
 
-    var uart = micro.Uart(cfg.uart_idx, cfg.pins).init(.{
+    var uart = microzig.Uart(cfg.uart_idx, cfg.pins).init(.{
         .baud_rate = 9600,
         .stop_bits = .one,
         .parity = null,
@@ -51,7 +51,7 @@ pub fn main() !void {
     }) catch |err| {
         blinkError(led, err);
 
-        micro.hang();
+        microzig.hang();
     };
 
     var out = uart.writer();
@@ -60,11 +60,11 @@ pub fn main() !void {
         led.setToHigh();
         try out.writeAll("Hello microzig!\r\n");
         led.setToLow();
-        micro.debug.busySleep(100_000);
+        microzig.debug.busySleep(100_000);
     }
 }
 
-fn blinkError(led: anytype, err: micro.uart.InitError) void {
+fn blinkError(led: anytype, err: microzig.uart.InitError) void {
     var blinks: u3 =
         switch (err) {
         error.UnsupportedBaudRate => 1,
@@ -75,8 +75,8 @@ fn blinkError(led: anytype, err: micro.uart.InitError) void {
 
     while (blinks > 0) : (blinks -= 1) {
         led.setToHigh();
-        micro.debug.busySleep(1_000_000);
+        microzig.debug.busySleep(1_000_000);
         led.setToLow();
-        micro.debug.busySleep(1_000_000);
+        microzig.debug.busySleep(1_000_000);
     }
 }

--- a/core/thoughts.md
+++ b/core/thoughts.md
@@ -20,11 +20,11 @@ root
 Declaring `panic` in the root file will cause `builtin` to reference the proper package which will then instantiate microzig which will reference `mcu` package which will instantiate `reset` (or similar) which will invoke `microzig.main()` which will invoke `root.main()`. Oh boy :laughing:
 
 ```zig
-const micro = @import("micro");
+const microzig = @import("microzig");
 
-pub const panic = micro.panic; // this will instantiate microzig
+pub const panic = microzig.panic; // this will instantiate microzig
 
-comptime { _ = micro };  // this should not be necessary
+comptime { _ = microzig };  // this should not be necessary
 
 pub fn main() void {
 
@@ -59,18 +59,18 @@ A symbol can be a function `fn() void`, or a anonymous enum literal `.hang` or `
 
 ```zig
 pub fn main() void {
-  micro.interrupts.enable(.WDT);  // enables the WDT interrupt
-  micro.interrupts.disable(.WDT); // enables the WDT interrupt
-  micro.interrupts.enable(.WTF); // yields compile error "WTF is not a valid interrupt"
-  micro.interrupts.enable(.PCINT0); // yields compile error "PCINT0 has no defined interrupt handler"
-  micro.interrupts.enable(.NMI); // yields compile error "NMI cannot be masked"
-  micro.interrupts.enableAll();
-  micro.interrupts.batchEnable(.{ .NMI, .WDT  });
+  microzig.interrupts.enable(.WDT);  // enables the WDT interrupt
+  microzig.interrupts.disable(.WDT); // enables the WDT interrupt
+  microzig.interrupts.enable(.WTF); // yields compile error "WTF is not a valid interrupt"
+  microzig.interrupts.enable(.PCINT0); // yields compile error "PCINT0 has no defined interrupt handler"
+  microzig.interrupts.enable(.NMI); // yields compile error "NMI cannot be masked"
+  microzig.interrupts.enableAll();
+  microzig.interrupts.batchEnable(.{ .NMI, .WDT  });
   
-  micro.interrupts.cli(); // set interrupt enabled (global enable)
+  microzig.interrupts.cli(); // set interrupt enabled (global enable)
   
   { // critical section
-    var crit = micro.interrupts.enterCriticalSection();
+    var crit = microzig.interrupts.enterCriticalSection();
     defer crit.leave();
   }
 }
@@ -100,7 +100,7 @@ pub const interrupt_handlers = struct {
 microzig should allow having a general purpose timer mechanism
 
 ```zig
-pub var cpu_frequency = 16.0 * micro.clock.mega_hertz;
+pub var cpu_frequency = 16.0 * microzig.clock.mega_hertz;
 
 pub const sleep_mode = .timer; // timer, busyloop, whatever
 
@@ -109,7 +109,7 @@ pub fn main() !void {
 
   while(true) {
     led.toggle();
-    micro.sleep(100_000); // sleep 100ms
+    microzig.sleep(100_000); // sleep 100ms
   }
 }
 ```
@@ -121,18 +121,18 @@ pub fn main() !void {
 
 ```zig
 
-// micro.Pin returns a type containing all relevant pin information
-const status_led_pin = micro.Pin("PA3");
+// microzig.Pin returns a type containing all relevant pin information
+const status_led_pin = microzig.Pin("PA3");
 
 // generate a runtime possible pin that cannot be used in all APIs
-var generic_pic: micro.RuntimePin.init(status_led_pin);
+var generic_pic: microzig.RuntimePin.init(status_led_pin);
 
 // 4 Bit IEEE-488 bit banging register
-const serial_out = micro.GpioOutputRegister(.{
-  micro.Pin("PA0"),
-  micro.Pin("PA1"),
-  micro.Pin("PA3"), // whoopsies, i miswired, let the software fix that
-  micro.Pin("PA2"),
+const serial_out = microzig.GpioOutputRegister(.{
+  microzig.Pin("PA0"),
+  microzig.Pin("PA1"),
+  microzig.Pin("PA3"), // whoopsies, i miswired, let the software fix that
+  microzig.Pin("PA2"),
 });
 
 pub fn bitBang(nibble: u4) void {
@@ -150,9 +150,9 @@ pub fn main() !void {
 	// route that pin to UART.RXD
   status_led_pin.route(.uart0_rxd); 
   
-  //var uart_read_dma_channel = micro.Dma.init(.{.channel = 1});
+  //var uart_read_dma_channel = microzig.Dma.init(.{.channel = 1});
   
-  const status_led = micro.Gpio(status_led_pin, .{
+  const status_led = microzig.Gpio(status_led_pin, .{
     .mode          = .output,       // { input, output, input_output, open_drain, generic }
     .initial_state = .unspecificed, // { unspecified, low, high, floating, driven }
   });
@@ -206,17 +206,17 @@ pub fn main() !void {
 
 ```zig
 const std = @import("std");
-const micro = @import("µzig");
+const microzig = @import("µzig");
 
 // if const it can be comptime-optimized
-pub var cpu_frequency = 100.0 * micro.clock.mega_hertz;
+pub var cpu_frequency = 100.0 * microzig.clock.mega_hertz;
 
 // if this is enabled, a event loop will run
 // in microzig.main() that allows using `async`/`await` "just like that" *grin*
 pub const io_mode = .evented;
 
 pub fn main() !void {
-  var debug_port = micro.Uart.init(0, .{
+  var debug_port = microzig.Uart.init(0, .{
     .baud_rate = 9600,
     .stop_bits = .@"2",
     .parity = .none, // { none, even, odd, mark, space }
@@ -239,7 +239,7 @@ pub fn main() !void {
 
 ## Initialization
 
-somewhere inside micro.zig
+somewhere inside microzig.zig
 ```zig
 extern fn reset() noreturn {
   if(@hasDecl(mcu, "mcu_reset")) {

--- a/port/gigadevice/gd32/src/boards/longan_nano.zig
+++ b/port/gigadevice/gd32/src/boards/longan_nano.zig
@@ -1,5 +1,5 @@
 pub const chip = @import("chip");
-pub const micro = @import("microzig");
+pub const microzig = @import("microzig");
 
 pub const cpu_frequency = 8_000_000; // 8 MHz
 

--- a/port/gigadevice/gd32/src/boards/longan_nano.zig
+++ b/port/gigadevice/gd32/src/boards/longan_nano.zig
@@ -1,5 +1,4 @@
 pub const chip = @import("chip");
-pub const microzig = @import("microzig");
 
 pub const cpu_frequency = 8_000_000; // 8 MHz
 

--- a/port/gigadevice/gd32/src/hals/GD32VF103.zig
+++ b/port/gigadevice/gd32/src/hals/GD32VF103.zig
@@ -1,5 +1,5 @@
-const micro = @import("microzig");
-const peripherals = micro.chip.peripherals;
+const microzig = @import("microzig");
+const peripherals = microzig.chip.peripherals;
 const UART3 = peripherals.UART3;
 const UART4 = peripherals.UART4;
 
@@ -40,13 +40,13 @@ pub const gpio = struct {
         // TODO: check if pin is already configured as input
     }
 
-    pub fn read(comptime pin: type) micro.gpio.State {
+    pub fn read(comptime pin: type) microzig.gpio.State {
         _ = pin;
         // TODO: check if pin is configured as input
         return .low;
     }
 
-    pub fn write(comptime pin: type, state: micro.gpio.State) void {
+    pub fn write(comptime pin: type, state: microzig.gpio.State) void {
         _ = pin;
         _ = state;
         // TODO: check if pin is configured as output
@@ -74,7 +74,7 @@ pub const uart = struct {
     };
 };
 
-pub fn Uart(comptime index: usize, comptime pins: micro.uart.Pins) type {
+pub fn Uart(comptime index: usize, comptime pins: microzig.uart.Pins) type {
     if (pins.tx != null or pins.rx != null)
         @compileError("TODO: custom pins are not currently supported");
 
@@ -86,7 +86,7 @@ pub fn Uart(comptime index: usize, comptime pins: micro.uart.Pins) type {
         };
         const Self = @This();
 
-        pub fn init(config: micro.uart.Config) !Self {
+        pub fn init(config: microzig.uart.Config) !Self {
             _ = config;
             return Self{};
         }

--- a/port/gigadevice/gd32/src/hals/GD32VF103/uart.zig
+++ b/port/gigadevice/gd32/src/hals/GD32VF103/uart.zig
@@ -1,5 +1,5 @@
-const micro = @import("microzig");
-const peripherals = micro.chip.peripherals;
+const microzig = @import("microzig");
+const peripherals = microzig.chip.peripherals;
 const UART3 = peripherals.UART3;
 const UART4 = peripherals.UART4;
 
@@ -24,7 +24,7 @@ pub const uart = struct {
     };
 };
 
-pub fn Uart(comptime index: usize, comptime pins: micro.uart.Pins) type {
+pub fn Uart(comptime index: usize, comptime pins: microzig.uart.Pins) type {
     if (pins.tx != null or pins.rx != null)
         @compileError("TODO: custom pins are not currently supported");
 
@@ -36,7 +36,7 @@ pub fn Uart(comptime index: usize, comptime pins: micro.uart.Pins) type {
         };
         const Self = @This();
 
-        pub fn init(config: micro.uart.Config) !Self {
+        pub fn init(config: microzig.uart.Config) !Self {
             _ = config;
             return Self{};
         }

--- a/port/gigadevice/gd32/test/programs/minimal.zig
+++ b/port/gigadevice/gd32/test/programs/minimal.zig
@@ -1,4 +1,4 @@
-const micro = @import("microzig");
+const microzig = @import("microzig");
 
 pub fn main() void {
     // This function will contain the application logic.

--- a/port/microchip/avr/src/boards.zig
+++ b/port/microchip/avr/src/boards.zig
@@ -1,5 +1,4 @@
 const std = @import("std");
-const microzig = @import("microzig");
 const chips = @import("chips.zig");
 
 fn root_dir() []const u8 {

--- a/port/microchip/avr/src/boards.zig
+++ b/port/microchip/avr/src/boards.zig
@@ -1,5 +1,5 @@
 const std = @import("std");
-const micro = @import("microzig");
+const microzig = @import("microzig");
 const chips = @import("chips.zig");
 
 fn root_dir() []const u8 {

--- a/port/microchip/avr/src/chips.zig
+++ b/port/microchip/avr/src/chips.zig
@@ -1,7 +1,7 @@
 const std = @import("std");
-const micro = @import("microzig");
-const Chip = micro.Chip;
-const MemoryRegion = micro.MemoryRegion;
+const microzig = @import("microzig");
+const Chip = microzig.Chip;
+const MemoryRegion = microzig.MemoryRegion;
 
 fn root_dir() []const u8 {
     return std.fs.path.dirname(@src().file) orelse ".";

--- a/port/microchip/avr/src/hals/ATmega328P.zig
+++ b/port/microchip/avr/src/hals/ATmega328P.zig
@@ -1,9 +1,9 @@
 const std = @import("std");
-const micro = @import("microzig");
-const peripherals = micro.chip.peripherals;
+const microzig = @import("microzig");
+const peripherals = microzig.chip.peripherals;
 const USART0 = peripherals.USART0;
 
-pub const cpu = micro.cpu;
+pub const cpu = microzig.cpu;
 const Port = enum(u8) {
     B = 1,
     C = 2,
@@ -53,14 +53,14 @@ pub const gpio = struct {
         cpu.cbi(regs(pin).dir_addr, pin.pin);
     }
 
-    pub fn read(comptime pin: type) micro.core.experimental.gpio.State {
+    pub fn read(comptime pin: type) microzig.core.experimental.gpio.State {
         return if ((regs(pin).pin.* & (1 << pin.pin)) != 0)
             .high
         else
             .low;
     }
 
-    pub fn write(comptime pin: type, state: micro.core.experimental.gpio.State) void {
+    pub fn write(comptime pin: type, state: microzig.core.experimental.gpio.State) void {
         switch (state) {
             .high => cpu.sbi(regs(pin).port_addr, pin.pin),
             .low => cpu.cbi(regs(pin).port_addr, pin.pin),
@@ -92,7 +92,7 @@ pub const uart = struct {
     };
 };
 
-pub fn Uart(comptime index: usize, comptime pins: micro.uart.Pins) type {
+pub fn Uart(comptime index: usize, comptime pins: microzig.uart.Pins) type {
     if (index != 0) @compileError("Atmega328p only has a single uart!");
     if (pins.tx != null or pins.rx != null)
         @compileError("Atmega328p has fixed pins for uart!");
@@ -101,17 +101,17 @@ pub fn Uart(comptime index: usize, comptime pins: micro.uart.Pins) type {
         const Self = @This();
 
         fn computeDivider(baud_rate: u32) !u12 {
-            const pclk = micro.clock.get().cpu;
+            const pclk = microzig.clock.get().cpu;
             const divider = ((pclk + (8 * baud_rate)) / (16 * baud_rate)) - 1;
 
             return std.math.cast(u12, divider) orelse return error.UnsupportedBaudRate;
         }
 
         fn computeBaudRate(divider: u12) u32 {
-            return micro.clock.get().cpu / (16 * @as(u32, divider) + 1);
+            return microzig.clock.get().cpu / (16 * @as(u32, divider) + 1);
         }
 
-        pub fn init(config: micro.uart.Config) !Self {
+        pub fn init(config: microzig.uart.Config) !Self {
             const ucsz: u3 = switch (config.data_bits) {
                 .five => 0b000,
                 .six => 0b001,

--- a/port/microchip/avr/src/hals/ATmega32U4.zig
+++ b/port/microchip/avr/src/hals/ATmega32U4.zig
@@ -1,10 +1,10 @@
 // Almost an exact clone of ATmega328p
 const std = @import("std");
-const micro = @import("microzig");
-const peripherals = micro.chip.peripherals;
+const microzig = @import("microzig");
+const peripherals = microzig.chip.peripherals;
 const USART1 = peripherals.USART1;
 
-pub const cpu = micro.cpu;
+pub const cpu = microzig.cpu;
 const Port = enum(u8) {
     B = 1,
     C = 2,
@@ -63,14 +63,14 @@ pub const gpio = struct {
         cpu.cbi(regs(pin).dir_addr, pin.pin);
     }
 
-    pub fn read(comptime pin: type) micro.core.experimental.gpio.State {
+    pub fn read(comptime pin: type) microzig.core.experimental.gpio.State {
         return if ((regs(pin).pin.* & (1 << pin.pin)) != 0)
             .high
         else
             .low;
     }
 
-    pub fn write(comptime pin: type, state: micro.core.experimental.gpio.State) void {
+    pub fn write(comptime pin: type, state: microzig.core.experimental.gpio.State) void {
         switch (state) {
             .high => cpu.sbi(regs(pin).port_addr, pin.pin),
             .low => cpu.cbi(regs(pin).port_addr, pin.pin),
@@ -102,7 +102,7 @@ pub const uart = struct {
     };
 };
 
-pub fn Uart(comptime index: usize, comptime pins: micro.uart.Pins) type {
+pub fn Uart(comptime index: usize, comptime pins: microzig.uart.Pins) type {
     if (index != 0) @compileError("Atmega32U4 only has a single uart!");
     if (pins.tx != null or pins.rx != null)
         @compileError("Atmega32U4 has fixed pins for uart!");
@@ -111,17 +111,17 @@ pub fn Uart(comptime index: usize, comptime pins: micro.uart.Pins) type {
         const Self = @This();
 
         fn computeDivider(baud_rate: u32) !u12 {
-            const pclk = micro.clock.get().cpu;
+            const pclk = microzig.clock.get().cpu;
             const divider = ((pclk + (8 * baud_rate)) / (16 * baud_rate)) - 1;
 
             return std.math.cast(u12, divider) orelse return error.UnsupportedBaudRate;
         }
 
         fn computeBaudRate(divider: u12) u32 {
-            return micro.clock.get().cpu / (16 * @as(u32, divider) + 1);
+            return microzig.clock.get().cpu / (16 * @as(u32, divider) + 1);
         }
 
-        pub fn init(config: micro.uart.Config) !Self {
+        pub fn init(config: microzig.uart.Config) !Self {
             const ucsz: u3 = switch (config.data_bits) {
                 .five => 0b000,
                 .six => 0b001,

--- a/port/microchip/avr/test/programs/minimal.zig
+++ b/port/microchip/avr/test/programs/minimal.zig
@@ -1,4 +1,4 @@
-const micro = @import("microzig");
+const microzig = @import("microzig");
 
 pub fn main() void {
     // This function will contain the application logic.

--- a/port/nordic/nrf5x/test/programs/minimal.zig
+++ b/port/nordic/nrf5x/test/programs/minimal.zig
@@ -1,4 +1,4 @@
-const micro = @import("microzig");
+const microzig = @import("microzig");
 
 pub fn main() void {
     // This function will contain the application logic.

--- a/port/nxp/lpc/src/boards/mbed_LPC1768.zig
+++ b/port/nxp/lpc/src/boards/mbed_LPC1768.zig
@@ -1,21 +1,21 @@
 pub const chip = @import("chip");
-pub const micro = @import("microzig");
+pub const microzig = @import("microzig");
 
 pub const clock_frequencies = .{
     .cpu = 100_000_000, // 100 Mhz
 };
 
 pub fn debug_write(string: []const u8) void {
-    const clk_pin = micro.Pin("DIP5");
-    const dat_pin = micro.Pin("DIP6");
+    const clk_pin = microzig.Pin("DIP5");
+    const dat_pin = microzig.Pin("DIP6");
 
-    const clk = micro.core.experimental.Gpio(clk_pin, .{ .mode = .output, .initial_state = .low });
-    const dat = micro.core.experimental.Gpio(dat_pin, .{ .mode = .output, .initial_state = .low });
+    const clk = microzig.core.experimental.Gpio(clk_pin, .{ .mode = .output, .initial_state = .low });
+    const dat = microzig.core.experimental.Gpio(dat_pin, .{ .mode = .output, .initial_state = .low });
 
     clk.init();
     dat.init();
 
-    micro.debug.busy_sleep(1_000);
+    microzig.debug.busy_sleep(1_000);
 
     for (string) |c| {
         comptime var i: usize = 128;
@@ -26,9 +26,9 @@ pub fn debug_write(string: []const u8) void {
                 dat.write(.low);
             }
             clk.write(.high);
-            micro.debug.busy_sleep(1_000);
+            microzig.debug.busy_sleep(1_000);
             clk.write(.low);
-            micro.debug.busy_sleep(1_000);
+            microzig.debug.busy_sleep(1_000);
         }
     }
     dat.write(.low);

--- a/port/nxp/lpc/src/hals/LPC176x5x.zig
+++ b/port/nxp/lpc/src/hals/LPC176x5x.zig
@@ -1,6 +1,6 @@
 const std = @import("std");
-const micro = @import("microzig");
-const peripherals = micro.chip.peripherals;
+const microzig = @import("microzig");
+const peripherals = microzig.chip.peripherals;
 const GPIO = peripherals.GPIO;
 const PINCONNECT = peripherals.PINCONNECT;
 const UART0 = peripherals.UART0;
@@ -75,14 +75,14 @@ pub const gpio = struct {
         pin.regs.dir.raw &= ~pin.gpio_mask;
     }
 
-    pub fn read(comptime pin: type) micro.gpio.State {
+    pub fn read(comptime pin: type) microzig.gpio.State {
         return if ((pin.regs.pin.raw & pin.gpio_mask) != 0)
-            micro.gpio.State.high
+            microzig.gpio.State.high
         else
-            micro.gpio.State.low;
+            microzig.gpio.State.low;
     }
 
-    pub fn write(comptime pin: type, state: micro.gpio.State) void {
+    pub fn write(comptime pin: type, state: microzig.gpio.State) void {
         if (state == .high) {
             pin.regs.set.raw = pin.gpio_mask;
         } else {
@@ -119,7 +119,7 @@ pub const uart = struct {
     };
 };
 
-pub fn Uart(comptime index: usize, comptime pins: micro.uart.Pins) type {
+pub fn Uart(comptime index: usize, comptime pins: microzig.uart.Pins) type {
     if (pins.tx != null or pins.rx != null)
         @compileError("TODO: custom pins are not currently supported");
 
@@ -133,8 +133,8 @@ pub fn Uart(comptime index: usize, comptime pins: micro.uart.Pins) type {
         };
         const Self = @This();
 
-        pub fn init(config: micro.uart.Config) !Self {
-            micro.debug.write("0");
+        pub fn init(config: microzig.uart.Config) !Self {
+            microzig.debug.write("0");
             switch (index) {
                 0 => {
                     SYSCON.PCONP.modify(.{ .PCUART0 = 1 });
@@ -154,7 +154,7 @@ pub fn Uart(comptime index: usize, comptime pins: micro.uart.Pins) type {
                 },
                 else => unreachable,
             }
-            micro.debug.write("1");
+            microzig.debug.write("1");
 
             UARTn.LCR.modify(.{
                 // 8N1
@@ -165,17 +165,17 @@ pub fn Uart(comptime index: usize, comptime pins: micro.uart.Pins) type {
                 .BC = 0,
                 .DLAB = 1,
             });
-            micro.debug.write("2");
+            microzig.debug.write("2");
 
             // TODO: UARTN_FIFOS_ARE_DISA is not available in all uarts
             //UARTn.FCR.modify(.{ .FIFOEN = .UARTN_FIFOS_ARE_DISA });
 
-            micro.debug.writer().print("clock: {} baud: {} ", .{
-                micro.clock.get().cpu,
+            microzig.debug.writer().print("clock: {} baud: {} ", .{
+                microzig.clock.get().cpu,
                 config.baud_rate,
             }) catch {};
 
-            const pclk = micro.clock.get().cpu / 4;
+            const pclk = microzig.clock.get().cpu / 4;
             const divider = (pclk / (16 * config.baud_rate));
 
             const regval = std.math.cast(u16, divider) orelse return error.UnsupportedBaudRate;

--- a/port/nxp/lpc/test/programs/minimal.zig
+++ b/port/nxp/lpc/test/programs/minimal.zig
@@ -1,4 +1,4 @@
-const micro = @import("microzig");
+const microzig = @import("microzig");
 
 pub fn main() void {
     // This function will contain the application logic.

--- a/port/stmicro/stm32/src/boards/STM32F3DISCOVERY.zig
+++ b/port/stmicro/stm32/src/boards/STM32F3DISCOVERY.zig
@@ -1,4 +1,4 @@
-pub const micro = @import("microzig");
+pub const microzig = @import("microzig");
 
 pub const cpu_frequency = 8_000_000;
 
@@ -24,7 +24,7 @@ pub const pin_map = .{
 };
 
 pub fn debug_write(string: []const u8) void {
-    const uart1 = micro.core.experimental.Uart(1, .{}).get_or_init(.{
+    const uart1 = microzig.core.experimental.Uart(1, .{}).get_or_init(.{
         .baud_rate = 9600,
         .data_bits = .eight,
         .parity = null,

--- a/port/stmicro/stm32/src/hals/STM32F429.zig
+++ b/port/stmicro/stm32/src/hals/STM32F429.zig
@@ -21,8 +21,8 @@
 //! TODO: add more clock calculations when adding Uart
 
 const std = @import("std");
-const micro = @import("microzig");
-const peripherals = micro.peripherals;
+const microzig = @import("microzig");
+const peripherals = microzig.peripherals;
 const RCC = peripherals.RCC;
 
 pub const clock = struct {
@@ -77,13 +77,13 @@ pub const gpio = struct {
         setRegField(@field(pin.gpio_port, "MODER"), "MODER" ++ pin.suffix, 0b00);
     }
 
-    pub fn read(comptime pin: type) micro.gpio.State {
+    pub fn read(comptime pin: type) microzig.gpio.State {
         const idr_reg = pin.gpio_port.IDR;
         const reg_value = @field(idr_reg.read(), "IDR" ++ pin.suffix); // TODO extract to getRegField()?
-        return @as(micro.gpio.State, @enumFromInt(reg_value));
+        return @as(microzig.gpio.State, @enumFromInt(reg_value));
     }
 
-    pub fn write(comptime pin: type, state: micro.gpio.State) void {
+    pub fn write(comptime pin: type, state: microzig.gpio.State) void {
         switch (state) {
             .low => setRegField(pin.gpio_port.BSRR, "BR" ++ pin.suffix, 1),
             .high => setRegField(pin.gpio_port.BSRR, "BS" ++ pin.suffix, 1),

--- a/port/stmicro/stm32/test/programs/minimal.zig
+++ b/port/stmicro/stm32/test/programs/minimal.zig
@@ -1,4 +1,4 @@
-const micro = @import("microzig");
+const microzig = @import("microzig");
 
 pub fn main() void {
     // This function will contain the application logic.

--- a/port/wch/ch32v/src/boards/CH32V003F4P6-R0-1v1.zig
+++ b/port/wch/ch32v/src/boards/CH32V003F4P6-R0-1v1.zig
@@ -1,6 +1,6 @@
 // CH32V003F4P6_MINI
 // CH32V003
 pub const chip = @import("chip");
-pub const micro = @import("microzig");
+pub const microzig = @import("microzig");
 
 pub const cpu_frequency = 24_000_000; // 24 MHz

--- a/port/wch/ch32v/src/boards/CH32V003F4P6-R0-1v1.zig
+++ b/port/wch/ch32v/src/boards/CH32V003F4P6-R0-1v1.zig
@@ -1,6 +1,5 @@
 // CH32V003F4P6_MINI
 // CH32V003
 pub const chip = @import("chip");
-pub const microzig = @import("microzig");
 
 pub const cpu_frequency = 24_000_000; // 24 MHz

--- a/port/wch/ch32v/src/boards/CH32V103-R1-1v1.zig
+++ b/port/wch/ch32v/src/boards/CH32V103-R1-1v1.zig
@@ -1,6 +1,6 @@
 // CH32V103最小系統
 // CH32V103
 pub const chip = @import("chip");
-pub const micro = @import("microzig");
+pub const microzig = @import("microzig");
 
 pub const cpu_frequency = 8_000_000; // 8 MHz

--- a/port/wch/ch32v/src/boards/CH32V307V-R1-1v0.zig
+++ b/port/wch/ch32v/src/boards/CH32V307V-R1-1v0.zig
@@ -1,6 +1,6 @@
 // CH32V307V_MINI
 // CH32V307
 pub const chip = @import("chip");
-pub const micro = @import("microzig");
+pub const microzig = @import("microzig");
 
 pub const cpu_frequency = 8_000_000; // 8 MHz

--- a/port/wch/ch32v/src/boards/CH32V307V-R1-1v0.zig
+++ b/port/wch/ch32v/src/boards/CH32V307V-R1-1v0.zig
@@ -1,6 +1,5 @@
 // CH32V307V_MINI
 // CH32V307
 pub const chip = @import("chip");
-pub const microzig = @import("microzig");
 
 pub const cpu_frequency = 8_000_000; // 8 MHz

--- a/port/wch/ch32v/src/boards/CH32Vx03C-R0-1v0.zig
+++ b/port/wch/ch32v/src/boards/CH32Vx03C-R0-1v0.zig
@@ -1,6 +1,6 @@
 // CH32Vx03C_MINI
 // CH32V203
 pub const chip = @import("chip");
-pub const micro = @import("microzig");
+pub const microzig = @import("microzig");
 
 pub const cpu_frequency = 8_000_000; // 8 MHz

--- a/port/wch/ch32v/src/boards/CH32Vx03C-R0-1v0.zig
+++ b/port/wch/ch32v/src/boards/CH32Vx03C-R0-1v0.zig
@@ -1,6 +1,5 @@
 // CH32Vx03C_MINI
 // CH32V203
 pub const chip = @import("chip");
-pub const microzig = @import("microzig");
 
 pub const cpu_frequency = 8_000_000; // 8 MHz

--- a/port/wch/ch32v/test/programs/minimal.zig
+++ b/port/wch/ch32v/test/programs/minimal.zig
@@ -1,4 +1,4 @@
-const micro = @import("microzig");
+const microzig = @import("microzig");
 
 pub fn main() !void {
     // This function will contain the application logic.

--- a/tools/regz/src/arch/arm.zig
+++ b/tools/regz/src/arch/arm.zig
@@ -103,8 +103,8 @@ pub fn write_interrupt_vector(
         try writer.writeAll(
             \\
             \\pub const VectorTable = extern struct {
-            \\    const Handler = micro.interrupt.Handler;
-            \\    const unhandled = micro.interrupt.unhandled;
+            \\    const Handler = microzig.interrupt.Handler;
+            \\    const unhandled = microzig.interrupt.unhandled;
             \\
             \\    initial_stack_pointer: u32,
             \\    Reset: Handler,

--- a/tools/regz/src/arch/avr.zig
+++ b/tools/regz/src/arch/avr.zig
@@ -24,8 +24,8 @@ pub fn write_interrupt_vector(
         try writer.writeAll(
             \\
             \\pub const VectorTable = extern struct {
-            \\    const Handler = micro.interrupt.Handler;
-            \\    const unhandled = micro.interrupt.unhandled;
+            \\    const Handler = microzig.interrupt.Handler;
+            \\    const unhandled = microzig.interrupt.unhandled;
             \\
             \\    RESET: Handler,
             \\

--- a/tools/regz/src/arch/riscv.zig
+++ b/tools/regz/src/arch/riscv.zig
@@ -21,8 +21,8 @@ pub fn write_interrupt_vector(
     try writer.writeAll(
         \\
         \\pub const VectorTable = extern struct {
-        \\    const Handler = micro.interrupt.Handler;
-        \\    const unhandled = micro.interrupt.unhandled;
+        \\    const Handler = microzig.interrupt.Handler;
+        \\    const unhandled = microzig.interrupt.unhandled;
         \\
     );
 

--- a/tools/regz/src/gen.zig
+++ b/tools/regz/src/gen.zig
@@ -35,8 +35,8 @@ pub fn to_zig(db: *Database, out_writer: anytype, opts: ToZigOptions) !void {
     const writer = buffer.writer();
     if (opts.for_microzig) {
         try writer.writeAll(
-            \\const micro = @import("microzig");
-            \\const mmio = micro.mmio;
+            \\const microzig = @import("microzig");
+            \\const mmio = microzig.mmio;
             \\
         );
     } else {
@@ -935,8 +935,8 @@ test "gen.peripheral instantiation" {
 
     try db.to_zig(buffer.writer(), .{ .for_microzig = true });
     try std.testing.expectEqualStrings(
-        \\const micro = @import("microzig");
-        \\const mmio = micro.mmio;
+        \\const microzig = @import("microzig");
+        \\const mmio = microzig.mmio;
         \\
         \\pub const Interrupt = struct {
         \\    name: [:0]const u8,
@@ -975,8 +975,8 @@ test "gen.peripherals with a shared type" {
 
     try db.to_zig(buffer.writer(), .{ .for_microzig = true });
     try std.testing.expectEqualStrings(
-        \\const micro = @import("microzig");
-        \\const mmio = micro.mmio;
+        \\const microzig = @import("microzig");
+        \\const mmio = microzig.mmio;
         \\
         \\pub const Interrupt = struct {
         \\    name: [:0]const u8,
@@ -1016,8 +1016,8 @@ test "gen.peripheral with modes" {
 
     try db.to_zig(buffer.writer(), .{ .for_microzig = true });
     try std.testing.expectEqualStrings(
-        \\const micro = @import("microzig");
-        \\const mmio = micro.mmio;
+        \\const microzig = @import("microzig");
+        \\const mmio = microzig.mmio;
         \\
         \\pub const Interrupt = struct {
         \\    name: [:0]const u8,
@@ -1084,8 +1084,8 @@ test "gen.peripheral with enum" {
 
     try db.to_zig(buffer.writer(), .{ .for_microzig = true });
     try std.testing.expectEqualStrings(
-        \\const micro = @import("microzig");
-        \\const mmio = micro.mmio;
+        \\const microzig = @import("microzig");
+        \\const mmio = microzig.mmio;
         \\
         \\pub const Interrupt = struct {
         \\    name: [:0]const u8,
@@ -1119,8 +1119,8 @@ test "gen.peripheral with enum, enum is exhausted of values" {
 
     try db.to_zig(buffer.writer(), .{ .for_microzig = true });
     try std.testing.expectEqualStrings(
-        \\const micro = @import("microzig");
-        \\const mmio = micro.mmio;
+        \\const microzig = @import("microzig");
+        \\const mmio = microzig.mmio;
         \\
         \\pub const Interrupt = struct {
         \\    name: [:0]const u8,
@@ -1153,8 +1153,8 @@ test "gen.field with named enum" {
 
     try db.to_zig(buffer.writer(), .{ .for_microzig = true });
     try std.testing.expectEqualStrings(
-        \\const micro = @import("microzig");
-        \\const mmio = micro.mmio;
+        \\const microzig = @import("microzig");
+        \\const mmio = microzig.mmio;
         \\
         \\pub const Interrupt = struct {
         \\    name: [:0]const u8,
@@ -1191,8 +1191,8 @@ test "gen.field with anonymous enum" {
 
     try db.to_zig(buffer.writer(), .{ .for_microzig = true });
     try std.testing.expectEqualStrings(
-        \\const micro = @import("microzig");
-        \\const mmio = micro.mmio;
+        \\const microzig = @import("microzig");
+        \\const mmio = microzig.mmio;
         \\
         \\pub const Interrupt = struct {
         \\    name: [:0]const u8,
@@ -1227,8 +1227,8 @@ test "gen.namespaced register groups" {
 
     try db.to_zig(buffer.writer(), .{ .for_microzig = true });
     try std.testing.expectEqualStrings(
-        \\const micro = @import("microzig");
-        \\const mmio = micro.mmio;
+        \\const microzig = @import("microzig");
+        \\const mmio = microzig.mmio;
         \\
         \\pub const Interrupt = struct {
         \\    name: [:0]const u8,
@@ -1275,8 +1275,8 @@ test "gen.peripheral with reserved register" {
 
     try db.to_zig(buffer.writer(), .{ .for_microzig = true });
     try std.testing.expectEqualStrings(
-        \\const micro = @import("microzig");
-        \\const mmio = micro.mmio;
+        \\const microzig = @import("microzig");
+        \\const mmio = microzig.mmio;
         \\
         \\pub const Interrupt = struct {
         \\    name: [:0]const u8,
@@ -1314,8 +1314,8 @@ test "gen.peripheral with count" {
 
     try db.to_zig(buffer.writer(), .{ .for_microzig = true });
     try std.testing.expectEqualStrings(
-        \\const micro = @import("microzig");
-        \\const mmio = micro.mmio;
+        \\const microzig = @import("microzig");
+        \\const mmio = microzig.mmio;
         \\
         \\pub const Interrupt = struct {
         \\    name: [:0]const u8,
@@ -1353,8 +1353,8 @@ test "gen.peripheral with count, padding required" {
 
     try db.to_zig(buffer.writer(), .{ .for_microzig = true });
     try std.testing.expectEqualStrings(
-        \\const micro = @import("microzig");
-        \\const mmio = micro.mmio;
+        \\const microzig = @import("microzig");
+        \\const mmio = microzig.mmio;
         \\
         \\pub const Interrupt = struct {
         \\    name: [:0]const u8,
@@ -1393,8 +1393,8 @@ test "gen.register with count" {
 
     try db.to_zig(buffer.writer(), .{ .for_microzig = true });
     try std.testing.expectEqualStrings(
-        \\const micro = @import("microzig");
-        \\const mmio = micro.mmio;
+        \\const microzig = @import("microzig");
+        \\const mmio = microzig.mmio;
         \\
         \\pub const Interrupt = struct {
         \\    name: [:0]const u8,
@@ -1432,8 +1432,8 @@ test "gen.register with count and fields" {
 
     try db.to_zig(buffer.writer(), .{ .for_microzig = true });
     try std.testing.expectEqualStrings(
-        \\const micro = @import("microzig");
-        \\const mmio = micro.mmio;
+        \\const microzig = @import("microzig");
+        \\const mmio = microzig.mmio;
         \\
         \\pub const Interrupt = struct {
         \\    name: [:0]const u8,
@@ -1474,8 +1474,8 @@ test "gen.field with count, width of one, offset, and padding" {
 
     try db.to_zig(buffer.writer(), .{ .for_microzig = true });
     try std.testing.expectEqualStrings(
-        \\const micro = @import("microzig");
-        \\const mmio = micro.mmio;
+        \\const microzig = @import("microzig");
+        \\const mmio = microzig.mmio;
         \\
         \\pub const Interrupt = struct {
         \\    name: [:0]const u8,
@@ -1516,8 +1516,8 @@ test "gen.field with count, multi-bit width, offset, and padding" {
 
     try db.to_zig(buffer.writer(), .{ .for_microzig = true });
     try std.testing.expectEqualStrings(
-        \\const micro = @import("microzig");
-        \\const mmio = micro.mmio;
+        \\const microzig = @import("microzig");
+        \\const mmio = microzig.mmio;
         \\
         \\pub const Interrupt = struct {
         \\    name: [:0]const u8,
@@ -1552,8 +1552,8 @@ test "gen.interrupts.avr" {
 
     try db.to_zig(buffer.writer(), .{ .for_microzig = true });
     try std.testing.expectEqualStrings(
-        \\const micro = @import("microzig");
-        \\const mmio = micro.mmio;
+        \\const microzig = @import("microzig");
+        \\const mmio = microzig.mmio;
         \\
         \\pub const Interrupt = struct {
         \\    name: [:0]const u8,
@@ -1569,8 +1569,8 @@ test "gen.interrupts.avr" {
         \\        };
         \\
         \\        pub const VectorTable = extern struct {
-        \\            const Handler = micro.interrupt.Handler;
-        \\            const unhandled = micro.interrupt.unhandled;
+        \\            const Handler = microzig.interrupt.Handler;
+        \\            const unhandled = microzig.interrupt.unhandled;
         \\
         \\            RESET: Handler,
         \\            TEST_VECTOR1: Handler = unhandled,
@@ -1592,8 +1592,8 @@ test "gen.peripheral type with register and field" {
 
     try db.to_zig(buffer.writer(), .{ .for_microzig = true });
     try std.testing.expectEqualStrings(
-        \\const micro = @import("microzig");
-        \\const mmio = micro.mmio;
+        \\const microzig = @import("microzig");
+        \\const mmio = microzig.mmio;
         \\
         \\pub const Interrupt = struct {
         \\    name: [:0]const u8,
@@ -1627,8 +1627,8 @@ test "gen.name collisions in enum name cause them to be anonymous" {
 
     try db.to_zig(buffer.writer(), .{ .for_microzig = true });
     try std.testing.expectEqualStrings(
-        \\const micro = @import("microzig");
-        \\const mmio = micro.mmio;
+        \\const microzig = @import("microzig");
+        \\const mmio = microzig.mmio;
         \\
         \\pub const Interrupt = struct {
         \\    name: [:0]const u8,
@@ -1669,8 +1669,8 @@ test "gen.pick one enum field in value collisions" {
 
     try db.to_zig(buffer.writer(), .{ .for_microzig = true });
     try std.testing.expectEqualStrings(
-        \\const micro = @import("microzig");
-        \\const mmio = micro.mmio;
+        \\const microzig = @import("microzig");
+        \\const mmio = microzig.mmio;
         \\
         \\pub const Interrupt = struct {
         \\    name: [:0]const u8,
@@ -1704,8 +1704,8 @@ test "gen.pick one enum field in name collisions" {
 
     try db.to_zig(buffer.writer(), .{ .for_microzig = true });
     try std.testing.expectEqualStrings(
-        \\const micro = @import("microzig");
-        \\const mmio = micro.mmio;
+        \\const microzig = @import("microzig");
+        \\const mmio = microzig.mmio;
         \\
         \\pub const Interrupt = struct {
         \\    name: [:0]const u8,
@@ -1739,8 +1739,8 @@ test "gen.register fields with name collision" {
 
     try db.to_zig(buffer.writer(), .{ .for_microzig = true });
     try std.testing.expectEqualStrings(
-        \\const micro = @import("microzig");
-        \\const mmio = micro.mmio;
+        \\const microzig = @import("microzig");
+        \\const mmio = microzig.mmio;
         \\
         \\pub const Interrupt = struct {
         \\    name: [:0]const u8,


### PR DESCRIPTION
Just looked for instances of `const micro = @import("microzig")` and replaced `\bmicro\b` with microzig in those files.

Also removed some instances of microzig being imported needlessly.