### PR TITLE
Fix PR website building gh action

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -183,7 +183,7 @@ jobs:
       - name: Setup Zig
         uses: mlugg/setup-zig@v1
         with:
-          version: ${{ env.ZIG_VERSION }}
+          version: 0.14.0
       - name: Build Website
         run: zig build
         working-directory: website

--- a/.github/workflows/publish-github-pages.yml
+++ b/.github/workflows/publish-github-pages.yml
@@ -6,8 +6,6 @@ on:
   release:
     types:
       - published
-env:
-  ZIG_VERSION: 0.14.0
 
 jobs:
   # Build job

--- a/.github/workflows/publish-github-pages.yml
+++ b/.github/workflows/publish-github-pages.yml
@@ -6,6 +6,8 @@ on:
   release:
     types:
       - published
+env:
+  ZIG_VERSION: 0.14.0
 
 jobs:
   # Build job

--- a/.github/workflows/publish-github-pages.yml
+++ b/.github/workflows/publish-github-pages.yml
@@ -62,7 +62,7 @@ jobs:
           echo "{ \"releases\": [$(IFS=,; echo "${releases_with_artifact[*]}")] }" > website/zig-out/downloads/microzig/metadata.json
 
       - name: Build Website
-        run: zig build --summary all
+        run: zig version
         working-directory: website
 
       - name: List Contents

--- a/.github/workflows/publish-github-pages.yml
+++ b/.github/workflows/publish-github-pages.yml
@@ -62,7 +62,7 @@ jobs:
           echo "{ \"releases\": [$(IFS=,; echo "${releases_with_artifact[*]}")] }" > website/zig-out/downloads/microzig/metadata.json
 
       - name: Build Website
-        run: zig version
+        run: zig build --summary all
         working-directory: website
 
       - name: List Contents


### PR DESCRIPTION
In the PR workflow we build the website, but we use zig master. Seems that zig master changed underneath us to make it no longer compatible with the version of zine we pin.

Simply use the 0.14.0 release of zig for this workflow.