### PR TITLE
Regz offset comments

### DIFF
--- a/tools/regz/src/gen.zig
+++ b/tools/regz/src/gen.zig
@@ -963,6 +963,7 @@ test "gen.peripheral instantiation" {
         \\pub const types = struct {
         \\    pub const peripherals = struct {
         \\        pub const TEST_PERIPHERAL = extern struct {
+        \\            /// offset: 0x00
         \\            TEST_REGISTER: mmio.Mmio(packed struct(u32) {
         \\                TEST_FIELD: u1,
         \\                padding: u31 = 0,
@@ -1004,6 +1005,7 @@ test "gen.peripherals with a shared type" {
         \\pub const types = struct {
         \\    pub const peripherals = struct {
         \\        pub const TEST_PERIPHERAL = extern struct {
+        \\            /// offset: 0x00
         \\            TEST_REGISTER: mmio.Mmio(packed struct(u32) {
         \\                TEST_FIELD: u1,
         \\                padding: u31 = 0,
@@ -1063,14 +1065,18 @@ test "gen.peripheral with modes" {
         \\            }
         \\
         \\            TEST_MODE1: extern struct {
+        \\                /// offset: 0x00
         \\                TEST_REGISTER1: u32,
+        \\                /// offset: 0x04
         \\                COMMON_REGISTER: mmio.Mmio(packed struct(u32) {
         \\                    TEST_FIELD: u1,
         \\                    padding: u31 = 0,
         \\                }),
         \\            },
         \\            TEST_MODE2: extern struct {
+        \\                /// offset: 0x00
         \\                TEST_REGISTER2: u32,
+        \\                /// offset: 0x04
         \\                COMMON_REGISTER: mmio.Mmio(packed struct(u32) {
         \\                    TEST_FIELD: u1,
         \\                    padding: u31 = 0,
@@ -1110,6 +1116,7 @@ test "gen.peripheral with enum" {
         \\                _,
         \\            };
         \\
+        \\            /// offset: 0x00
         \\            TEST_REGISTER: u8,
         \\        };
         \\    };
@@ -1144,6 +1151,7 @@ test "gen.peripheral with enum, enum is exhausted of values" {
         \\                TEST_ENUM_FIELD2 = 0x1,
         \\            };
         \\
+        \\            /// offset: 0x00
         \\            TEST_REGISTER: u8,
         \\        };
         \\    };
@@ -1179,6 +1187,7 @@ test "gen.field with named enum" {
         \\                _,
         \\            };
         \\
+        \\            /// offset: 0x00
         \\            TEST_REGISTER: mmio.Mmio(packed struct(u8) {
         \\                TEST_FIELD: TEST_ENUM,
         \\                padding: u4 = 0,
@@ -1211,6 +1220,7 @@ test "gen.field with anonymous enum" {
         \\pub const types = struct {
         \\    pub const peripherals = struct {
         \\        pub const TEST_PERIPHERAL = extern struct {
+        \\            /// offset: 0x00
         \\            TEST_REGISTER: mmio.Mmio(packed struct(u8) {
         \\                TEST_FIELD: enum(u4) {
         \\                    TEST_ENUM_FIELD1 = 0x0,
@@ -1257,14 +1267,20 @@ test "gen.namespaced register groups" {
         \\    pub const peripherals = struct {
         \\        pub const PORT = struct {
         \\            pub const PORTB = extern struct {
+        \\                /// offset: 0x00
         \\                PORTB: u8,
+        \\                /// offset: 0x01
         \\                DDRB: u8,
+        \\                /// offset: 0x02
         \\                PINB: u8,
         \\            };
         \\
         \\            pub const PORTC = extern struct {
+        \\                /// offset: 0x00
         \\                PORTC: u8,
+        \\                /// offset: 0x01
         \\                DDRC: u8,
+        \\                /// offset: 0x02
         \\                PINC: u8,
         \\            };
         \\        };
@@ -1303,8 +1319,11 @@ test "gen.peripheral with reserved register" {
         \\pub const types = struct {
         \\    pub const peripherals = struct {
         \\        pub const PORTB = extern struct {
+        \\            /// offset: 0x00
         \\            PORTB: u32,
+        \\            /// offset: 0x04
         \\            reserved8: [4]u8,
+        \\            /// offset: 0x08
         \\            PINB: u32,
         \\        };
         \\    };
@@ -1342,8 +1361,11 @@ test "gen.peripheral with count" {
         \\pub const types = struct {
         \\    pub const peripherals = struct {
         \\        pub const PORTB = extern struct {
+        \\            /// offset: 0x00
         \\            PORTB: u8,
+        \\            /// offset: 0x01
         \\            DDRB: u8,
+        \\            /// offset: 0x02
         \\            PINB: u8,
         \\        };
         \\    };
@@ -1381,8 +1403,11 @@ test "gen.peripheral with count, padding required" {
         \\pub const types = struct {
         \\    pub const peripherals = struct {
         \\        pub const PORTB = extern struct {
+        \\            /// offset: 0x00
         \\            PORTB: u8,
+        \\            /// offset: 0x01
         \\            DDRB: u8,
+        \\            /// offset: 0x02
         \\            PINB: u8,
         \\            padding: [1]u8,
         \\        };
@@ -1421,8 +1446,11 @@ test "gen.register with count" {
         \\pub const types = struct {
         \\    pub const peripherals = struct {
         \\        pub const PORTB = extern struct {
+        \\            /// offset: 0x00
         \\            PORTB: [4]u8,
+        \\            /// offset: 0x04
         \\            DDRB: u8,
+        \\            /// offset: 0x05
         \\            PINB: u8,
         \\        };
         \\    };
@@ -1460,11 +1488,14 @@ test "gen.register with count and fields" {
         \\pub const types = struct {
         \\    pub const peripherals = struct {
         \\        pub const PORTB = extern struct {
+        \\            /// offset: 0x00
         \\            PORTB: [4]mmio.Mmio(packed struct(u8) {
         \\                TEST_FIELD: u4,
         \\                padding: u4 = 0,
         \\            }),
+        \\            /// offset: 0x04
         \\            DDRB: u8,
+        \\            /// offset: 0x05
         \\            PINB: u8,
         \\        };
         \\    };
@@ -1494,6 +1525,7 @@ test "gen.field with count, width of one, offset, and padding" {
         \\pub const types = struct {
         \\    pub const peripherals = struct {
         \\        pub const PORTB = extern struct {
+        \\            /// offset: 0x00
         \\            PORTB: mmio.Mmio(packed struct(u8) {
         \\                reserved2: u2 = 0,
         \\                /// (1/5 of TEST_FIELD)
@@ -1536,6 +1568,7 @@ test "gen.field with count, multi-bit width, offset, and padding" {
         \\pub const types = struct {
         \\    pub const peripherals = struct {
         \\        pub const PORTB = extern struct {
+        \\            /// offset: 0x00
         \\            PORTB: mmio.Mmio(packed struct(u8) {
         \\                reserved2: u2 = 0,
         \\                /// (1/2 of TEST_FIELD)
@@ -1614,6 +1647,7 @@ test "gen.peripheral type with register and field" {
         \\        /// test peripheral
         \\        pub const TEST_PERIPHERAL = extern struct {
         \\            /// test register
+        \\            /// offset: 0x00
         \\            TEST_REGISTER: mmio.Mmio(packed struct(u32) {
         \\                /// test field
         \\                TEST_FIELD: u1,
@@ -1647,6 +1681,7 @@ test "gen.name collisions in enum name cause them to be anonymous" {
         \\pub const types = struct {
         \\    pub const peripherals = struct {
         \\        pub const TEST_PERIPHERAL = extern struct {
+        \\            /// offset: 0x00
         \\            TEST_REGISTER: mmio.Mmio(packed struct(u8) {
         \\                TEST_FIELD1: enum(u4) {
         \\                    TEST_ENUM_FIELD1 = 0x0,
@@ -1689,6 +1724,7 @@ test "gen.pick one enum field in value collisions" {
         \\pub const types = struct {
         \\    pub const peripherals = struct {
         \\        pub const TEST_PERIPHERAL = extern struct {
+        \\            /// offset: 0x00
         \\            TEST_REGISTER: mmio.Mmio(packed struct(u8) {
         \\                TEST_FIELD: enum(u4) {
         \\                    TEST_ENUM_FIELD1 = 0x0,
@@ -1724,6 +1760,7 @@ test "gen.pick one enum field in name collisions" {
         \\pub const types = struct {
         \\    pub const peripherals = struct {
         \\        pub const TEST_PERIPHERAL = extern struct {
+        \\            /// offset: 0x00
         \\            TEST_REGISTER: mmio.Mmio(packed struct(u8) {
         \\                TEST_FIELD: enum(u4) {
         \\                    TEST_ENUM_FIELD1 = 0x0,
@@ -1761,6 +1798,7 @@ test "gen.register fields with name collision" {
         \\        /// test peripheral
         \\        pub const TEST_PERIPHERAL = extern struct {
         \\            /// test register
+        \\            /// offset: 0x00
         \\            TEST_REGISTER: mmio.Mmio(packed struct(u32) {
         \\                /// test field 1
         \\                TEST_FIELD: u1,

--- a/tools/regz/src/gen.zig
+++ b/tools/regz/src/gen.zig
@@ -732,8 +732,9 @@ fn write_registers_base(
     const writer = buffer.writer();
     var offset: u64 = 0;
     for (non_overlapping.items) |register| {
-        try writer.print("/// Offset: 0x{x}\n", .{offset});
+        // Pad out space between registers with 'reserved' byte arrays
         if (offset < register.offset_bytes) {
+            try writer.print("/// offset: 0x{x:0>2}\n", .{offset});
             try writer.print("reserved{}: [{}]u8,\n", .{ register.offset_bytes, register.offset_bytes - offset });
             offset = register.offset_bytes;
         }
@@ -770,6 +771,12 @@ fn write_register(
     const writer = buffer.writer();
     if (register.description) |description|
         try write_doc_comment(arena, description, writer);
+
+    // Add offset comment
+    var offset_buf: [80]u8 = undefined;
+    const offset_str: []const u8 =
+        try std.fmt.bufPrint(&offset_buf, "offset: 0x{x:0>2}", .{register.offset_bytes});
+    try write_doc_comment(arena, offset_str, writer);
 
     var array_prefix_buf: [80]u8 = undefined;
     const array_prefix: []const u8 = if (register.count) |count|

--- a/tools/regz/src/gen.zig
+++ b/tools/regz/src/gen.zig
@@ -725,13 +725,14 @@ fn write_registers_base(
         }
     }
 
-    // registers _should_ be sorted when then make their way here
+    // registers _should_ be sorted by the time they make their way here
     var buffer = std.ArrayList(u8).init(arena);
     defer buffer.deinit();
 
     const writer = buffer.writer();
     var offset: u64 = 0;
     for (non_overlapping.items) |register| {
+        try writer.print("/// Offset: 0x{x}\n", .{offset});
         if (offset < register.offset_bytes) {
             try writer.print("reserved{}: [{}]u8,\n", .{ register.offset_bytes, register.offset_bytes - offset });
             offset = register.offset_bytes;


### PR DESCRIPTION
Add a docstring comment under the register name

```zig
        /// I2C (Inter-Integrated Circuit) Controller
        pub const I2C0 = extern struct {
            /// I2C_SCL_LOW_PERIOD_REG
            /// offset: 0x00
            SCL_LOW_PERIOD: mmio.Mmio(packed struct(u32) {
                /// reg_scl_low_period
                SCL_LOW_PERIOD: u9,
                padding: u23 = 0,
            }),
            /// I2C_CTR_REG
            /// offset: 0x04
            CTR: mmio.Mmio(packed struct(u32) {
                /// reg_sda_force_out
                SDA_FORCE_OUT: u1,
...
            /// offset: 0xe0
            reserved240: [16]u8,
```