### PR TITLE
WCH CH32V: examples: replace busyloop with busy_delay

### DIFF
--- a/examples/wch/ch32v/src/blinky.zig
+++ b/examples/wch/ch32v/src/blinky.zig
@@ -29,14 +29,15 @@ pub fn main() !void {
         pins.led.toggle();
         // pins.PB0.toggle();
 
-        busyloop();
+        busy_delay(1000);
     }
 }
 
-inline fn busyloop() void {
-    // const limit = 5_000_000;
-    // const limit = cpu.cpu_frequency / 2;
-    const limit = if (@hasDecl(cpu, "cpu_frequency")) cpu.cpu_frequency / 2 else 5_000_000;
+inline fn busy_delay(comptime ms: u32) void {
+    const cpu_frequency = if (@hasDecl(cpu, "cpu_frequency")) cpu.cpu_frequency else 8_000_000;
+    const cycles_per_ms = cpu_frequency / 1_000;
+    const loop_cycles = 3;
+    const limit = cycles_per_ms * ms / loop_cycles;
 
     var i: u32 = 0;
     while (i < limit) : (i += 1) {

--- a/examples/wch/ch32v/src/blinky_ch32v003.zig
+++ b/examples/wch/ch32v/src/blinky_ch32v003.zig
@@ -27,15 +27,15 @@ pub fn main() !void {
         pins.led.toggle();
         pins.PC1.toggle();
 
-        busyloop();
+        busy_delay(1000);
     }
 }
 
-inline fn busyloop() void {
-    // const limit = 5_000_000;
-    // const limit = cpu.cpu_frequency / 2;
-    // CPU frequency is 24MHz
-    const limit = if (@hasDecl(cpu, "cpu_frequency")) cpu.cpu_frequency / 12 else 5_000_000;
+inline fn busy_delay(comptime ms: u32) void {
+    const cpu_frequency = if (@hasDecl(cpu, "cpu_frequency")) cpu.cpu_frequency else 8_000_000;
+    const cycles_per_ms = cpu_frequency / 1_000;
+    const loop_cycles = 4;
+    const limit = cycles_per_ms * ms / loop_cycles;
 
     var i: u32 = 0;
     while (i < limit) : (i += 1) {

--- a/examples/wch/ch32v/src/board_blinky.zig
+++ b/examples/wch/ch32v/src/board_blinky.zig
@@ -23,14 +23,15 @@ pub fn main() !void {
         // }
         pins.led.toggle();
 
-        busyloop();
+        busy_delay(1000);
     }
 }
 
-// cpu_frequency
-
-inline fn busyloop() void {
-    const limit = board.cpu_frequency / 4;
+inline fn busy_delay(comptime ms: u32) void {
+    const cpu_frequency = board.cpu_frequency;
+    const cycles_per_ms = cpu_frequency / 1_000;
+    const loop_cycles = 3;
+    const limit = cycles_per_ms * ms / loop_cycles;
 
     var i: u32 = 0;
     while (i < limit) : (i += 1) {


### PR DESCRIPTION
 for improved timing accuracy