### PR TITLE
Fixed race condition in RP2xxx i2c_slave

### DIFF
--- a/port/raspberrypi/rp2xxx/src/hal/i2c_slave.zig
+++ b/port/raspberrypi/rp2xxx/src/hal/i2c_slave.zig
@@ -217,6 +217,14 @@ fn isr_common(self: *Self) void {
     // Save the interrupt status and clear it
 
     const interruptStatus = self.regs.IC_RAW_INTR_STAT.read();
+
+    // -- Clear Abort --
+    // IC_CLR_INTR does not do this correctly.
+
+    if (interruptStatus.TX_ABRT == .ACTIVE) {
+        self.regs.IC_CLR_TX_ABRT.raw = 0;
+    }
+
     _ = self.regs.IC_CLR_INTR.read();
 
     // -- General Call --

--- a/port/raspberrypi/rp2xxx/src/hal/i2c_slave.zig
+++ b/port/raspberrypi/rp2xxx/src/hal/i2c_slave.zig
@@ -160,7 +160,12 @@ pub fn open(self: *Self, addr: i2c.Address, transfer_buffer: []u8, rxCallback: R
     //   } ;
 
     self.enable();
-    irq.enable(.I2C1_IRQ);
+
+    if (self.regs == I2C0) {
+        irq.enable(.I2C0_IRQ);
+    } else {
+        irq.enable(.I2C1_IRQ);
+    }
 }
 
 /// Close the I2C slave driver


### PR DESCRIPTION
I discovered a race condition with a write-restart-read operation where the ISR could be called with both the RESTART and READ_REQ flags set.  

The original code handled the READ_REQ and asked for the read data before handling the RESTART which sent the write data to the user.
 
Reordering handling of the flags resolves this.