### PR TITLE
HID: basic keyboard support

### DIFF
--- a/core/src/core/usb.zig
+++ b/core/src/core/usb.zig
@@ -238,7 +238,7 @@ pub fn Usb(comptime f: anytype) type {
                                     if (feature) |feat| {
                                         switch (feat) {
                                             .DeviceRemoteWakeup, .EndpointHalt => CmdEndpoint.send_cmd_ack(),
-                                            // TODO
+                                            // TODO: https://github.com/ZigEmbeddedGroup/microzig/issues/453
                                             .TestMode => {},
                                         }
                                     }

--- a/core/src/core/usb.zig
+++ b/core/src/core/usb.zig
@@ -23,6 +23,7 @@ pub const utils = @import("usb/utils.zig");
 pub const templates = @import("usb/templates.zig");
 
 const DescType = types.DescType;
+const FeatureSelector = types.FeatureSelector;
 const Dir = types.Dir;
 const Endpoint = types.Endpoint;
 const SetupRequest = types.SetupRequest;
@@ -202,12 +203,12 @@ pub fn Usb(comptime f: anytype) type {
                             const req = SetupRequest.from_u8(setup.request);
                             if (req == null) return;
                             switch (req.?) {
-                                SetupRequest.SetAddress => {
+                                .SetAddress => {
                                     S.new_address = @as(u8, @intCast(setup.value & 0xff));
                                     CmdEndpoint.send_cmd_ack();
                                     if (S.debug_mode) std.log.info("    SetAddress: {}", .{S.new_address.?});
                                 },
-                                SetupRequest.SetConfiguration => {
+                                .SetConfiguration => {
                                     if (S.debug_mode) std.log.info("    SetConfiguration", .{});
                                     const cfg_num = setup.value;
                                     if (S.cfg_num != cfg_num) {
@@ -226,10 +227,20 @@ pub fn Usb(comptime f: anytype) type {
                                     S.configured = true;
                                     CmdEndpoint.send_cmd_ack();
                                 },
-                                SetupRequest.GetDescriptor => {
+                                .GetDescriptor => {
                                     const descriptor_type = DescType.from_u8(@intCast(setup.value >> 8));
                                     if (descriptor_type) |dt| {
                                         try process_get_descriptor(setup, dt);
+                                    }
+                                },
+                                .SetFeature => {
+                                    const feature = FeatureSelector.from_u8(@intCast(setup.value >> 8));
+                                    if (feature) |feat| {
+                                        switch (feat) {
+                                            .DeviceRemoteWakeup, .EndpointHalt => CmdEndpoint.send_cmd_ack(),
+                                            // TODO
+                                            .TestMode => {},
+                                        }
                                     }
                                 },
                             }
@@ -470,9 +481,8 @@ pub fn Usb(comptime f: anytype) type {
                         else => {
                             const ep_num = Endpoint.num_from_address(epb.endpoint_address);
                             const ep_dir = Endpoint.dir_from_address(epb.endpoint_address).as_number();
-                            var driver = get_driver(ep_to_drv[ep_num][ep_dir]);
-                            if (driver != null) {
-                                driver.?.transfer(epb.endpoint_address, epb.buffer);
+                            if (get_driver(ep_to_drv[ep_num][ep_dir])) |driver| {
+                                driver.transfer(epb.endpoint_address, epb.buffer);
                             }
                             if (Endpoint.dir_from_address(epb.endpoint_address) == .Out) {
                                 f.endpoint_reset_rx(epb.endpoint_address);

--- a/core/src/core/usb/hid.zig
+++ b/core/src/core/usb/hid.zig
@@ -370,24 +370,6 @@ pub fn hid_usage_page(comptime n: u2, usage: [n]u8) [n + 1]u8 {
     );
 }
 
-pub fn hid_usage_min(comptime n: u2, data: [n]u8) [n + 1]u8 {
-    return hid_report_item(
-        n,
-        @intFromEnum(ReportItemTypes.Local),
-        @intFromEnum(LocalItem.UsageMin),
-        data,
-    );
-}
-
-pub fn hid_usage_max(comptime n: u2, data: [n]u8) [n + 1]u8 {
-    return hid_report_item(
-        n,
-        @intFromEnum(ReportItemTypes.Local),
-        @intFromEnum(LocalItem.UsageMax),
-        data,
-    );
-}
-
 pub fn hid_logical_min(comptime n: u2, data: [n]u8) [n + 1]u8 {
     return hid_report_item(
         n,
@@ -432,6 +414,24 @@ pub fn hid_usage(comptime n: u2, data: [n]u8) [n + 1]u8 {
         n,
         @intFromEnum(ReportItemTypes.Local),
         @intFromEnum(LocalItem.Usage),
+        data,
+    );
+}
+
+pub fn hid_usage_min(comptime n: u2, data: [n]u8) [n + 1]u8 {
+    return hid_report_item(
+        n,
+        @intFromEnum(ReportItemTypes.Local),
+        @intFromEnum(LocalItem.UsageMin),
+        data,
+    );
+}
+
+pub fn hid_usage_max(comptime n: u2, data: [n]u8) [n + 1]u8 {
+    return hid_report_item(
+        n,
+        @intFromEnum(ReportItemTypes.Local),
+        @intFromEnum(LocalItem.UsageMax),
         data,
     );
 }

--- a/core/src/core/usb/hid.zig
+++ b/core/src/core/usb/hid.zig
@@ -595,6 +595,32 @@ pub const HidClassDriver = struct {
                 switch (hid_request_type.?) {
                     .SetIdle => {
                         if (stage == .Setup) {
+                            // TODO: The host is attempting to limit bandwidth by requesting that
+                            // the device only return report data when its values actually change,
+                            // or when the specified duration elapses. In practice, the device can
+                            // still send reports as often as it wants, but for completeness this
+                            // should be implemented eventually.
+                            self.device.?.control_ack(setup);
+                        }
+                    },
+                    .SetProtocol => {
+                        if (stage == .Setup) {
+                            // TODO: The device should switch the format of its reports from the
+                            // boot keyboard/mouse protocol to the format described in its report descriptor,
+                            // or vice versa.
+                            //
+                            // For now, this request is ACKed without doing anything; in practice,
+                            // the OS will reuqest the report protocol anyway, so usually only one format is needed.
+                            // Unless the report format matches the boot protocol exactly (see ReportDescriptorKeyboard),
+                            // our device might not work in a limited BIOS environment.
+                            self.device.?.control_ack(setup);
+                        }
+                    },
+                    .SetReport => {
+                        if (stage == .Setup) {
+                            // TODO: This request sends a feature or ouptut report to the device,
+                            // e.g. turning on the caps lock LED. This must be handled in an
+                            // application-specific way, so notify the application code of the event.
                             self.device.?.control_ack(setup);
                         }
                     },

--- a/core/src/core/usb/hid.zig
+++ b/core/src/core/usb/hid.zig
@@ -156,16 +156,6 @@ pub const ReportType = enum(u8) {
     Feature = 3,
 };
 
-/// HID class specific control request
-pub const Request = enum(u8) {
-    GetReport = 0x01,
-    GetIdle = 0x02,
-    GetProtocol = 0x03,
-    SetReport = 0x09,
-    SetIdle = 0x0a,
-    SetProtocol = 0x0b,
-};
-
 /// HID country codes
 pub const CountryCode = enum(u8) {
     NotSupported = 0,

--- a/core/src/core/usb/hid.zig
+++ b/core/src/core/usb/hid.zig
@@ -253,49 +253,49 @@ pub const LocalItem = enum(u4) {
 };
 
 pub const UsageTable = struct {
-    const desktop: [1]u8 = "\x01".*;
-    const keyboard: [1]u8 = "\x07".*;
-    const led: [1]u8 = "\x08".*;
-    const fido: [2]u8 = "\xD0\xF1".*;
-    const vendor: [2]u8 = "\x00\xFF".*;
+    pub const desktop: [1]u8 = "\x01".*;
+    pub const keyboard: [1]u8 = "\x07".*;
+    pub const led: [1]u8 = "\x08".*;
+    pub const fido: [2]u8 = "\xD0\xF1".*;
+    pub const vendor: [2]u8 = "\x00\xFF".*;
 };
 
 pub const FidoAllianceUsage = struct {
-    const u2fhid: [1]u8 = "\x01".*;
-    const data_in: [1]u8 = "\x20".*;
-    const data_out: [1]u8 = "\x21".*;
+    pub const u2fhid: [1]u8 = "\x01".*;
+    pub const data_in: [1]u8 = "\x20".*;
+    pub const data_out: [1]u8 = "\x21".*;
 };
 
 pub const DesktopUsage = struct {
-    const keyboard: [1]u8 = "\x06".*;
+    pub const keyboard: [1]u8 = "\x06".*;
 };
 
-const HID_DATA: u8 = 0 << 0;
-const HID_CONSTANT: u8 = 1 << 0;
+pub const HID_DATA: u8 = 0 << 0;
+pub const HID_CONSTANT: u8 = 1 << 0;
 
-const HID_ARRAY = 0 << 1;
-const HID_VARIABLE = 1 << 1;
+pub const HID_ARRAY = 0 << 1;
+pub const HID_VARIABLE = 1 << 1;
 
-const HID_ABSOLUTE = 0 << 2;
-const HID_RELATIVE = 1 << 2;
+pub const HID_ABSOLUTE = 0 << 2;
+pub const HID_RELATIVE = 1 << 2;
 
-const HID_WRAP_NO = 0 << 3;
-const HID_WRAP = 1 << 3;
+pub const HID_WRAP_NO = 0 << 3;
+pub const HID_WRAP = 1 << 3;
 
-const HID_LINEAR = 0 << 4;
-const HID_NONLINEAR = 1 << 4;
+pub const HID_LINEAR = 0 << 4;
+pub const HID_NONLINEAR = 1 << 4;
 
-const HID_PREFERRED_STATE = 0 << 5;
-const HID_PREFERRED_NO = 1 << 5;
+pub const HID_PREFERRED_STATE = 0 << 5;
+pub const HID_PREFERRED_NO = 1 << 5;
 
-const HID_NO_NULL_POSITION = 0 << 6;
-const HID_NULL_STATE = 1 << 6;
+pub const HID_NO_NULL_POSITION = 0 << 6;
+pub const HID_NULL_STATE = 1 << 6;
 
-const HID_NON_VOLATILE = 0 << 7;
-const HID_VOLATILE = 1 << 7;
+pub const HID_NON_VOLATILE = 0 << 7;
+pub const HID_VOLATILE = 1 << 7;
 
-const HID_BITFIELD = 0 << 8;
-const HID_BUFFERED_BYTES = 1 << 8;
+pub const HID_BITFIELD = 0 << 8;
+pub const HID_BUFFERED_BYTES = 1 << 8;
 
 // +++++++++++++++++++++++++++++++++++++++++++++++++
 // Report Descriptor Functions

--- a/core/src/core/usb/hid.zig
+++ b/core/src/core/usb/hid.zig
@@ -618,7 +618,7 @@ pub const HidClassDriver = struct {
                     },
                     .SetReport => {
                         if (stage == .Setup) {
-                            // TODO: This request sends a feature or ouptut report to the device,
+                            // TODO: This request sends a feature or output report to the device,
                             // e.g. turning on the caps lock LED. This must be handled in an
                             // application-specific way, so notify the application code of the event.
                             self.device.?.control_ack(setup);

--- a/core/src/core/usb/hid.zig
+++ b/core/src/core/usb/hid.zig
@@ -600,6 +600,8 @@ pub const HidClassDriver = struct {
                             // or when the specified duration elapses. In practice, the device can
                             // still send reports as often as it wants, but for completeness this
                             // should be implemented eventually.
+                            //
+                            // https://github.com/ZigEmbeddedGroup/microzig/issues/454
                             self.device.?.control_ack(setup);
                         }
                     },
@@ -613,6 +615,8 @@ pub const HidClassDriver = struct {
                             // the OS will reuqest the report protocol anyway, so usually only one format is needed.
                             // Unless the report format matches the boot protocol exactly (see ReportDescriptorKeyboard),
                             // our device might not work in a limited BIOS environment.
+                            //
+                            // https://github.com/ZigEmbeddedGroup/microzig/issues/454
                             self.device.?.control_ack(setup);
                         }
                     },
@@ -621,6 +625,8 @@ pub const HidClassDriver = struct {
                             // TODO: This request sends a feature or output report to the device,
                             // e.g. turning on the caps lock LED. This must be handled in an
                             // application-specific way, so notify the application code of the event.
+                            //
+                            // https://github.com/ZigEmbeddedGroup/microzig/issues/454
                             self.device.?.control_ack(setup);
                         }
                     },

--- a/core/src/core/usb/hid.zig
+++ b/core/src/core/usb/hid.zig
@@ -528,7 +528,7 @@ pub const ReportDescriptorKeyboard = hid_usage_page(1, UsageTable.desktop) //
     ++ hid_logical_max(2, "\xff\x00".*) //
     ++ hid_report_count(1, "\x06".*) //
     ++ hid_report_size(1, "\x08".*) //
-    ++ hid_output(HID_DATA | HID_ARRAY | HID_ABSOLUTE) //
+    ++ hid_input(HID_DATA | HID_ARRAY | HID_ABSOLUTE) //
     // End
     ++ hid_collection_end();
 

--- a/core/src/core/usb/types.zig
+++ b/core/src/core/usb/types.zig
@@ -52,9 +52,21 @@ pub const ControlStage = enum {
 
 /// The types of USB SETUP requests that we understand.
 pub const SetupRequest = enum(u8) {
-    GetDescriptor = 0x06,
+    SetFeature = 0x03,
     SetAddress = 0x05,
+    GetDescriptor = 0x06,
     SetConfiguration = 0x09,
+
+    pub fn from_u8(v: u8) ?@This() {
+        return std.meta.intToEnum(@This(), v) catch null;
+    }
+};
+
+pub const FeatureSelector = enum(u8) {
+    EndpointHalt = 0x00,
+    DeviceRemoteWakeup = 0x01,
+    TestMode = 0x02,
+    // The remaining features only apply to OTG devices.
 
     pub fn from_u8(v: u8) ?@This() {
         return std.meta.intToEnum(@This(), v) catch null;


### PR DESCRIPTION
This PR includes enough changes to facilitate a working USB HID keyboard implementation using MicroZig.

- Fix critical typo from #426
- Make fields pub that are required for app code to define its own report descriptors
- ACK requests that are required for keyboard; some of these are stubs which need further improvements

I used this code, along with my own application code, to create a USB HID keyboard that connects and types successfully. Tested on macOS Sequoia and Arch Linux. I tried both the included `ReportDescriptorKeyboard` and a custom report format, both work well.

I have done my best to document the areas that were added as stubs and which need improvement.