### PR TITLE
Aviron: Fix ELF loading

### DIFF
--- a/sim/aviron/src/main.zig
+++ b/sim/aviron/src/main.zig
@@ -88,12 +88,12 @@ pub fn main() !u8 {
                     if (phdr.p_type != std.elf.PT_LOAD)
                         continue; // Header isn't lodead
 
-                    const dest_mem = if (phdr.p_vaddr >= 0x0080_0000)
+                    const dest_mem = if (phdr.p_paddr >= 0x0080_0000)
                         &sram.data
                     else
                         &flash_storage.data;
 
-                    const addr_masked: u24 = @intCast(phdr.p_vaddr & 0x007F_FFFF);
+                    const addr_masked: u24 = @intCast(phdr.p_paddr & 0x007F_FFFF);
 
                     try source.seekTo(phdr.p_offset);
                     try source.reader().readNoEof(dest_mem[addr_masked..][0..phdr.p_filesz]);

--- a/sim/aviron/src/main.zig
+++ b/sim/aviron/src/main.zig
@@ -85,20 +85,19 @@ pub fn main() !u8 {
 
                 var pheaders = header.program_header_iterator(&source);
                 while (try pheaders.next()) |phdr| {
-                    // Only consider segments that are type LOAD
                     if (phdr.p_type != std.elf.PT_LOAD)
-                        continue;
+                        continue; // Header isn't lodead
 
-                    // Skip segments that ONLY exist in SRAM (e.g. .bss)
-                    if (phdr.p_paddr >= 0x0080_0000)
-                        continue;
+                    const dest_mem = if (phdr.p_vaddr >= 0x0080_0000)
+                        &sram.data
+                    else
+                        &flash_storage.data;
 
-                    const dest_mem = &flash_storage.data;
-                    const addr: u24 = @truncate(phdr.p_paddr);
+                    const addr_masked: u24 = @intCast(phdr.p_vaddr & 0x007F_FFFF);
 
                     try source.seekTo(phdr.p_offset);
-                    try source.reader().readNoEof(dest_mem[addr..][0..phdr.p_filesz]);
-                    @memset(dest_mem[addr + phdr.p_filesz ..][0 .. phdr.p_memsz - phdr.p_filesz], 0xFF);
+                    try source.reader().readNoEof(dest_mem[addr_masked..][0..phdr.p_filesz]);
+                    @memset(dest_mem[addr_masked + phdr.p_filesz ..][0 .. phdr.p_memsz - phdr.p_filesz], 0);
                 }
             },
             .binary, .bin => {


### PR DESCRIPTION
This should fix #524.

Use the physical address from the header, rather than the virtual. This makes it so that `.data` (which has a 'physical' on flash and a 'virtual' in sram) is copied to flash and counts on the copying stub to copy it into memory.

This will break any elf (or test elf) that counts on aviron doing the lifting here.