### PR TITLE
esp: hal: gpio: Add various fixes and features

### DIFF
--- a/port/espressif/esp/src/hal/gpio.zig
+++ b/port/espressif/esp/src/hal/gpio.zig
@@ -269,7 +269,7 @@ pub const Pin = enum(u5) {
 
     pub fn set_output_drive_strength(self: Pin, strength: DriveStrength) void {
         IO_MUX.GPIO[@intFromEnum(self)].modify(.{
-            .FUN_DRV = DriveStrength.to_value(strength, self),
+            .FUN_DRV = strength.to_value(self),
         });
     }
 

--- a/port/espressif/esp/src/hal/gpio.zig
+++ b/port/espressif/esp/src/hal/gpio.zig
@@ -30,7 +30,7 @@ pub const DriveStrength = enum {
     @"20mA",
     @"40mA",
 
-    /// Get the appropriate value of DriveStrentgh based on the pin number.
+    /// Get the appropriate value of DriveStrength based on the pin number.
     /// See section 5.15.2 (IO MUX Registers) of the Technical Reference Manual
     fn to_value(strength: DriveStrength, pin: Pin) u2 {
         return switch (@intFromEnum(pin)) {


### PR DESCRIPTION
1. Fix up `DriveStrength` - The bit values depends on the GPIO number, which is crazy. See page 187 of the TRM
2. Split up setting pulldowns/pullups based on sleep mode (This was previously incorrect).
3. Fix `set_open_drain_output`, which never would have compiled.