### PR TITLE
WCH CH32V: add system clock init

### DIFF
--- a/port/wch/ch32v/src/cpus/qingkev2-rv32ec.zig
+++ b/port/wch/ch32v/src/cpus/qingkev2-rv32ec.zig
@@ -48,6 +48,15 @@ pub const startup_logic = struct {
         asm volatile ("csrsi mtvec, 0b11"); // mtvec: absolute address + vector table mode
         microzig.cpu.interrupt.enable_interrupts();
 
+        // init system clock
+        const RCC = microzig.chip.peripherals.RCC;
+        RCC.CTLR.modify(.{ .HSION = 1 });
+        RCC.CFGR0.raw &= 0xF8FF0000;
+        RCC.CTLR.modify(.{ .HSEON = 0, .CSSON = 0 });
+        RCC.CTLR.modify(.{ .HSEBYP = 0 });
+        RCC.CFGR0.raw &= 0xFFFEFFFF;
+        RCC.INTR.raw = 0x009F0000;
+
         microzig_main();
     }
 

--- a/port/wch/ch32v/src/cpus/qingkev3-rv32imac.zig
+++ b/port/wch/ch32v/src/cpus/qingkev3-rv32imac.zig
@@ -48,6 +48,15 @@ pub const startup_logic = struct {
         asm volatile ("csrsi mtvec, 0b1"); // mtvec: vector table mode
         microzig.cpu.interrupt.enable_interrupts();
 
+        // init system clock
+        const RCC = microzig.chip.peripherals.RCC;
+        RCC.CTLR.modify(.{ .HSION = 1 });
+        RCC.CFGR0.raw &= 0xF8FF0000;
+        RCC.CTLR.modify(.{ .HSEON = 0, .CSSON = 0 });
+        RCC.CTLR.modify(.{ .HSEBYP = 0 });
+        RCC.CFGR0.raw &= 0xFFFEFFFF;
+        RCC.INTR.raw = 0x00FF0000;
+
         microzig_main();
     }
 

--- a/port/wch/ch32v/src/cpus/qingkev4-rv32imac.zig
+++ b/port/wch/ch32v/src/cpus/qingkev4-rv32imac.zig
@@ -48,6 +48,17 @@ pub const startup_logic = struct {
         asm volatile ("csrsi mtvec, 0b11"); // mtvec: absolute address + vector table mode
         microzig.cpu.interrupt.enable_interrupts();
 
+        // init system clock
+        const RCC = microzig.chip.peripherals.RCC;
+        RCC.CTLR.modify(.{ .HSION = 1 });
+        RCC.CFGR0.raw &= 0xF8FF0000;
+        RCC.CTLR.modify(.{ .HSEON = 0, .CSSON = 0 });
+        RCC.CTLR.modify(.{ .HSEBYP = 0 });
+        RCC.CFGR0.raw &= 0xFF80FFFF;
+        RCC.CTLR.raw &= 0xEBFFFFFF;
+        RCC.INTR.raw = 0x00FF0000;
+        RCC.CFGR2.raw = 0x00000000;
+
         microzig_main();
     }
 


### PR DESCRIPTION
Added clock reset to default values after reset, as done in the original HAL from WCH.

This is necessary because different chip revisions may have different default settings. For example, on my 003 chips, the default HB bus frequency is 8 MHz, while it should be 24 MHz. This code fixes that.

Tested on: CH32V003 and CH32V305