### PR TITLE
Fix typo in utf8ToUtf16Le alias

### DIFF
--- a/core/src/core/usb.zig
+++ b/core/src/core/usb.zig
@@ -668,6 +668,6 @@ test "tests" {
 }
 
 test "utf8 to utf16" {
-    try std.testing.expectEqualSlices(u8, "M\x00y\x00 \x00V\x00e\x00n\x00d\x00o\x00r\x00", &UsbUtils.utf8Toutf16Le("My Vendor"));
-    try std.testing.expectEqualSlices(u8, "R\x00a\x00s\x00p\x00b\x00e\x00r\x00r\x00y\x00 \x00P\x00i\x00", &UsbUtils.utf8Toutf16Le("Raspberry Pi"));
+    try std.testing.expectEqualSlices(u8, "M\x00y\x00 \x00V\x00e\x00n\x00d\x00o\x00r\x00", &UsbUtils.utf8ToUtf16Le("My Vendor"));
+    try std.testing.expectEqualSlices(u8, "R\x00a\x00s\x00p\x00b\x00e\x00r\x00r\x00y\x00 \x00P\x00i\x00", &UsbUtils.utf8ToUtf16Le("Raspberry Pi"));
 }

--- a/port/raspberrypi/rp2xxx/src/hal/usb.zig
+++ b/port/raspberrypi/rp2xxx/src/hal/usb.zig
@@ -48,7 +48,7 @@ pub const Dir = usb.types.Dir;
 pub const TransferType = usb.types.TransferType;
 pub const Endpoint = usb.types.Endpoint;
 
-pub const utf8ToUtf16Le = usb.utf8Toutf16Le;
+pub const utf8ToUtf16Le = usb.utf8ToUtf16Le;
 
 const BufferControlMmio = microzig.mmio.Mmio(@TypeOf(microzig.chip.peripherals.USB_DPRAM.EP0_IN_BUFFER_CONTROL).underlying_type);
 const EndpointControlMimo = microzig.mmio.Mmio(@TypeOf(peripherals.USB_DPRAM.EP1_IN_CONTROL).underlying_type);


### PR DESCRIPTION
Previously, the alias was spelled differently from the canonical name.