### PR TITLE
examples: Add 'example' option to only build matches

### DIFF
--- a/examples/espressif/esp/build.zig
+++ b/examples/espressif/esp/build.zig
@@ -23,11 +23,9 @@ pub fn build(b: *std.Build) void {
 
     for (available_examples) |example| {
         // If we specify example, only select the ones that match
-        if (maybe_example) |selected_example| {
-            if (!std.mem.containsAtLeast(u8, example.name, 1, selected_example)) {
+        if (maybe_example) |selected_example|
+            if (!std.mem.containsAtLeast(u8, example.name, 1, selected_example))
                 continue;
-            }
-        }
 
         for (targets) |target_desc| {
             // `add_firmware` basically works like addExecutable, but takes a

--- a/examples/espressif/esp/build.zig
+++ b/examples/espressif/esp/build.zig
@@ -7,6 +7,7 @@ const MicroBuild = microzig.MicroBuild(.{
 
 pub fn build(b: *std.Build) void {
     const optimize = b.standardOptimizeOption(.{});
+    const maybe_example = b.option([]const u8, "example", "only build matching examples");
 
     const mz_dep = b.dependency("microzig", .{});
     const mb = MicroBuild.init(b, mz_dep) orelse return;
@@ -21,6 +22,13 @@ pub fn build(b: *std.Build) void {
     };
 
     for (available_examples) |example| {
+        // If we specify example, only select the ones that match
+        if (maybe_example) |selected_example| {
+            if (!std.mem.containsAtLeast(u8, example.name, 1, selected_example)) {
+                continue;
+            }
+        }
+
         for (targets) |target_desc| {
             // `add_firmware` basically works like addExecutable, but takes a
             // `microzig.Target` for target instead of a `std.zig.CrossTarget`.

--- a/examples/espressif/esp/src/blinky.zig
+++ b/examples/espressif/esp/src/blinky.zig
@@ -36,7 +36,7 @@ pub fn main() !void {
 
     const led_r_pin = gpio.instance.GPIO3;
     const led_g_pin = gpio.instance.GPIO4;
-    const led_b_pin = gpio.instance.GPIO8;
+    const led_b_pin = gpio.instance.GPIO5;
 
     led_r_pin.apply(pin_config);
     led_g_pin.apply(pin_config);

--- a/examples/espressif/esp/src/blinky.zig
+++ b/examples/espressif/esp/src/blinky.zig
@@ -36,7 +36,7 @@ pub fn main() !void {
 
     const led_r_pin = gpio.instance.GPIO3;
     const led_g_pin = gpio.instance.GPIO4;
-    const led_b_pin = gpio.instance.GPIO5;
+    const led_b_pin = gpio.instance.GPIO8;
 
     led_r_pin.apply(pin_config);
     led_g_pin.apply(pin_config);

--- a/examples/gigadevice/gd32/build.zig
+++ b/examples/gigadevice/gd32/build.zig
@@ -21,11 +21,9 @@ pub fn build(b: *std.Build) void {
 
     for (available_examples) |example| {
         // If we specify example, only select the ones that match
-        if (maybe_example) |selected_example| {
-            if (!std.mem.containsAtLeast(u8, example.name, 1, selected_example)) {
+        if (maybe_example) |selected_example|
+            if (!std.mem.containsAtLeast(u8, example.name, 1, selected_example))
                 continue;
-            }
-        }
 
         // `add_firmware` basically works like addExecutable, but takes a
         // `microzig.Target` for target instead of a `std.zig.CrossTarget`.

--- a/examples/gigadevice/gd32/build.zig
+++ b/examples/gigadevice/gd32/build.zig
@@ -7,6 +7,7 @@ const MicroBuild = microzig.MicroBuild(.{
 
 pub fn build(b: *std.Build) void {
     const optimize = b.standardOptimizeOption(.{});
+    const maybe_example = b.option([]const u8, "example", "only build matching examples");
 
     const mz_dep = b.dependency("microzig", .{});
     const mb = MicroBuild.init(b, mz_dep) orelse return;
@@ -19,6 +20,13 @@ pub fn build(b: *std.Build) void {
     };
 
     for (available_examples) |example| {
+        // If we specify example, only select the ones that match
+        if (maybe_example) |selected_example| {
+            if (!std.mem.containsAtLeast(u8, example.name, 1, selected_example)) {
+                continue;
+            }
+        }
+
         // `add_firmware` basically works like addExecutable, but takes a
         // `microzig.Target` for target instead of a `std.zig.CrossTarget`.
         //

--- a/examples/microchip/atsam/build.zig
+++ b/examples/microchip/atsam/build.zig
@@ -7,6 +7,7 @@ const MicroBuild = microzig.MicroBuild(.{
 
 pub fn build(b: *std.Build) void {
     const optimize = b.standardOptimizeOption(.{});
+    const maybe_example = b.option([]const u8, "example", "only build matching examples");
 
     const mz_dep = b.dependency("microzig", .{});
     const mb = MicroBuild.init(b, mz_dep) orelse return;
@@ -16,6 +17,13 @@ pub fn build(b: *std.Build) void {
     };
 
     for (available_examples) |example| {
+        // If we specify example, only select the ones that match
+        if (maybe_example) |selected_example| {
+            if (!std.mem.containsAtLeast(u8, example.name, 1, selected_example)) {
+                continue;
+            }
+        }
+
         // `add_firmware` basically works like addExecutable, but takes a
         // `microzig.Target` for target instead of a `std.zig.CrossTarget`.
         //

--- a/examples/microchip/atsam/build.zig
+++ b/examples/microchip/atsam/build.zig
@@ -18,11 +18,9 @@ pub fn build(b: *std.Build) void {
 
     for (available_examples) |example| {
         // If we specify example, only select the ones that match
-        if (maybe_example) |selected_example| {
-            if (!std.mem.containsAtLeast(u8, example.name, 1, selected_example)) {
+        if (maybe_example) |selected_example|
+            if (!std.mem.containsAtLeast(u8, example.name, 1, selected_example))
                 continue;
-            }
-        }
 
         // `add_firmware` basically works like addExecutable, but takes a
         // `microzig.Target` for target instead of a `std.zig.CrossTarget`.

--- a/examples/microchip/avr/build.zig
+++ b/examples/microchip/avr/build.zig
@@ -19,11 +19,9 @@ pub fn build(b: *std.Build) void {
 
     for (available_examples) |example| {
         // If we specify example, only select the ones that match
-        if (maybe_example) |selected_example| {
-            if (!std.mem.containsAtLeast(u8, example.name, 1, selected_example)) {
+        if (maybe_example) |selected_example|
+            if (!std.mem.containsAtLeast(u8, example.name, 1, selected_example))
                 continue;
-            }
-        }
 
         // `add_firmware` basically works like addExecutable, but takes a
         // `microzig.Target` for target instead of a `std.zig.CrossTarget`.

--- a/examples/microchip/avr/build.zig
+++ b/examples/microchip/avr/build.zig
@@ -7,6 +7,7 @@ const MicroBuild = microzig.MicroBuild(.{
 
 pub fn build(b: *std.Build) void {
     const optimize = b.standardOptimizeOption(.{});
+    const maybe_example = b.option([]const u8, "example", "only build matching examples");
 
     const mz_dep = b.dependency("microzig", .{});
     const mb = MicroBuild.init(b, mz_dep) orelse return;
@@ -17,6 +18,13 @@ pub fn build(b: *std.Build) void {
     };
 
     for (available_examples) |example| {
+        // If we specify example, only select the ones that match
+        if (maybe_example) |selected_example| {
+            if (!std.mem.containsAtLeast(u8, example.name, 1, selected_example)) {
+                continue;
+            }
+        }
+
         // `add_firmware` basically works like addExecutable, but takes a
         // `microzig.Target` for target instead of a `std.zig.CrossTarget`.
         //

--- a/examples/no_hal/stm32_l031/build.zig
+++ b/examples/no_hal/stm32_l031/build.zig
@@ -7,6 +7,7 @@ const MicroBuild = microzig.MicroBuild(.{
 
 pub fn build(b: *std.Build) void {
     const optimize = b.standardOptimizeOption(.{});
+    const maybe_example = b.option([]const u8, "example", "only build matching examples");
 
     const mz_dep = b.dependency("microzig", .{});
     const mb = MicroBuild.init(b, mz_dep) orelse return;
@@ -16,6 +17,13 @@ pub fn build(b: *std.Build) void {
     };
 
     for (available_examples) |example| {
+        // If we specify example, only select the ones that match
+        if (maybe_example) |selected_example| {
+            if (!std.mem.containsAtLeast(u8, example.name, 1, selected_example)) {
+                continue;
+            }
+        }
+
         // `add_firmware` basically works like addExecutable, but takes a
         // `microzig.Target` for target instead of a `std.zig.CrossTarget`.
         //

--- a/examples/no_hal/stm32_l031/build.zig
+++ b/examples/no_hal/stm32_l031/build.zig
@@ -18,11 +18,9 @@ pub fn build(b: *std.Build) void {
 
     for (available_examples) |example| {
         // If we specify example, only select the ones that match
-        if (maybe_example) |selected_example| {
-            if (!std.mem.containsAtLeast(u8, example.name, 1, selected_example)) {
+        if (maybe_example) |selected_example|
+            if (!std.mem.containsAtLeast(u8, example.name, 1, selected_example))
                 continue;
-            }
-        }
 
         // `add_firmware` basically works like addExecutable, but takes a
         // `microzig.Target` for target instead of a `std.zig.CrossTarget`.

--- a/examples/nordic/nrf5x/build.zig
+++ b/examples/nordic/nrf5x/build.zig
@@ -7,6 +7,7 @@ const MicroBuild = microzig.MicroBuild(.{
 
 pub fn build(b: *std.Build) void {
     const optimize = b.standardOptimizeOption(.{});
+    const maybe_example = b.option([]const u8, "example", "only build matching examples");
 
     const mz_dep = b.dependency("microzig", .{});
     const mb = MicroBuild.init(b, mz_dep) orelse return;
@@ -16,6 +17,13 @@ pub fn build(b: *std.Build) void {
     };
 
     for (available_examples) |example| {
+        // If we specify example, only select the ones that match
+        if (maybe_example) |selected_example| {
+            if (!std.mem.containsAtLeast(u8, example.name, 1, selected_example)) {
+                continue;
+            }
+        }
+
         // `add_firmware` basically works like addExecutable, but takes a
         // `microzig.Target` for target instead of a `std.zig.CrossTarget`.
         //

--- a/examples/nordic/nrf5x/build.zig
+++ b/examples/nordic/nrf5x/build.zig
@@ -18,11 +18,9 @@ pub fn build(b: *std.Build) void {
 
     for (available_examples) |example| {
         // If we specify example, only select the ones that match
-        if (maybe_example) |selected_example| {
-            if (!std.mem.containsAtLeast(u8, example.name, 1, selected_example)) {
+        if (maybe_example) |selected_example|
+            if (!std.mem.containsAtLeast(u8, example.name, 1, selected_example))
                 continue;
-            }
-        }
 
         // `add_firmware` basically works like addExecutable, but takes a
         // `microzig.Target` for target instead of a `std.zig.CrossTarget`.

--- a/examples/nxp/lpc/build.zig
+++ b/examples/nxp/lpc/build.zig
@@ -7,6 +7,7 @@ const MicroBuild = microzig.MicroBuild(.{
 
 pub fn build(b: *std.Build) void {
     const optimize = b.standardOptimizeOption(.{});
+    const maybe_example = b.option([]const u8, "example", "only build matching examples");
 
     const mz_dep = b.dependency("microzig", .{});
     const mb = MicroBuild.init(b, mz_dep) orelse return;
@@ -16,6 +17,13 @@ pub fn build(b: *std.Build) void {
     };
 
     for (available_examples) |example| {
+        // If we specify example, only select the ones that match
+        if (maybe_example) |selected_example| {
+            if (!std.mem.containsAtLeast(u8, example.name, 1, selected_example)) {
+                continue;
+            }
+        }
+
         // `add_firmware` basically works like addExecutable, but takes a
         // `microzig.Target` for target instead of a `std.zig.CrossTarget`.
         //

--- a/examples/nxp/lpc/build.zig
+++ b/examples/nxp/lpc/build.zig
@@ -18,11 +18,9 @@ pub fn build(b: *std.Build) void {
 
     for (available_examples) |example| {
         // If we specify example, only select the ones that match
-        if (maybe_example) |selected_example| {
-            if (!std.mem.containsAtLeast(u8, example.name, 1, selected_example)) {
+        if (maybe_example) |selected_example|
+            if (!std.mem.containsAtLeast(u8, example.name, 1, selected_example))
                 continue;
-            }
-        }
 
         // `add_firmware` basically works like addExecutable, but takes a
         // `microzig.Target` for target instead of a `std.zig.CrossTarget`.

--- a/examples/raspberrypi/rp2xxx/build.zig
+++ b/examples/raspberrypi/rp2xxx/build.zig
@@ -79,11 +79,9 @@ pub fn build(b: *std.Build) void {
 
     for (available_examples.items) |example| {
         // If we specify example, only select the ones that match
-        if (maybe_example) |selected_example| {
-            if (!std.mem.containsAtLeast(u8, example.name, 1, selected_example)) {
+        if (maybe_example) |selected_example|
+            if (!std.mem.containsAtLeast(u8, example.name, 1, selected_example))
                 continue;
-            }
-        }
 
         // `add_firmware` basically works like addExecutable, but takes a
         // `microzig.Target` for target instead of a `std.zig.CrossTarget`.

--- a/examples/raspberrypi/rp2xxx/build.zig
+++ b/examples/raspberrypi/rp2xxx/build.zig
@@ -7,6 +7,7 @@ const MicroBuild = microzig.MicroBuild(.{
 
 pub fn build(b: *std.Build) void {
     const optimize = b.standardOptimizeOption(.{});
+    const maybe_example = b.option([]const u8, "example", "only build matching examples");
 
     const mz_dep = b.dependency("microzig", .{});
     const mb = MicroBuild.init(b, mz_dep) orelse return;
@@ -77,6 +78,13 @@ pub fn build(b: *std.Build) void {
     }
 
     for (available_examples.items) |example| {
+        // If we specify example, only select the ones that match
+        if (maybe_example) |selected_example| {
+            if (!std.mem.containsAtLeast(u8, example.name, 1, selected_example)) {
+                continue;
+            }
+        }
+
         // `add_firmware` basically works like addExecutable, but takes a
         // `microzig.Target` for target instead of a `std.zig.CrossTarget`.
         //

--- a/examples/stmicro/stm32/build.zig
+++ b/examples/stmicro/stm32/build.zig
@@ -28,11 +28,9 @@ pub fn build(b: *std.Build) void {
 
     for (available_examples) |example| {
         // If we specify example, only select the ones that match
-        if (maybe_example) |selected_example| {
-            if (!std.mem.containsAtLeast(u8, example.name, 1, selected_example)) {
+        if (maybe_example) |selected_example|
+            if (!std.mem.containsAtLeast(u8, example.name, 1, selected_example))
                 continue;
-            }
-        }
 
         // `add_firmware` basically works like addExecutable, but takes a
         // `microzig.Target` for target instead of a `std.zig.CrossTarget`.

--- a/examples/stmicro/stm32/build.zig
+++ b/examples/stmicro/stm32/build.zig
@@ -7,6 +7,7 @@ const MicroBuild = microzig.MicroBuild(.{
 
 pub fn build(b: *std.Build) void {
     const optimize = b.standardOptimizeOption(.{});
+    const maybe_example = b.option([]const u8, "example", "only build matching examples");
 
     const mz_dep = b.dependency("microzig", .{});
     const mb = MicroBuild.init(b, mz_dep) orelse return;
@@ -26,6 +27,13 @@ pub fn build(b: *std.Build) void {
     };
 
     for (available_examples) |example| {
+        // If we specify example, only select the ones that match
+        if (maybe_example) |selected_example| {
+            if (!std.mem.containsAtLeast(u8, example.name, 1, selected_example)) {
+                continue;
+            }
+        }
+
         // `add_firmware` basically works like addExecutable, but takes a
         // `microzig.Target` for target instead of a `std.zig.CrossTarget`.
         //

--- a/examples/wch/ch32v/build.zig
+++ b/examples/wch/ch32v/build.zig
@@ -38,11 +38,9 @@ pub fn build(b: *std.Build) void {
 
     for (available_examples) |example| {
         // If we specify example, only select the ones that match
-        if (maybe_example) |selected_example| {
-            if (!std.mem.containsAtLeast(u8, example.name, 1, selected_example)) {
+        if (maybe_example) |selected_example|
+            if (!std.mem.containsAtLeast(u8, example.name, 1, selected_example))
                 continue;
-            }
-        }
 
         // `add_firmware` basically works like addExecutable, but takes a
         // `microzig.Target` for target instead of a `std.zig.CrossTarget`.

--- a/examples/wch/ch32v/build.zig
+++ b/examples/wch/ch32v/build.zig
@@ -7,6 +7,7 @@ const MicroBuild = microzig.MicroBuild(.{
 
 pub fn build(b: *std.Build) void {
     const optimize = b.standardOptimizeOption(.{});
+    const maybe_example = b.option([]const u8, "example", "only build matching examples");
 
     const mz_dep = b.dependency("microzig", .{});
     const mb = MicroBuild.init(b, mz_dep) orelse return;
@@ -36,6 +37,13 @@ pub fn build(b: *std.Build) void {
     };
 
     for (available_examples) |example| {
+        // If we specify example, only select the ones that match
+        if (maybe_example) |selected_example| {
+            if (!std.mem.containsAtLeast(u8, example.name, 1, selected_example)) {
+                continue;
+            }
+        }
+
         // `add_firmware` basically works like addExecutable, but takes a
         // `microzig.Target` for target instead of a `std.zig.CrossTarget`.
         //


### PR DESCRIPTION
Add an option to all example directories to allow a user to only build examples that only match by name.

So someone could do:

`zig build -Dexample riscv` to build only the riscv versions of rp2xxxx.

Or they could do `zig build -Dexample blinky` to build blinky (for all supported targets)