### PR TITLE
WCH CH32V: fix cpu startup

### DIFF
--- a/port/wch/ch32v/src/cpus/qingkev2-rv32ec.zig
+++ b/port/wch/ch32v/src/cpus/qingkev2-rv32ec.zig
@@ -27,7 +27,7 @@ pub inline fn wfe() void {
 pub const startup_logic = struct {
     extern fn microzig_main() noreturn;
 
-    pub fn _start() callconv(.c) noreturn {
+    pub fn _start() callconv(.c) void {
         // set global pointer
         asm volatile (
             \\.option push
@@ -40,13 +40,24 @@ pub const startup_logic = struct {
             :
             : [eos] "r" (@as(u32, microzig.config.end_of_stack)),
         );
-        root.initialize_system_memories();
+
+        // It is not allowed to call the function directly from the interrupt, the MCU does not start after a power-off.
+        @export(&initialize_system_memories, .{ .name = "initialize_system_memories" });
+        asm volatile (
+            \\jal initialize_system_memories
+        );
 
         // Vendor-defined CSRs
         // 3.2 Interrupt-related CSR Registers
         asm volatile ("csrsi 0x804, 0b111"); // INTSYSCR: enable EABI + Interrupt nesting + HPE
         asm volatile ("csrsi mtvec, 0b11"); // mtvec: absolute address + vector table mode
-        microzig.cpu.interrupt.enable_interrupts();
+
+        // Enable interrupts.
+        // Set MPIE and MIE.
+        asm volatile (
+            \\li t0, 0x88
+            \\csrw mstatus, t0
+        );
 
         // init system clock
         const RCC = microzig.chip.peripherals.RCC;
@@ -57,11 +68,23 @@ pub const startup_logic = struct {
         RCC.CFGR0.raw &= 0xFFFEFFFF;
         RCC.INTR.raw = 0x009F0000;
 
-        microzig_main();
+        // Load the address of the `microzig_main` function into the `mepc` register
+        // and transfer control to it using the `mret` instruction.
+        // This is necessary to ensure proper MCU startup after a power-off.
+        // Directly calling the function from an interrupt would prevent the MCU from starting correctly.
+        asm volatile (
+            \\la t0, microzig_main
+            \\csrw mepc, t0
+            \\mret
+        );
     }
 
     export fn _reset_vector() linksection("microzig_flash_start") callconv(.naked) void {
         asm volatile ("j _start");
+    }
+
+    fn initialize_system_memories() callconv(.c) void {
+        root.initialize_system_memories();
     }
 };
 

--- a/port/wch/ch32v/src/cpus/qingkev3-rv32imac.zig
+++ b/port/wch/ch32v/src/cpus/qingkev3-rv32imac.zig
@@ -27,7 +27,7 @@ pub inline fn wfe() void {
 pub const startup_logic = struct {
     extern fn microzig_main() noreturn;
 
-    pub fn _start() callconv(.c) noreturn {
+    pub fn _start() callconv(.c) void {
         // set global pointer
         asm volatile (
             \\.option push
@@ -40,13 +40,24 @@ pub const startup_logic = struct {
             :
             : [eos] "r" (@as(u32, microzig.config.end_of_stack)),
         );
-        root.initialize_system_memories();
+
+        // It is not allowed to call the function directly from the interrupt, the MCU does not start after a power-off.
+        @export(&initialize_system_memories, .{ .name = "initialize_system_memories" });
+        asm volatile (
+            \\jal initialize_system_memories
+        );
 
         // // Vendor-defined CSRs
         // // 3.2 Interrupt-related CSR Registers
         // asm volatile ("csrsi 0x804, 0b111"); // INTSYSCR: enable EABI + Interrupt nesting + HPE
         asm volatile ("csrsi mtvec, 0b1"); // mtvec: vector table mode
-        microzig.cpu.interrupt.enable_interrupts();
+
+        // Enable interrupts.
+        // Set MPIE and MIE.
+        asm volatile (
+            \\li t0, 0x88
+            \\csrw mstatus, t0
+        );
 
         // init system clock
         const RCC = microzig.chip.peripherals.RCC;
@@ -57,7 +68,15 @@ pub const startup_logic = struct {
         RCC.CFGR0.raw &= 0xFFFEFFFF;
         RCC.INTR.raw = 0x00FF0000;
 
-        microzig_main();
+        // Load the address of the `microzig_main` function into the `mepc` register
+        // and transfer control to it using the `mret` instruction.
+        // This is necessary to ensure proper MCU startup after a power-off.
+        // Directly calling the function from an interrupt would prevent the MCU from starting correctly.
+        asm volatile (
+            \\la t0, microzig_main
+            \\csrw mepc, t0
+            \\mret
+        );
     }
 
     export fn _reset_vector() linksection("microzig_flash_start") callconv(.naked) void {
@@ -68,6 +87,10 @@ pub const startup_logic = struct {
             \\nop
             \\j _start
         );
+    }
+
+    fn initialize_system_memories() callconv(.c) void {
+        root.initialize_system_memories();
     }
 };
 

--- a/port/wch/ch32v/src/cpus/qingkev4-rv32imac.zig
+++ b/port/wch/ch32v/src/cpus/qingkev4-rv32imac.zig
@@ -27,7 +27,7 @@ pub inline fn wfe() void {
 pub const startup_logic = struct {
     extern fn microzig_main() noreturn;
 
-    pub fn _start() callconv(.c) noreturn {
+    pub fn _start() callconv(.c) void {
         // set global pointer
         asm volatile (
             \\.option push
@@ -40,13 +40,30 @@ pub const startup_logic = struct {
             :
             : [eos] "r" (@as(u32, microzig.config.end_of_stack)),
         );
-        root.initialize_system_memories();
+
+        // It is not allowed to call the function directly from the interrupt, the MCU does not start after a power-off.
+        @export(&initialize_system_memories, .{ .name = "initialize_system_memories" });
+        asm volatile (
+            \\jal initialize_system_memories
+        );
 
         // Vendor-defined CSRs
         // 3.2 Interrupt-related CSR Registers
         asm volatile ("csrsi 0x804, 0b0111"); // INTSYSCR: enable Interrupt nesting + HPE and the configured interrupt nesting depth is 2.
         asm volatile ("csrsi mtvec, 0b11"); // mtvec: absolute address + vector table mode
-        microzig.cpu.interrupt.enable_interrupts();
+
+        // Enable floating point and interrupt.
+        // Set MPIE, MIE and floating point status to Dirty.
+        asm volatile (
+            \\li t0, 0x6088
+            \\csrw mstatus, t0
+        );
+
+        // Microprocessor Configuration Registers (corecfgr)
+        asm volatile (
+            \\li t0, 0x1f
+            \\csrw 0xbc0, t0
+        );
 
         // init system clock
         const RCC = microzig.chip.peripherals.RCC;
@@ -59,11 +76,23 @@ pub const startup_logic = struct {
         RCC.INTR.raw = 0x00FF0000;
         RCC.CFGR2.raw = 0x00000000;
 
-        microzig_main();
+        // Load the address of the `microzig_main` function into the `mepc` register
+        // and transfer control to it using the `mret` instruction.
+        // This is necessary to ensure proper MCU startup after a power-off.
+        // Directly calling the function from an interrupt would prevent the MCU from starting correctly.
+        asm volatile (
+            \\la t0, microzig_main
+            \\csrw mepc, t0
+            \\mret
+        );
     }
 
     export fn _reset_vector() linksection("microzig_flash_start") callconv(.naked) void {
         asm volatile ("j _start");
+    }
+
+    fn initialize_system_memories() callconv(.c) void {
+        root.initialize_system_memories();
     }
 };
 


### PR DESCRIPTION
~Depends on: https://github.com/ZigEmbeddedGroup/microzig/pull/520
Please review only this commit: https://github.com/ZigEmbeddedGroup/microzig/pull/522/commits/2281a878cbf53fc56c45bfe414eccc0bf462e5d4~

Because `_start` is called during an interrupt, calling external functions causes the microcontroller to hang.
This is not noticeable during debugging, since everything works after flashing, but if the microcontroller is powered off, it won't start on the next power-up, not even after pressing the reset button.
This doesn't affect the `ch32v003`, as it has no reset interrupt, but I decided to make everything consistent.

Tested on: CH32V003 and CH32V305
