### PR TITLE
Fixup stepper

### DIFF
--- a/drivers/stepper/stepper.zig
+++ b/drivers/stepper/stepper.zig
@@ -180,7 +180,6 @@ pub fn Stepper(comptime Driver: type) type {
         }
 
         pub fn move(self: *Self, steps: i32) !void {
-            // std.log.info("Running {} steps", .{steps}); // DELETEME
             self.start_move(steps);
             while (try self.next_action()) {}
         }

--- a/drivers/stepper/stepper.zig
+++ b/drivers/stepper/stepper.zig
@@ -143,7 +143,7 @@ pub fn Stepper(comptime Driver: type) type {
             }
         }
 
-        pub fn set_rpm(self: Self, rpm: f64) void {
+        pub fn set_rpm(self: *Self, rpm: f64) void {
             self.rpm = rpm;
         }
 

--- a/drivers/stepper/stepper.zig
+++ b/drivers/stepper/stepper.zig
@@ -313,7 +313,7 @@ pub fn Stepper(comptime Driver: type) type {
 
             // Track when we started the step
             const start = self.clock.get_time_since_boot();
-            const pulse = self.step_pulse; // save value because calcStepPulse() will overwrite it
+            const pulse = self.step_pulse; // save value because calc_step_pulse can overwrite it
             self.calc_step_pulse();
 
             // We should pull HIGH for at least STEP_HIGH_MIN us

--- a/drivers/stepper/stepper.zig
+++ b/drivers/stepper/stepper.zig
@@ -80,7 +80,7 @@ pub fn Stepper(comptime Driver: type) type {
         cruise_step_pulse: mdf.time.Duration = .from_us(0),
         remainder: mdf.time.Duration = .from_us(0),
         last_action_end: mdf.time.Absolute = .from_us(0),
-        next_action_interval: mdf.time.Duration = .from_us(0),
+        next_action_time: mdf.time.Absolute = .from_us(0),
         step_count: u32 = 0,
         dir_state: mdf.base.Digital_IO.State = .low,
         motor_steps: u16,
@@ -180,9 +180,9 @@ pub fn Stepper(comptime Driver: type) type {
         }
 
         pub fn move(self: *Self, steps: i32) !void {
+            // std.log.info("Running {} steps", .{steps}); // DELETEME
             self.start_move(steps);
-            var action = try self.next_action();
-            while (@intFromEnum(action) != 0) : (action = try self.next_action()) {}
+            while (try self.next_action()) {}
         }
 
         pub fn rotate(self: *Self, deg: i32) !void {
@@ -196,7 +196,8 @@ pub fn Stepper(comptime Driver: type) type {
         pub fn start_move_time(self: *Self, steps: i32, time: mdf.time.Duration) void {
             // set up new move
             self.dir_state = if (steps >= 0) .high else .low;
-            self.last_action_end = .from_us(0);
+            self.last_action_end = self.clock.get_time_since_boot();
+            self.next_action_time = self.last_action_end;
             self.steps_remaining = @abs(steps);
             self.step_count = 0;
             self.remainder = .from_us(0);
@@ -300,29 +301,37 @@ pub fn Stepper(comptime Driver: type) type {
             while (!deadline.is_reached_by(self.clock.get_time_since_boot())) {}
         }
 
-        pub fn next_action(self: *Self) !mdf.time.Duration {
-            if (self.steps_remaining > 0) {
-                self.delay_micros(self.next_action_interval, self.last_action_end);
-                //  DIR pin is sampled on rising STEP edge, so it is set first
-                try self.dir_pin.write(self.dir_state);
-                try self.step_pin.write(.high);
-                // Absolute time now
-                const start = self.clock.get_time_since_boot();
-                const pulse = self.step_pulse; // save value because calcStepPulse() will overwrite it
-                self.calc_step_pulse();
-                // We should pull HIGH for at least 1-2us (step_high_min)
-                self.clock.sleep_us(Driver.STEP_HIGH_MIN);
-                try self.step_pin.write(.low);
-                // account for calc_step_pulse() execution time; sets ceiling for max rpm on slower MCUs
-                self.last_action_end = self.clock.get_time_since_boot();
-                const elapsed = self.last_action_end.diff(start);
-                self.next_action_interval = if (elapsed.less_than(pulse)) pulse.minus(elapsed) else @enumFromInt(1);
-            } else {
-                // end of move
-                self.last_action_end = .from_us(0);
-                self.next_action_interval = .from_us(0);
-            }
-            return self.next_action_interval;
+        /// Perform the next step, waiting until the next_action_time has been reached
+        pub fn next_action(self: *Self) !bool {
+            if (self.steps_remaining == 0) return false;
+
+            // Wait until we reach the deadline
+            while (!self.next_action_time.is_reached_by(self.clock.get_time_since_boot())) {}
+
+            //  DIR pin is sampled on rising STEP edge, so it is set first
+            try self.dir_pin.write(self.dir_state);
+            try self.step_pin.write(.high);
+
+            // Track when we started the step
+            const start = self.clock.get_time_since_boot();
+            const pulse = self.step_pulse; // save value because calcStepPulse() will overwrite it
+            self.calc_step_pulse();
+
+            // We should pull HIGH for at least 1-2us (step_high_min)
+            self.clock.sleep_us(Driver.STEP_HIGH_MIN);
+            try self.step_pin.write(.low);
+
+            // Update timing reference
+            self.last_action_end = self.clock.get_time_since_boot();
+            const elapsed = self.last_action_end.diff(start);
+
+            // Calculate the next interval, accounting for the time spent in this function
+            self.next_action_time = if (elapsed.less_than(pulse))
+                self.last_action_end.add_duration(pulse.minus(elapsed))
+            else
+                self.last_action_end;
+
+            return self.steps_remaining > 0;
         }
 
         pub fn get_current_state(self: Self) State {

--- a/examples/raspberrypi/rp2xxx/src/stepper.zig
+++ b/examples/raspberrypi/rp2xxx/src/stepper.zig
@@ -8,7 +8,29 @@ const ClockDevice = rp2xxx.drivers.ClockDevice;
 const stepper_driver = microzig.drivers.stepper;
 const A4988 = stepper_driver.Stepper(stepper_driver.A4988);
 
+////
+const uart = rp2xxx.uart.instance.num(0);
+const baud_rate = 115200;
+const uart_tx_pin = gpio.num(0);
+
+pub fn panic(message: []const u8, _: ?*std.builtin.StackTrace, _: ?usize) noreturn {
+    std.log.err("panic: {s}", .{message});
+    @breakpoint();
+    while (true) {}
+}
+
+pub const microzig_options = microzig.Options{
+    .log_level = .debug,
+    .logFn = rp2xxx.uart.logFn,
+};
+////
 pub fn main() !void {
+    uart_tx_pin.set_function(.uart);
+    uart.apply(.{
+        .baud_rate = baud_rate,
+        .clock_config = rp2xxx.clock_config,
+    });
+    rp2xxx.uart.init_logger(uart);
     const led = gpio.num(8);
     led.set_function(.sio);
     led.set_direction(.out);
@@ -29,35 +51,35 @@ pub fn main() !void {
     }
 
     var stepper = A4988.init(.{
+        // .ms1_pin = pins.ms1.digital_io(),
+        // .ms2_pin = pins.ms2.digital_io(),
+        // .ms3_pin = pins.ms3.digital_io(),
         .dir_pin = pins.dir.digital_io(),
         .step_pin = pins.step.digital_io(),
-        .ms1_pin = pins.ms1.digital_io(),
-        .ms2_pin = pins.ms2.digital_io(),
-        .ms3_pin = pins.ms3.digital_io(),
         .clock_device = cd.clock_device(),
     });
 
-    try stepper.begin(300, 1);
+    try stepper.begin(200, 1);
     // Only needed if you set the enable pin
     // try stepper.enable();
 
     while (true) {
-        const linear_profile = stepper_driver.Speed_Profile{ .linear_speed = .{ .accel = 2000, .decel = 2000 } };
-        const constant_profile = stepper_driver.Speed_Profile.constant_speed;
+        // const linear_profile = stepper_driver.Speed_Profile{ .linear_speed = .{ .accel = 2000, .decel = 2000 } };
+        // const constant_profile = stepper_driver.Speed_Profile.constant_speed;
         // Try both constant and linear acceleration profiles
-        inline for (.{ constant_profile, linear_profile }) |profile| {
-            stepper.set_speed_profile(
-                profile,
-            );
-            // Try different microsteps
-            inline for (.{ 2, 4, 8, 16 }) |ms| {
-                _ = try stepper.set_microstep(ms);
-                try stepper.rotate(360);
-                time.sleep_ms(250);
-                try stepper.rotate(-360);
-                time.sleep_ms(250);
-            }
-            time.sleep_ms(1000);
-        }
+        // inline for (.{ constant_profile, linear_profile }) |profile| {
+        //     stepper.set_speed_profile(
+        //         profile,
+        //     );
+        // Try different microsteps
+        // inline for (.{ 2, 4, 8, 16 }) |ms| {
+        //     _ = try stepper.set_microstep(ms);
+        try stepper.rotate(360);
+        time.sleep_ms(250);
+        try stepper.rotate(-360);
+        time.sleep_ms(250);
+        // }
+        // time.sleep_ms(1000);
+        // }
     }
 }

--- a/examples/raspberrypi/rp2xxx/src/stepper.zig
+++ b/examples/raspberrypi/rp2xxx/src/stepper.zig
@@ -8,29 +8,7 @@ const ClockDevice = rp2xxx.drivers.ClockDevice;
 const stepper_driver = microzig.drivers.stepper;
 const A4988 = stepper_driver.Stepper(stepper_driver.A4988);
 
-////
-const uart = rp2xxx.uart.instance.num(0);
-const baud_rate = 115200;
-const uart_tx_pin = gpio.num(0);
-
-pub fn panic(message: []const u8, _: ?*std.builtin.StackTrace, _: ?usize) noreturn {
-    std.log.err("panic: {s}", .{message});
-    @breakpoint();
-    while (true) {}
-}
-
-pub const microzig_options = microzig.Options{
-    .log_level = .debug,
-    .logFn = rp2xxx.uart.logFn,
-};
-////
 pub fn main() !void {
-    uart_tx_pin.set_function(.uart);
-    uart.apply(.{
-        .baud_rate = baud_rate,
-        .clock_config = rp2xxx.clock_config,
-    });
-    rp2xxx.uart.init_logger(uart);
     const led = gpio.num(8);
     led.set_function(.sio);
     led.set_direction(.out);
@@ -51,35 +29,35 @@ pub fn main() !void {
     }
 
     var stepper = A4988.init(.{
-        // .ms1_pin = pins.ms1.digital_io(),
-        // .ms2_pin = pins.ms2.digital_io(),
-        // .ms3_pin = pins.ms3.digital_io(),
         .dir_pin = pins.dir.digital_io(),
         .step_pin = pins.step.digital_io(),
+        .ms1_pin = pins.ms1.digital_io(),
+        .ms2_pin = pins.ms2.digital_io(),
+        .ms3_pin = pins.ms3.digital_io(),
         .clock_device = cd.clock_device(),
     });
 
-    try stepper.begin(200, 1);
+    try stepper.begin(300, 1);
     // Only needed if you set the enable pin
     // try stepper.enable();
 
     while (true) {
-        // const linear_profile = stepper_driver.Speed_Profile{ .linear_speed = .{ .accel = 2000, .decel = 2000 } };
-        // const constant_profile = stepper_driver.Speed_Profile.constant_speed;
+        const linear_profile = stepper_driver.Speed_Profile{ .linear_speed = .{ .accel = 2000, .decel = 2000 } };
+        const constant_profile = stepper_driver.Speed_Profile.constant_speed;
         // Try both constant and linear acceleration profiles
-        // inline for (.{ constant_profile, linear_profile }) |profile| {
-        //     stepper.set_speed_profile(
-        //         profile,
-        //     );
-        // Try different microsteps
-        // inline for (.{ 2, 4, 8, 16 }) |ms| {
-        //     _ = try stepper.set_microstep(ms);
-        try stepper.rotate(360);
-        time.sleep_ms(250);
-        try stepper.rotate(-360);
-        time.sleep_ms(250);
-        // }
-        // time.sleep_ms(1000);
-        // }
+        inline for (.{ constant_profile, linear_profile }) |profile| {
+            stepper.set_speed_profile(
+                profile,
+            );
+            // Try different microsteps
+            inline for (.{ 2, 4, 8, 16 }) |ms| {
+                _ = try stepper.set_microstep(ms);
+                try stepper.rotate(360);
+                time.sleep_ms(250);
+                try stepper.rotate(-360);
+                time.sleep_ms(250);
+            }
+            time.sleep_ms(1000);
+        }
     }
 }


### PR DESCRIPTION
* Use an absolute time for next action instead of a duration to simplify calculations
* Wait min low time for pulse
* Fix `set_rpm` not working because it didn't have a pointer receiver.
* Make `next_action` return a boolean and just loop on that value in `move`

Fixes #458 