### PR TITLE
RP2XXX USB - replace rom.memcpy with @memcpy

### DIFF
--- a/port/raspberrypi/rp2xxx/src/hal/usb.zig
+++ b/port/raspberrypi/rp2xxx/src/hal/usb.zig
@@ -17,7 +17,6 @@ pub const vendor = usb.vendor;
 pub const templates = usb.templates.DescriptorsConfigTemplates;
 pub const utils = usb.UsbUtils;
 
-const rom = @import("rom.zig");
 const resets = @import("resets.zig");
 
 pub const RP2XXX_MAX_ENDPOINTS_COUNT = 16;
@@ -256,7 +255,7 @@ pub fn F(comptime config: UsbConfig) type {
 
             const ep = hardware_endpoint_get_by_address(ep_addr);
 
-            _ = rom.memcpy(ep.data_buffer[0..buffer.len], buffer);
+            @memcpy(ep.data_buffer[0..buffer.len], buffer);
 
             // Configure the IN:
             const np: u1 = if (ep.next_pid_1) 1 else 0;

--- a/port/raspberrypi/rp2xxx/src/hal/usb.zig
+++ b/port/raspberrypi/rp2xxx/src/hal/usb.zig
@@ -255,7 +255,8 @@ pub fn F(comptime config: UsbConfig) type {
 
             const ep = hardware_endpoint_get_by_address(ep_addr);
 
-            @memcpy(ep.data_buffer[0..buffer.len], buffer);
+            // TODO: please fixme: https://github.com/ZigEmbeddedGroup/microzig/issues/452
+            std.mem.copyForwards(u8, ep.data_buffer[0..buffer.len], buffer);
 
             // Configure the IN:
             const np: u1 = if (ep.next_pid_1) 1 else 0;


### PR DESCRIPTION
In commit 68b5ad1 `rom.memcpy` was replaced by `@memcpy` by @patryk4815  but one more `rom.memcpy` left.
