### PR TITLE
Need more branch quota in Mmio

### DIFF
--- a/core/src/mmio.zig
+++ b/core/src/mmio.zig
@@ -2,6 +2,9 @@ const std = @import("std");
 const assert = std.debug.assert;
 
 pub fn Mmio(comptime PackedT: type) type {
+
+    @setEvalBranchQuota(2_000);
+
     const size = @bitSizeOf(PackedT);
     if ((size % 8) != 0)
         @compileError("size must be divisible by 8!");


### PR DESCRIPTION
On MacOS with Zig version 0.14.0, trying to build:

```
const std = @import("std");
const microzig = @import("microzig");

const PPB = microzig.chip.peripherals.PPB;

pub fn main() void {
    PPB.NVIC_ISER0.write(.{ .SETENA = 0 });
}
```

With build.zig:

```
const std = @import("std");
const microzig = @import("microzig");

const MicroBuild = microzig.MicroBuild(.{
    .rp2xxx = true,
});

pub fn build(b: *std.Build) void {
    const mz_dep = b.dependency("microzig", .{});
    const mb = MicroBuild.init(b, mz_dep) orelse return;

    const firmware = mb.add_firmware(.{
        .name = "microzig-test",
        .target = mb.ports.rp2xxx.boards.raspberrypi.pico2_arm,
        .optimize = .ReleaseSmall,
        .root_source_file = b.path("src/main.zig"),
    });

    mb.install_firmware(firmware, .{});

    mb.install_firmware(firmware, .{ .format = .elf });
}
```

Results in the compile time error:

```
└──> zig build            
install
└─ install generated to microzig-test.uf2
   └─ run elf2uf2 (microzig-test.uf2)
      └─ zig build-exe microzig-test ReleaseSmall thumb-freestanding-eabihf 1 errors
.zig-cache/o/3c11013c7404cc818431b19aab8467e1/chip.zig:27850:35: error: evaluation exceeded 1000 backwards branches
            TRCCLAIMSET: mmio.Mmio(packed struct(u32) {
                         ~~~~~~~~~^
.zig-cache/o/3c11013c7404cc818431b19aab8467e1/chip.zig:27850:35: note: use @setEvalBranchQuota() to raise the branch limit from 1000
error: the following command failed with 1 compilation errors:
/opt/zig-macos-aarch64-0.14.0/zig build-exe -fno-strip -OReleaseSmall -target thumb-freestanding-eabihf -mcpu cortex_m33 --dep microzig --dep app -Mroot=/Users/craig/GitHub/microzig/core/src/start.zig --dep config --dep drivers --dep cpu --dep chip --dep hal --dep board --dep app -Mmicrozig=/Users/craig/GitHub/microzig/core/src/microzig.zig --dep microzig -Mapp=/Users/craig/TestBed/microzig-test/src/main.zig -Mconfig=/Users/craig/TestBed/microzig-test/.zig-cache/c/11d0b83c86968c11ed60260dfa1e9b49/options.zig -Mdrivers=/Users/craig/GitHub/microzig/drivers/framework.zig --dep microzig -Mcpu=/Users/craig/GitHub/microzig/core/src/cpus/cortex_m.zig --dep microzig -Mchip=/Users/craig/TestBed/microzig-test/.zig-cache/o/3c11013c7404cc818431b19aab8467e1/chip.zig --dep microzig -Mhal=/Users/craig/GitHub/microzig/port/raspberrypi/rp2xxx/src/hal.zig --dep microzig -Mboard=/Users/craig/GitHub/microzig/port/raspberrypi/rp2xxx/src/boards/raspberry_pi_pico2.zig -ffunction-sections -fdata-sections --gc-sections --cache-dir /Users/craig/TestBed/microzig-test/.zig-cache --global-cache-dir /Users/craig/.cache/zig --name microzig-test -static -fcompiler-rt --script /Users/craig/GitHub/microzig/port/raspberrypi/rp2xxx/rp2350_arm.ld --zig-lib-dir /opt/zig-macos-aarch64-0.14.0/lib/ --listen=- 
Build Summary: 9/14 steps succeeded; 1 failed
install transitive failure
├─ install generated to microzig-test.uf2 transitive failure
│  └─ run elf2uf2 (microzig-test.uf2) transitive failure
│     └─ zig build-exe microzig-test ReleaseSmall thumb-freestanding-eabihf 1 errors
└─ install generated to microzig-test.elf transitive failure
   └─ zig build-exe microzig-test ReleaseSmall thumb-freestanding-eabihf (+2 more reused dependencies)
error: the following build command failed with exit code 1:
/Users/craig/TestBed/microzig-test/.zig-cache/o/7e75dc0683014a5b230092d3bd474a46/build /opt/zig-macos-aarch64-0.14.0/zig /opt/zig-macos-aarch64-0.14.0/lib /Users/craig/TestBed/microzig-test /Users/craig/TestBed/microzig-test/.zig-cache /Users/craig/.cache/zig --seed 0x72cfd7fa -Z38d6015e263976b4
```

Doing the same on RP2040 with `.target = mb.ports.rp2xxx.boards.raspberrypi.pico,` works fine.

Expanding the branch quota fixes this.