### PR TITLE
esp: hal: i2c (part 2)

### DIFF
--- a/drivers/display/sh1106.zig
+++ b/drivers/display/sh1106.zig
@@ -176,7 +176,7 @@ pub fn SH1106(comptime options: Options) type {
             try self.set_display(.on);
         }
 
-        pub fn write_full_display(self: Self, data: *const [cols * 8]u8) !void {
+        pub fn write_full_display(self: Self, data: *const [cols * rows / 8]u8) !void {
             for (0..8) |page| {
                 try self.set_page_address(@intCast(page));
                 const start = cols * page;

--- a/examples/espressif/esp/build.zig
+++ b/examples/espressif/esp/build.zig
@@ -22,6 +22,8 @@ pub fn build(b: *std.Build) void {
         .{ .name = "custom_clock_config", .file = "src/custom_clock_config.zig" },
         .{ .name = "gpio_input", .file = "src/gpio_input.zig" },
         .{ .name = "i2c_bus_scan", .file = "src/i2c_bus_scan.zig" },
+        .{ .name = "i2c_temp", .file = "src/i2c_temp.zig" },
+        .{ .name = "i2c_display_sh1106", .file = "src/i2c_display_sh1106.zig" },
         .{ .name = "stepper_driver", .file = "src/stepper_driver.zig" },
         .{ .name = "stepper_driver_dumb", .file = "src/stepper_driver_dumb.zig" },
         .{ .name = "systimer", .file = "src/systimer.zig" },

--- a/examples/espressif/esp/src/i2c_bus_scan.zig
+++ b/examples/espressif/esp/src/i2c_bus_scan.zig
@@ -19,12 +19,6 @@ pub fn main() !void {
     const sda_pin = gpio.num(5);
     const scl_pin = gpio.num(6);
 
-    // TODO: Should this be done in apply?
-    // Enable I2C peripheral clock
-    peripherals.SYSTEM.PERIP_CLK_EN0.modify(.{ .I2C_EXT0_CLK_EN = 1 });
-    // Take I2C out of reset
-    peripherals.SYSTEM.PERIP_RST_EN0.modify(.{ .I2C_EXT0_RST = 0 });
-
     try i2c0.apply(
         .{ .sda = sda_pin, .scl = scl_pin },
         100_000,

--- a/examples/espressif/esp/src/i2c_display_sh1106.zig
+++ b/examples/espressif/esp/src/i2c_display_sh1106.zig
@@ -34,15 +34,15 @@ pub fn main() !void {
     );
 
     // Create i2c datagram device
-    var i2c_device = I2C_Device.init(i2c0, @enumFromInt(0x3C));
+    const i2c_device = I2C_Device.init(i2c0, @enumFromInt(0x3C));
     // Pass i2c device to driver to create display instance
     const display_driver = SH1106(.{
         .mode = .i2c,
-        .Datagram_Device = microzig.drivers.base.Datagram_Device,
+        .Datagram_Device = I2C_Device,
     });
 
     // Configure device
-    const display = try display_driver.init(i2c_device.datagram_device());
+    const display = try display_driver.init(i2c_device);
 
     while (true) {
         std.log.debug("Clearing (white)", .{});

--- a/examples/espressif/esp/src/i2c_display_sh1106.zig
+++ b/examples/espressif/esp/src/i2c_display_sh1106.zig
@@ -22,12 +22,6 @@ pub fn main() !void {
     const sda_pin = gpio.num(5);
     const scl_pin = gpio.num(6);
 
-    // TODO: Should this be done in apply?
-    // Enable I2C peripheral clock
-    peripherals.SYSTEM.PERIP_CLK_EN0.modify(.{ .I2C_EXT0_CLK_EN = 1 });
-    // Take I2C out of reset
-    peripherals.SYSTEM.PERIP_RST_EN0.modify(.{ .I2C_EXT0_RST = 0 });
-
     try i2c0.apply(
         .{ .sda = sda_pin, .scl = scl_pin },
         400_000,

--- a/examples/espressif/esp/src/i2c_temp.zig
+++ b/examples/espressif/esp/src/i2c_temp.zig
@@ -22,12 +22,6 @@ pub fn main() !void {
     const sda_pin = gpio.num(5);
     const scl_pin = gpio.num(6);
 
-    // TODO: Should this be done in apply?
-    // Enable I2C peripheral clock
-    peripherals.SYSTEM.PERIP_CLK_EN0.modify(.{ .I2C_EXT0_CLK_EN = 1 });
-    // Take I2C out of reset
-    peripherals.SYSTEM.PERIP_RST_EN0.modify(.{ .I2C_EXT0_RST = 0 });
-
     try i2c0.apply(
         .{ .sda = sda_pin, .scl = scl_pin },
         100_000,

--- a/examples/raspberrypi/rp2xxx/src/rp2040_only/hd44780.zig
+++ b/examples/raspberrypi/rp2xxx/src/rp2040_only/hd44780.zig
@@ -1,7 +1,6 @@
 const std = @import("std");
 const microzig = @import("microzig");
 const drivers = microzig.drivers;
-const lcd_driver = drivers.display.hd44780;
 const lcd = drivers.display.HD44780;
 const PCF8574 = drivers.IO_expander.PCF8574;
 const State = drivers.base.Digital_IO.State;

--- a/port/espressif/esp/src/hal/drivers.zig
+++ b/port/espressif/esp/src/hal/drivers.zig
@@ -9,9 +9,93 @@ const hal = microzig.hal;
 const drivers = microzig.drivers.base;
 const time = microzig.drivers.time;
 
+const Datagram_Device = drivers.Datagram_Device;
 const Digital_IO = drivers.Digital_IO;
 const Clock_Device = drivers.Clock_Device;
 
+///
+/// A datagram device attached to an I²C bus.
+///
+pub const I2C_Device = struct {
+    // const BaseError = error{ IoError, Timeout }; // DELETEME
+    // pub const ConnectError = BaseError || error{DeviceBusy}; // DELETEME
+    pub const ConnectError = Datagram_Device.ConnectError;
+
+    // const WriteError = BaseError || error{ Unsupported, NotConnected }; // DELETEME
+    pub const WriteError = Datagram_Device.WriteError;
+    // pub const ReadError = BaseError || error{ Unsupported, NotConnected, BufferOverrun }; // DELETEME
+    pub const ReadError = Datagram_Device.ReadError;
+
+    /// Selects which I²C bus should be used.
+    bus: hal.i2c.I2C,
+
+    /// The address of our I²C device.
+    address: hal.i2c.Address,
+
+    pub fn init(bus: hal.i2c.I2C, address: hal.i2c.Address) I2C_Device {
+        return .{
+            .bus = bus,
+            .address = address,
+        };
+    }
+
+    pub fn datagram_device(dev: *I2C_Device) Datagram_Device {
+        return .{
+            .ptr = dev,
+            .vtable = &vtable,
+        };
+    }
+
+    pub fn connect(dev: I2C_Device) ConnectError!void {
+        _ = dev;
+    }
+
+    pub fn disconnect(dev: I2C_Device) void {
+        _ = dev;
+    }
+
+    pub fn write(dev: I2C_Device, datagram: []const u8) !void {
+        try dev.bus.write_blocking(dev.address, datagram, null);
+    }
+
+    pub fn writev(dev: I2C_Device, datagrams: []const []const u8) !void {
+        try dev.bus.writev_blocking(dev.address, datagrams, null);
+    }
+
+    pub fn read(dev: I2C_Device, datagram: []u8) !usize {
+        try dev.bus.read_blocking(dev.address, datagram, null);
+        return datagram.len;
+    }
+
+    pub fn readv(dev: I2C_Device, datagrams: []const []u8) !usize {
+        try dev.bus.readv_blocking(dev.address, datagrams, null);
+
+        return microzig.utilities.Slice_Vector([]u8).init(datagrams).size();
+    }
+
+    const vtable = Datagram_Device.VTable{
+        .connect_fn = null,
+        .disconnect_fn = null,
+        .writev_fn = writev_fn,
+        .readv_fn = readv_fn,
+    };
+
+    fn writev_fn(dd: *anyopaque, chunks: []const []const u8) WriteError!void {
+        const dev: *I2C_Device = @ptrCast(@alignCast(dd));
+        // TODO: Have to switch on the errors from readv, which are errors from read_blocking
+        return dev.writev(chunks) catch |e| {
+            std.log.info("Got error writing: {any}", .{e});
+            return WriteError.Unsupported;
+        };
+    }
+
+    fn readv_fn(dd: *anyopaque, chunks: []const []u8) ReadError!usize {
+        const dev: *I2C_Device = @ptrCast(@alignCast(dd));
+        // Map errors from i2c driver to datagram device errors
+        // TODO: Have to switch on the errors from readv, which are errors from read_blocking
+        return dev.readv(chunks) catch return ReadError.Unsupported;
+    }
+};
 ///
 /// Implementation of a digital i/o device.
 ///

--- a/port/espressif/esp/src/hal/drivers.zig
+++ b/port/espressif/esp/src/hal/drivers.zig
@@ -42,6 +42,14 @@ pub const I2C_Device = struct {
         };
     }
 
+    pub fn connect(dev: I2C_Device) ConnectError!void {
+        _ = dev;
+    }
+
+    pub fn disconnect(dev: I2C_Device) void {
+        _ = dev;
+    }
+
     pub fn write(dev: I2C_Device, datagram: []const u8) !void {
         try dev.bus.write_blocking(dev.address, datagram, null);
     }

--- a/port/espressif/esp/src/hal/i2c.zig
+++ b/port/espressif/esp/src/hal/i2c.zig
@@ -602,8 +602,8 @@ pub const I2C = enum(u1) {
             return Error.TargetAddressReserved;
         self.clear_interrupts();
 
-        // Short circuit for zero length reads as that would be an invalid operation
-        // readlengths in the TRM are 1-255
+        // Short circuit for zero length reads as that would be an invalid operation.
+        // Read lengths in the TRM are 1-255.
         if (buffer.len == 0 and !start and !stop)
             return;
 
@@ -706,7 +706,7 @@ pub const I2C = enum(u1) {
             return Error.TargetAddressReserved;
 
         // Short circuit for zero length writes without start or end as that would be an
-        // invalid operation write lengths in the TRM are 1-255
+        // invalid operation. Write lengths in the TRM are 1-255.
         if (bytes.len == 0 and !start and !stop)
             return;
 

--- a/port/espressif/esp/src/hal/i2c.zig
+++ b/port/espressif/esp/src/hal/i2c.zig
@@ -172,6 +172,11 @@ pub const I2C = enum(u1) {
     pub fn apply(self: I2C, pins: Pins, frequency: u32) ConfigError!void {
         const regs = self.get_regs();
 
+        // Enable I2C peripheral clock
+        microzig.hal.system.clocks_enable_set(.{ .i2c_ext0 = true });
+        // Take I2C out of reset
+        microzig.hal.system.peripheral_reset_clear(.{ .i2c_ext0 = true });
+
         // Setup SDA pin
         pins.sda.set_open_drain_output(true);
         pins.sda.set_input_enable(true);


### PR DESCRIPTION
This PR extends the functionality of the hal to support writes larger than the fifo (32 bytes).

It also implements an i2c `Datagram_Device`

Finally, it adds a few examples.

This converts the hal into almost a direct port of [esp-rs](https://github.com/esp-rs/esp-hal/blob/main/esp-hal/src/i2c/lp_i2c.rs)'s I2C HAL
