### PR TITLE
examples: rp2xxx: Make examples more consistent

### DIFF
--- a/examples/raspberrypi/rp2xxx/src/adc.zig
+++ b/examples/raspberrypi/rp2xxx/src/adc.zig
@@ -15,19 +15,19 @@ pub const microzig_options = microzig.Options{
     .logFn = rp2xxx.uart.logFn,
 };
 
-pub fn main() void {
-    adc.apply(.{
-        .temp_sensor_enabled = true,
-    });
-
+pub fn main() !void {
+    // init uart logging
     uart_tx_pin.set_function(.uart);
-
     uart.apply(.{
         .baud_rate = baud_rate,
         .clock_config = rp2xxx.clock_config,
     });
-
     rp2xxx.uart.init_logger(uart);
+
+    adc.apply(.{
+        .temp_sensor_enabled = true,
+    });
+
     while (true) : (time.sleep_ms(1000)) {
         const sample = adc.convert_one_shot_blocking(.temp_sensor) catch {
             std.log.err("conversion failed!", .{});

--- a/examples/raspberrypi/rp2xxx/src/changing_system_clocks.zig
+++ b/examples/raspberrypi/rp2xxx/src/changing_system_clocks.zig
@@ -27,7 +27,6 @@ pub fn init() void {
 }
 
 pub fn main() !void {
-
     // Don't forget to bring a blinky!
     const led_gpio = gpio.num(25);
     led_gpio.set_direction(.out);

--- a/examples/raspberrypi/rp2xxx/src/custom_clock_config.zig
+++ b/examples/raspberrypi/rp2xxx/src/custom_clock_config.zig
@@ -116,7 +116,6 @@ pub fn init() void {
 }
 
 pub fn main() !void {
-
     // Don't forget to bring a blinky!
     const led_gpio = gpio.num(25);
     led_gpio.set_direction(.out);

--- a/examples/raspberrypi/rp2xxx/src/gpio_clock_output.zig
+++ b/examples/raspberrypi/rp2xxx/src/gpio_clock_output.zig
@@ -9,7 +9,6 @@ const Pin = rp2xxx.gpio.Pin;
 const gpout0_pin = gpio.num(21);
 
 pub fn main() !void {
-
     // Don't forget to bring a blinky!
     const led_gpio = rp2xxx.gpio.num(25);
     led_gpio.set_direction(.out);

--- a/examples/raspberrypi/rp2xxx/src/i2c_bus_scan.zig
+++ b/examples/raspberrypi/rp2xxx/src/i2c_bus_scan.zig
@@ -6,25 +6,21 @@ const rp2xxx = microzig.hal;
 const i2c = rp2xxx.i2c;
 const gpio = rp2xxx.gpio;
 const peripherals = microzig.chip.peripherals;
-const chip = rp2xxx.compatibility.chip;
+
+const uart = rp2xxx.uart.instance.num(0);
+const baud_rate = 115200;
+const uart_tx_pin = gpio.num(0);
 
 pub const microzig_options = microzig.Options{
     .log_level = .info,
     .logFn = rp2xxx.uart.logFn,
 };
 
-const uart = rp2xxx.uart.instance.num(0);
-const baud_rate = 115200;
-const uart_tx_pin = gpio.num(0);
-const uart_rx_pin = gpio.num(1);
-
 const i2c0 = i2c.instance.num(0);
 
 pub fn main() !void {
-    inline for (&.{ uart_tx_pin, uart_rx_pin }) |pin| {
-        pin.set_function(.uart);
-    }
-
+    // init uart logging
+    uart_tx_pin.set_function(.uart);
     uart.apply(.{
         .baud_rate = baud_rate,
         .clock_config = rp2xxx.clock_config,

--- a/examples/raspberrypi/rp2xxx/src/interrupts.zig
+++ b/examples/raspberrypi/rp2xxx/src/interrupts.zig
@@ -54,12 +54,10 @@ pub fn set_alarm(us: u32) void {
 pub fn main() !void {
     // init uart logging
     uart_tx_pin.set_function(.uart);
-
     uart.apply(.{
         .baud_rate = baud_rate,
         .clock_config = rp2xxx.clock_config,
     });
-
     rp2xxx.uart.init_logger(uart);
 
     led.set_function(.sio);

--- a/examples/raspberrypi/rp2xxx/src/rp2040_only/flash_id.zig
+++ b/examples/raspberrypi/rp2xxx/src/rp2040_only/flash_id.zig
@@ -9,7 +9,6 @@ const flash = rp2xxx.flash;
 const uart = rp2xxx.uart.instance.num(0);
 const baud_rate = 115200;
 const uart_tx_pin = gpio.num(0);
-const uart_rx_pin = gpio.num(1);
 
 pub fn panic(message: []const u8, _: ?*std.builtin.StackTrace, _: ?usize) noreturn {
     std.log.err("panic: {s}", .{message});
@@ -23,15 +22,12 @@ pub const std_options = struct {
 };
 
 pub fn main() !void {
-    inline for (&.{ uart_tx_pin, uart_rx_pin }) |pin| {
-        pin.set_function(.uart);
-    }
-
+    // init uart logging
+    uart_tx_pin.set_function(.uart);
     uart.apply(.{
         .baud_rate = baud_rate,
         .clock_config = rp2xxx.clock_config,
     });
-
     rp2xxx.uart.init_logger(uart);
 
     while (true) {

--- a/examples/raspberrypi/rp2xxx/src/rp2040_only/flash_program.zig
+++ b/examples/raspberrypi/rp2xxx/src/rp2040_only/flash_program.zig
@@ -11,7 +11,6 @@ const led = gpio.num(25);
 const uart = rp2xxx.uart.instance.num(0);
 const baud_rate = 115200;
 const uart_tx_pin = gpio.num(0);
-const uart_rx_pin = gpio.num(1);
 
 const flash_target_offset: u32 = 256 * 1024;
 const flash_target_contents = @as([*]const u8, @ptrFromInt(rp2xxx.flash.XIP_BASE + flash_target_offset));
@@ -28,20 +27,17 @@ pub const microzig_options = microzig.Options{
 };
 
 pub fn main() !void {
-    led.set_function(.sio);
-    led.set_direction(.out);
-    led.put(1);
-
-    inline for (&.{ uart_tx_pin, uart_rx_pin }) |pin| {
-        pin.set_function(.uart);
-    }
-
+    // init uart logging
+    uart_tx_pin.set_function(.uart);
     uart.apply(.{
         .baud_rate = baud_rate,
         .clock_config = rp2xxx.clock_config,
     });
-
     rp2xxx.uart.init_logger(uart);
+
+    led.set_function(.sio);
+    led.set_direction(.out);
+    led.put(1);
 
     var data: [flash.PAGE_SIZE]u8 = undefined;
     var i: usize = 0;

--- a/examples/raspberrypi/rp2xxx/src/rp2040_only/i2c_slave.zig
+++ b/examples/raspberrypi/rp2xxx/src/rp2040_only/i2c_slave.zig
@@ -1,12 +1,13 @@
 const std = @import("std");
 const microzig = @import("microzig");
-
 const rp2xxx = microzig.hal;
-
 const gpio = rp2xxx.gpio;
 const i2c = rp2xxx.i2c;
 const time = rp2xxx.time;
+
 const uart = rp2xxx.uart.instance.num(0);
+const baud_rate = 115200;
+const uart_tx_pin = gpio.num(0);
 
 const pin_config = rp2xxx.pins.GlobalConfiguration{
     .GPIO0 = .{ .name = "gpio0", .function = .UART0_TX },
@@ -23,7 +24,6 @@ const pin_config = rp2xxx.pins.GlobalConfiguration{
 };
 
 pub const microzig_options = microzig.Options{
-    .log_level = .debug,
     .logFn = rp2xxx.uart.logFn,
     .interrupts = .{ .I2C0_IRQ = .{ .c = i2c.slave.isr1 } },
 };
@@ -32,14 +32,15 @@ var i2c_buffer: [10]u8 = undefined;
 var slave_addr: i2c.Address = @enumFromInt(0x42);
 
 pub fn main() !void {
-    pin_config.apply();
-
+    // init uart logging
+    uart_tx_pin.set_function(.uart);
     uart.apply(.{
-        .baud_rate = 115200,
+        .baud_rate = baud_rate,
         .clock_config = rp2xxx.clock_config,
     });
-
     rp2xxx.uart.init_logger(uart);
+
+    pin_config.apply();
 
     std.log.info("Hello from i2c_slave.", .{});
 

--- a/examples/raspberrypi/rp2xxx/src/rp2040_only/pcf8574.zig
+++ b/examples/raspberrypi/rp2xxx/src/rp2040_only/pcf8574.zig
@@ -1,17 +1,14 @@
 const std = @import("std");
 const microzig = @import("microzig");
 
-//Driver imports
 const drivers = microzig.drivers;
 const PCF8574 = drivers.IO_expander.PCF8574;
 const State = drivers.base.Digital_IO.State;
 
-//Hal imports
 const rp2040 = microzig.hal;
 const i2c = rp2040.i2c;
 const I2C_Device = rp2040.drivers.I2C_Device;
 const gpio = rp2040.gpio;
-const peripherals = microzig.chip.peripherals;
 const timer = rp2040.time;
 
 const i2c0 = i2c.instance.num(0);

--- a/examples/raspberrypi/rp2xxx/src/rp2040_only/random.zig
+++ b/examples/raspberrypi/rp2xxx/src/rp2040_only/random.zig
@@ -4,7 +4,6 @@ const std = @import("std");
 const microzig = @import("microzig");
 
 const rp2xxx = microzig.hal;
-const flash = rp2xxx.flash;
 const time = rp2xxx.time;
 const gpio = rp2xxx.gpio;
 const clocks = rp2xxx.clocks;
@@ -14,7 +13,6 @@ const led = gpio.num(25);
 const uart = rp2xxx.uart.instance.num(0);
 const baud_rate = 115200;
 const uart_tx_pin = gpio.num(0);
-const uart_rx_pin = gpio.num(1);
 
 pub fn panic(message: []const u8, _: ?*std.builtin.StackTrace, _: ?usize) noreturn {
     std.log.err("panic: {s}", .{message});
@@ -28,23 +26,20 @@ pub const microzig_options = microzig.Options{
 };
 
 pub fn main() !void {
-    led.set_function(.sio);
-    led.set_direction(.out);
-    led.put(1);
-
-    inline for (&.{ uart_tx_pin, uart_rx_pin }) |pin| {
-        pin.set_function(.uart);
-    }
-
+    // init uart logging
+    uart_tx_pin.set_function(.uart);
     uart.apply(.{
         .baud_rate = baud_rate,
         .clock_config = rp2xxx.clock_config,
     });
+    rp2xxx.uart.init_logger(uart);
+
+    led.set_function(.sio);
+    led.set_direction(.out);
+    led.put(1);
 
     var ascon = rand.Ascon.init();
     var rng = ascon.random();
-
-    rp2xxx.uart.init_logger(uart);
 
     var buffer: [8]u8 = undefined;
     var dist: [256]usize = @splat(0);

--- a/examples/raspberrypi/rp2xxx/src/rp2040_only/tiles.zig
+++ b/examples/raspberrypi/rp2xxx/src/rp2040_only/tiles.zig
@@ -70,7 +70,7 @@ inline fn floatToBright(f: f32) u8 {
     ];
 }
 
-pub fn main() void {
+pub fn main() !void {
     pio.gpio_init(led_pin);
     sm_set_consecutive_pindirs(pio, sm, @intFromEnum(led_pin), 1, true);
 

--- a/examples/raspberrypi/rp2xxx/src/rp2040_only/usb_hid.zig
+++ b/examples/raspberrypi/rp2xxx/src/rp2040_only/usb_hid.zig
@@ -12,7 +12,6 @@ const led = gpio.num(25);
 const uart = rp2xxx.uart.instance.num(0);
 const baud_rate = 115200;
 const uart_tx_pin = gpio.num(0);
-const uart_rx_pin = gpio.num(1);
 
 const usb_dev = rp2xxx.usb.Usb(.{});
 
@@ -66,20 +65,17 @@ pub const microzig_options = microzig.Options{
 };
 
 pub fn main() !void {
-    led.set_function(.sio);
-    led.set_direction(.out);
-    led.put(1);
-
-    inline for (&.{ uart_tx_pin, uart_rx_pin }) |pin| {
-        pin.set_function(.uart);
-    }
-
+    // init uart logging
+    uart_tx_pin.set_function(.uart);
     uart.apply(.{
         .baud_rate = baud_rate,
         .clock_config = rp2xxx.clock_config,
     });
-
     rp2xxx.uart.init_logger(uart);
+
+    led.set_function(.sio);
+    led.set_direction(.out);
+    led.put(1);
 
     // First we initialize the USB clock
     usb_dev.init_clk();

--- a/examples/raspberrypi/rp2xxx/src/spi_slave.zig
+++ b/examples/raspberrypi/rp2xxx/src/spi_slave.zig
@@ -6,12 +6,17 @@ const time = rp2xxx.time;
 const gpio = rp2xxx.gpio;
 const chip = rp2xxx.compatibility.chip;
 
-const BUF_LEN = 0x100;
-const spi = rp2xxx.spi.instance.SPI0;
-
 const uart = rp2xxx.uart.instance.num(0);
 const uart_baud_rate = 115200;
 const uart_tx_pin = gpio.num(0);
+
+pub const microzig_options = microzig.Options{
+    .log_level = .debug,
+    .logFn = rp2xxx.uart.logFn,
+};
+
+const BUF_LEN = 0x100;
+const spi = rp2xxx.spi.instance.SPI0;
 
 // These may change depending on which GPIO pins you have your SPI device routed to.
 const CS_PIN = 17;
@@ -20,11 +25,6 @@ const SCK_PIN = 18;
 // either receiving or transmitting SPI data, no matter whether the chip is in
 // master or slave mode.
 const RX_PIN = 16;
-
-pub const microzig_options = microzig.Options{
-    .log_level = .debug,
-    .logFn = rp2xxx.uart.logFn,
-};
 
 pub fn main() !void {
     // Set pin functions for CS, SCK, RX

--- a/examples/raspberrypi/rp2xxx/src/squarewave.zig
+++ b/examples/raspberrypi/rp2xxx/src/squarewave.zig
@@ -30,7 +30,7 @@ const pio: Pio = rp2xxx.pio.num(0);
 const sm: StateMachine = .sm0;
 const pin = gpio.num(2);
 
-pub fn main() void {
+pub fn main() !void {
     pio.gpio_init(pin);
     pio.sm_load_and_start_program(sm, squarewave_program, .{
         .clkdiv = rp2xxx.pio.ClkDivOptions.from_float(125),

--- a/examples/raspberrypi/rp2xxx/src/stepper.zig
+++ b/examples/raspberrypi/rp2xxx/src/stepper.zig
@@ -1,3 +1,4 @@
+const std = @import("std");
 const microzig = @import("microzig");
 const rp2xxx = microzig.hal;
 const gpio = rp2xxx.gpio;
@@ -21,17 +22,10 @@ pub fn main() !void {
         dir: GPIO_Device,
         step: GPIO_Device,
     } = undefined;
-
-    inline for ([_]struct { field: []const u8, gpio: u6 }{
-        .{ .field = "ms1", .gpio = 1 },
-        .{ .field = "ms2", .gpio = 2 },
-        .{ .field = "ms3", .gpio = 3 },
-        .{ .field = "dir", .gpio = 14 },
-        .{ .field = "step", .gpio = 15 },
-    }) |info| {
-        const pin = gpio.num(info.gpio);
+    inline for (std.meta.fields(@TypeOf(pins)), .{ 1, 2, 3, 14, 15 }) |field, num| {
+        const pin = gpio.num(num);
         pin.set_function(.sio);
-        @field(pins, info.field) = GPIO_Device.init(pin);
+        @field(pins, field.name) = GPIO_Device.init(pin);
     }
 
     var stepper = A4988.init(.{

--- a/examples/raspberrypi/rp2xxx/src/stepper.zig
+++ b/examples/raspberrypi/rp2xxx/src/stepper.zig
@@ -13,30 +13,33 @@ pub fn main() !void {
     led.set_direction(.out);
     var cd = ClockDevice{};
 
-    const dir_pin = gpio.num(14);
-    dir_pin.set_function(.sio);
-    var dp = GPIO_Device.init(dir_pin);
+    // Setup all pins for the stepper driver
+    var pins: struct {
+        ms1: GPIO_Device,
+        ms2: GPIO_Device,
+        ms3: GPIO_Device,
+        dir: GPIO_Device,
+        step: GPIO_Device,
+    } = undefined;
 
-    const step_pin = gpio.num(15);
-    step_pin.set_function(.sio);
-    var sp = GPIO_Device.init(step_pin);
-
-    const ms1_pin = gpio.num(1);
-    const ms2_pin = gpio.num(2);
-    const ms3_pin = gpio.num(3);
-    ms1_pin.set_function(.sio);
-    ms2_pin.set_function(.sio);
-    ms3_pin.set_function(.sio);
-    var ms1 = GPIO_Device.init(ms1_pin);
-    var ms2 = GPIO_Device.init(ms2_pin);
-    var ms3 = GPIO_Device.init(ms3_pin);
+    inline for ([_]struct { field: []const u8, gpio: u6 }{
+        .{ .field = "ms1", .gpio = 1 },
+        .{ .field = "ms2", .gpio = 2 },
+        .{ .field = "ms3", .gpio = 3 },
+        .{ .field = "dir", .gpio = 14 },
+        .{ .field = "step", .gpio = 15 },
+    }) |info| {
+        const pin = gpio.num(info.gpio);
+        pin.set_function(.sio);
+        @field(pins, info.field) = GPIO_Device.init(pin);
+    }
 
     var stepper = A4988.init(.{
-        .dir_pin = dp.digital_io(),
-        .step_pin = sp.digital_io(),
-        .ms1_pin = ms1.digital_io(),
-        .ms2_pin = ms2.digital_io(),
-        .ms3_pin = ms3.digital_io(),
+        .dir_pin = pins.dir.digital_io(),
+        .step_pin = pins.step.digital_io(),
+        .ms1_pin = pins.ms1.digital_io(),
+        .ms2_pin = pins.ms2.digital_io(),
+        .ms3_pin = pins.ms3.digital_io(),
         .clock_device = cd.clock_device(),
     });
 

--- a/examples/raspberrypi/rp2xxx/src/uart_log.zig
+++ b/examples/raspberrypi/rp2xxx/src/uart_log.zig
@@ -1,10 +1,8 @@
 const std = @import("std");
 const microzig = @import("microzig");
-
 const rp2xxx = microzig.hal;
 const time = rp2xxx.time;
 const gpio = rp2xxx.gpio;
-const clocks = rp2xxx.clocks;
 
 const led = gpio.num(25);
 const uart = rp2xxx.uart.instance.num(0);

--- a/examples/raspberrypi/rp2xxx/src/usb_cdc.zig
+++ b/examples/raspberrypi/rp2xxx/src/usb_cdc.zig
@@ -5,7 +5,6 @@ const rp2xxx = microzig.hal;
 const flash = rp2xxx.flash;
 const time = rp2xxx.time;
 const gpio = rp2xxx.gpio;
-const clocks = rp2xxx.clocks;
 const usb = rp2xxx.usb;
 
 const led = gpio.num(25);

--- a/examples/raspberrypi/rp2xxx/src/ws2812.zig
+++ b/examples/raspberrypi/rp2xxx/src/ws2812.zig
@@ -36,7 +36,7 @@ const pio: Pio = rp2xxx.pio.num(0);
 const sm: StateMachine = .sm0;
 const led_pin = gpio.num(23);
 
-pub fn main() void {
+pub fn main() !void {
     pio.gpio_init(led_pin);
     pio.sm_set_pindir(sm, @intFromEnum(led_pin), 1, .out);
 

--- a/port/raspberrypi/rp2xxx/src/hal/i2c.zig
+++ b/port/raspberrypi/rp2xxx/src/hal/i2c.zig
@@ -11,9 +11,7 @@ const peripherals = microzig.chip.peripherals;
 const I2C0 = peripherals.I2C0;
 const I2C1 = peripherals.I2C1;
 
-const gpio = @import("gpio.zig");
 const clocks = @import("clocks.zig");
-const resets = @import("resets.zig");
 const time = @import("time.zig");
 const hw = @import("hw.zig");
 


### PR DESCRIPTION
Simply cleanup the examples so that they are more consistent:

1. Remove unused imports
2. Make the uart setup the same across all examples (except where rx is actually needed)
3. Cleanup the pin setup in the stepper example.

Only the stepper example is worth taking a close look at.