### PR TITLE
Fix RP2xxx get_cpu_id call

### DIFF
--- a/port/raspberrypi/rp2xxx/src/hal.zig
+++ b/port/raspberrypi/rp2xxx/src/hal.zig
@@ -82,7 +82,7 @@ pub fn init_sequence(comptime clock_cfg: clocks.config.Global) void {
 }
 
 pub fn get_cpu_id() u32 {
-    return SIO.CPUID.*;
+    return SIO.CPUID.read().CPUID;
 }
 
 test "hal tests" {


### PR DESCRIPTION
Calling the `rp2xxx.get_cpu_id()` function generates an error: `error: cannot dereference non-pointer type 'mmio.Mmio(chip.types.peripherals.SIO__struct_3160)'`

This change fixes that.