### PR TITLE
Rp2350 support improvement

### DIFF
--- a/port/raspberrypi/rp2xxx/build.zig
+++ b/port/raspberrypi/rp2xxx/build.zig
@@ -10,6 +10,9 @@ chips: struct {
 },
 
 boards: struct {
+    adafruit: struct {
+        metro_rp2350: *const microzig.Target,
+    },
     raspberrypi: struct {
         pico: *const microzig.Target,
         pico2_arm: *const microzig.Target,
@@ -142,6 +145,15 @@ pub fn init(dep: *std.Build.Dependency) Self {
             .rp2350_riscv = chip_rp2350_riscv.derive(.{}),
         },
         .boards = .{
+            .adafruit = .{
+                .metro_rp2350 = chip_rp2350_arm.derive(.{
+                    .board = .{
+                        .name = "Adafruit Metro RP2350",
+                        .url = "https://www.adafruit.com/product/5542",
+                        .root_source_file = b.path("src/boards/adafruit_metro_rp2350.zig"),
+                    },
+                }),
+            },
             .raspberrypi = .{
                 .pico = chip_rp2040.derive(.{
                     .board = .{

--- a/port/raspberrypi/rp2xxx/build.zig
+++ b/port/raspberrypi/rp2xxx/build.zig
@@ -149,7 +149,7 @@ pub fn init(dep: *std.Build.Dependency) Self {
                 .metro_rp2350 = chip_rp2350_arm.derive(.{
                     .board = .{
                         .name = "Adafruit Metro RP2350",
-                        .url = "https://www.adafruit.com/product/5542",
+                        .url = "https://www.adafruit.com/product/6267",
                         .root_source_file = b.path("src/boards/adafruit_metro_rp2350.zig"),
                     },
                 }),

--- a/port/raspberrypi/rp2xxx/src/boards/adafruit_metro_rp2350.zig
+++ b/port/raspberrypi/rp2xxx/src/boards/adafruit_metro_rp2350.zig
@@ -1,6 +1,6 @@
 pub const xosc_freq = 12_000_000;
 
-pub const has_qfn_80 = true;  // Uses QFN-80 chip with extra I/O pins
+pub const has_rp2350b = true; // Uses RP2350B chip with extra I/O pins
 
 // ### TODO ### Add automatic default pin configuration for board pins
 
@@ -11,34 +11,42 @@ const pins = hal.pins;
 pub const pin_config = pins.GlobalConfiguration{
     .GPIO12 = .{
         .name = "hstx_d2p",
+        .function = .HSTX,
     },
 
     .GPIO13 = .{
         .name = "hstx_d2n",
+        .function = .HSTX,
     },
 
     .GPIO14 = .{
         .name = "hstx_ckp",
+        .function = .HSTX,
     },
 
     .GPIO15 = .{
         .name = "hstx_ckn",
+        .function = .HSTX,
     },
 
     .GPIO16 = .{
         .name = "hstx_d1p",
+        .function = .HSTX,
     },
 
     .GPIO17 = .{
         .name = "hstx_d1n",
+        .function = .HSTX,
     },
 
     .GPIO18 = .{
         .name = "hstx_d0p",
+        .function = .HSTX,
     },
 
     .GPIO19 = .{
         .name = "hstx_d0n",
+        .function = .HSTX,
     },
 
     .GPIO20 = .{
@@ -71,10 +79,12 @@ pub const pin_config = pins.GlobalConfiguration{
 
     .GPIO26 = .{
         .name = "hstx_d26",
+        .function = .SIO,
     },
 
     .GPIO27 = .{
         .name = "hstx_d27",
+        .function = .SIO,
     },
 
     .GPIO28 = .{
@@ -145,27 +155,33 @@ pub const pin_config = pins.GlobalConfiguration{
     },
 
     .GPIO41 = .{
-        .name = "a0",
+        .name = "A0",
+        .function = .ADC1,
     },
 
     .GPIO42 = .{
-        .name = "a1",
+        .name = "A1",
+        .function = .ADC2,
     },
 
     .GPIO43 = .{
-        .name = "a2",
+        .name = "A2",
+        .function = .ADC3,
     },
 
     .GPIO44 = .{
-        .name = "a3",
+        .name = "A3",
+        .function = .ADC4,
     },
 
     .GPIO45 = .{
-        .name = "a4",
+        .name = "A4",
+        .function = .ADC5,
     },
 
     .GPIO46 = .{
-        .name = "a5",
+        .name = "A5",
+        .function = .ADC6,
     },
 
     .GPIO47 = .{

--- a/port/raspberrypi/rp2xxx/src/boards/adafruit_metro_rp2350.zig
+++ b/port/raspberrypi/rp2xxx/src/boards/adafruit_metro_rp2350.zig
@@ -187,5 +187,6 @@ pub const pin_config = pins.GlobalConfiguration{
     .GPIO47 = .{
         .name = "QMI_CS1",
         .function = .PIO2,
+        .direction = .out,
     },
 };

--- a/port/raspberrypi/rp2xxx/src/boards/adafruit_metro_rp2350.zig
+++ b/port/raspberrypi/rp2xxx/src/boards/adafruit_metro_rp2350.zig
@@ -1,0 +1,175 @@
+pub const xosc_freq = 12_000_000;
+
+pub const has_qfn_80 = true;  // Uses QFN-80 chip with extra I/O pins
+
+// ### TODO ### Add automatic default pin configuration for board pins
+
+const microzig = @import("microzig");
+const hal = microzig.hal;
+const pins = hal.pins;
+
+pub const pin_config = pins.GlobalConfiguration{
+    .GPIO12 = .{
+        .name = "hstx_d2p",
+    },
+
+    .GPIO13 = .{
+        .name = "hstx_d2n",
+    },
+
+    .GPIO14 = .{
+        .name = "hstx_ckp",
+    },
+
+    .GPIO15 = .{
+        .name = "hstx_ckn",
+    },
+
+    .GPIO16 = .{
+        .name = "hstx_d1p",
+    },
+
+    .GPIO17 = .{
+        .name = "hstx_d1n",
+    },
+
+    .GPIO18 = .{
+        .name = "hstx_d0p",
+    },
+
+    .GPIO19 = .{
+        .name = "hstx_d0n",
+    },
+
+    .GPIO20 = .{
+        .name = "sda",
+        .function = .I2C0,
+    },
+
+    .GPIO21 = .{
+        .name = "scl",
+        .function = .I2C0,
+    },
+
+    .GPIO23 = .{
+        .name = "red_led",
+        .function = .SIO,
+        .direction = .out,
+    },
+
+    .GPIO24 = .{
+        .name = "boot_button",
+        .function = .SIO,
+        .direction = .in,
+    },
+
+    .GPIO25 = .{
+        .name = "neo_pixel",
+        .function = .SIO,
+        .direction = .out,
+    },
+
+    .GPIO26 = .{
+        .name = "hstx_d26",
+    },
+
+    .GPIO27 = .{
+        .name = "hstx_d27",
+    },
+
+    .GPIO28 = .{
+        .name = "miso",
+        .function = .SPI0,
+    },
+
+    .GPIO29 = .{
+        .name = "usb_host_power",
+        .function = .SIO,
+        .direction = .out,
+    },
+
+    .GPIO30 = .{
+        .name = "mosi",
+        .function = .SPI0,
+    },
+
+    .GPIO31 = .{
+        .name = "sck",
+        .function = .SPI0,
+    },
+
+    .GPIO32 = .{
+        .name = "usb_host_data_plus",
+    },
+
+    .GPIO33 = .{
+        .name = "usb_host_data_minus",
+    },
+
+    .GPIO34 = .{
+        .name = "sd_sck",
+        .function = .SPI1,
+        .direction = .out,
+    },
+
+    .GPIO35 = .{
+        .name = "sd_miso",
+        .function = .SPI1,
+        .direction = .in,
+    },
+
+    .GPIO36 = .{
+        .name = "sd_mosi",
+        .function = .SPI1,
+        .direction = .out,
+    },
+
+    .GPIO37 = .{
+        .name = "sd_data1",
+        .direction = .out,
+    },
+
+    .GPIO38 = .{
+        .name = "sd_data2",
+        .direction = .out,
+    },
+
+    .GPIO39 = .{
+        .name = "sd_cs",
+        .function = .SPI1,
+        .direction = .out,
+    },
+
+    .GPIO40 = .{
+        .name = "sd_cd",
+    },
+
+    .GPIO41 = .{
+        .name = "a0",
+    },
+
+    .GPIO42 = .{
+        .name = "a1",
+    },
+
+    .GPIO43 = .{
+        .name = "a2",
+    },
+
+    .GPIO44 = .{
+        .name = "a3",
+    },
+
+    .GPIO45 = .{
+        .name = "a4",
+    },
+
+    .GPIO46 = .{
+        .name = "a5",
+    },
+
+    .GPIO47 = .{
+        .name = "QMI_CS1",
+        .function = .PIO2,
+    },
+};

--- a/port/raspberrypi/rp2xxx/src/hal/adc.zig
+++ b/port/raspberrypi/rp2xxx/src/hal/adc.zig
@@ -33,8 +33,11 @@ pub const Config = struct {
     /// each input. So for 4 inputs in round-robin mode you'd see 1/4 sample
     /// rate for a given put vs what is set here.
     sample_frequency: ?u32 = null,
+    /// Configure pins to be used in round-robin mode.
     round_robin: ?InputMask = null,
+    /// Configure the ADC FIFO.
     fifo: ?fifo.Config = null,
+    /// Enable the temperature sensor.
     temp_sensor_enabled: bool = false,
 };
 
@@ -42,7 +45,7 @@ pub const Config = struct {
 /// CS.EN = 1. The global clock configuration is not needed to configure the
 /// sample rate because the ADC hardware block requires a 48MHz clock.
 pub fn apply(config: Config) void {
-   ADC.CS.write(.{
+    ADC.CS.write(.{
         .EN = 0,
         .TS_EN = @intFromBool(config.temp_sensor_enabled),
         .START_ONCE = 0,

--- a/port/raspberrypi/rp2xxx/src/hal/adc.zig
+++ b/port/raspberrypi/rp2xxx/src/hal/adc.zig
@@ -10,6 +10,8 @@ const resets = @import("resets.zig");
 const clocks = @import("clocks.zig");
 const chip = @import("compatibility.zig").chip;
 
+const has_rp2350b = chip == .RP2350 and @hasDecl(microzig.board, "has_rp2350b") and microzig.board.has_rp2350b;
+
 pub const Error = error{
     /// ADC conversion failed, one such reason is that the controller failed to
     /// converge on a result.
@@ -26,7 +28,7 @@ pub fn set_enabled(enabled: bool) void {
     ADC.CS.modify(.{ .EN = @intFromBool(enabled) });
 }
 
-const Config = struct {
+pub const Config = struct {
     /// Note that this frequency is the sample frequency of the controller, not
     /// each input. So for 4 inputs in round-robin mode you'd see 1/4 sample
     /// rate for a given put vs what is set here.
@@ -40,38 +42,18 @@ const Config = struct {
 /// CS.EN = 1. The global clock configuration is not needed to configure the
 /// sample rate because the ADC hardware block requires a 48MHz clock.
 pub fn apply(config: Config) void {
-    switch (chip) {
-        .RP2040 => ADC.CS.write(.{
-            .EN = 0,
-            .TS_EN = @intFromBool(config.temp_sensor_enabled),
-            .START_ONCE = 0,
-            .START_MANY = 0,
-            .READY = 0,
+   ADC.CS.write(.{
+        .EN = 0,
+        .TS_EN = @intFromBool(config.temp_sensor_enabled),
+        .START_ONCE = 0,
+        .START_MANY = 0,
+        .READY = 0,
 
-            .ERR = 0,
-            .ERR_STICKY = 0,
-            .AINSEL = 0,
-            .RROBIN = if (config.round_robin) |rr|
-                @as(u5, @bitCast(rr))
-            else
-                0,
-        }),
-        .RP2350 => ADC.CS.write(.{
-            .EN = 0,
-            .TS_EN = @intFromBool(config.temp_sensor_enabled),
-            .START_ONCE = 0,
-            .START_MANY = 0,
-            .READY = 0,
-
-            .ERR = 0,
-            .ERR_STICKY = 0,
-            .AINSEL = 0,
-            .RROBIN = if (config.round_robin) |rr|
-                @as(u5, @bitCast(rr))
-            else
-                0,
-        }),
-    }
+        .ERR = 0,
+        .ERR_STICKY = 0,
+        .AINSEL = 0,
+        .RROBIN = if (config.round_robin) |rr| @bitCast(rr) else 0,
+    });
 
     if (config.sample_frequency) |sample_frequency| {
         const cycles = (48_000_000 * 256) / @as(u64, sample_frequency);
@@ -92,42 +74,80 @@ pub fn select_input(in: Input) void {
     ADC.CS.modify(.{ .AINSEL = @intFromEnum(in) });
 }
 
-/// Get the currently selected analog input. 0..3 are GPIO 26..29 respectively,
-/// 4 is the temperature sensor.
+/// Get the currently selected analog input.
 pub fn get_selected_input() Input {
     const cs = ADC.SC.read();
     return @as(Input, @enumFromInt(cs.AINSEL));
 }
 
-pub const Input = enum(u3) {
-    /// The temperature sensor must be enabled using
-    /// `set_temp_sensor_enabled()` in order to use it
-    temp_sensor = 5,
-    _,
+/// For RP2040 and RP2350A  , the values are:
+///
+///     0..3 are GPIO 26..29 respectively,
+///     4 is the temperature sensor.
+///
+/// For RP2350B, the values are:
+///
+///     0..7 are GPIO 40..47 respectively,
+///     8 is the temperature sensor.
+///
+pub const Input = if (has_rp2350b)
+    enum(u4) {
+        /// The temperature sensor must be enabled using
+        /// `set_temp_sensor_enabled()` in order to use it
+        ain0 = 0,
+        ain1 = 1,
+        ain2 = 2,
+        ain3 = 3,
+        ain4 = 4,
+        ain5 = 5,
+        ain6 = 6,
+        ain7 = 7,
+        temp_sensor = 8,
+        _,
 
-    /// Get the corresponding GPIO pin for an ADC input. Panics if you give it
-    /// temp_sensor.
-    pub fn get_gpio_pin(in: Input) gpio.Pin {
-        return switch (in) {
-            else => gpio.num(@as(u5, @intFromEnum(in)) + 26),
-            .temp_sensor => @panic("temp_sensor doesn't have a pin"),
-        };
-    }
-
-    /// Prepares an ADC input's corresponding GPIO pin to be used as an analog
-    /// input.
-    pub fn configure_gpio_pin(in: Input) void {
-        switch (in) {
-            else => {
-                const pin = in.get_gpio_pin();
-                pin.set_function(.disabled);
-                pin.set_pull(.disabled);
-                pin.set_input_enabled(false);
-            },
-            .temp_sensor => {},
+        pub fn get_gpio_pin(in: Input) gpio.Pin {
+            return switch (in) {
+                else => gpio.num(@as(u9, @intFromEnum(in)) + 40),
+                .temp_sensor => @panic("temp_sensor doesn't have a pin"),
+            };
         }
+
+        pub const configure_gpio_pin = configure_gpio_pin_num;
     }
-};
+else
+    enum(u3) {
+        /// The temperature sensor must be enabled using
+        /// `set_temp_sensor_enabled()` in order to use it
+        ain0 = 0,
+        ain1 = 1,
+        ain2 = 2,
+        ain3 = 3,
+        temp_sensor = 4,
+        _,
+
+        pub fn get_gpio_pin(in: Input) gpio.Pin {
+            return switch (in) {
+                else => gpio.num(@as(u5, @intFromEnum(in)) + 26),
+                .temp_sensor => @panic("temp_sensor doesn't have a pin"),
+            };
+        }
+
+        pub const configure_gpio_pin = configure_gpio_pin_num;
+    };
+
+/// Prepares an ADC input's corresponding GPIO pin to be used as an analog
+/// input.
+pub fn configure_gpio_pin_num(in: Input) void {
+    switch (in) {
+        else => {
+            const pin = in.get_gpio_pin();
+            pin.set_function(.disabled);
+            pin.set_pull(.disabled);
+            pin.set_input_enabled(false);
+        },
+        .temp_sensor => {},
+    }
+}
 
 /// Set to true to power on the temperature sensor.
 pub fn set_temp_sensor_enabled(enable: bool) void {
@@ -143,19 +163,41 @@ pub fn temp_sensor_result_to_celcius(comptime T: type, comptime vref: T, result:
 }
 
 /// For selecting which inputs are to be used in round-robin mode
-pub const InputMask = packed struct(u5) {
-    ain0: bool = false,
-    ain1: bool = false,
-    ain2: bool = false,
-    ain3: bool = false,
-    temp_sensor: bool = false,
-};
+pub const InputMask = if (chip == .RP2040)
+    packed struct(u5) {
+        ain0: bool = false,
+        ain1: bool = false,
+        ain2: bool = false,
+        ain3: bool = false,
+        temp_sensor: bool = false,
+    }
+else if (has_rp2350b)
+    packed struct(u9) {
+        ain0: bool = false,
+        ain1: bool = false,
+        ain2: bool = false,
+        ain3: bool = false,
+        ain4: bool = false,
+        ain5: bool = false,
+        ain6: bool = false,
+        ain7: bool = false,
+        temp_sensor: bool = false,
+    }
+else
+    packed struct(u9) {
+        ain0: bool = false,
+        ain1: bool = false,
+        ain2: bool = false,
+        ain3: bool = false,
+        temp_sensor: bool = false,
+        padding: u4 = 0,
+    };
 
 /// Sets which of the inputs are to be run in round-robin mode. Setting all to
 /// 0 will disable round-robin mode but `disableRoundRobin()` is provided so
 /// the user may be explicit.
 pub fn round_robin_set(enabled_inputs: InputMask) void {
-    ADC.CS.modify(.{ .RROBIN = @as(u5, @bitCast(enabled_inputs)) });
+    ADC.CS.modify(.{ .RROBIN = @bitCast(enabled_inputs) });
 }
 
 /// Disable round-robin sample mode.

--- a/port/raspberrypi/rp2xxx/src/hal/adc.zig
+++ b/port/raspberrypi/rp2xxx/src/hal/adc.zig
@@ -8,9 +8,10 @@ const ADC = microzig.chip.peripherals.ADC;
 const gpio = @import("gpio.zig");
 const resets = @import("resets.zig");
 const clocks = @import("clocks.zig");
-const chip = @import("compatibility.zig").chip;
+const compatibility = @import("compatibility.zig");
 
-const has_rp2350b = chip == .RP2350 and @hasDecl(microzig.board, "has_rp2350b") and microzig.board.has_rp2350b;
+const chip = compatibility.chip;
+const has_rp2350b = compatibility.has_rp2350b;
 
 pub const Error = error{
     /// ADC conversion failed, one such reason is that the controller failed to
@@ -83,7 +84,7 @@ pub fn get_selected_input() Input {
     return @as(Input, @enumFromInt(cs.AINSEL));
 }
 
-/// For RP2040 and RP2350A  , the values are:
+/// For RP2040 and RP2350A, the values are:
 ///
 ///     0..3 are GPIO 26..29 respectively,
 ///     4 is the temperature sensor.

--- a/port/raspberrypi/rp2xxx/src/hal/compatibility.zig
+++ b/port/raspberrypi/rp2xxx/src/hal/compatibility.zig
@@ -29,3 +29,5 @@ pub const arch: Arch = switch (chip) {
     else
         @compileError(std.fmt.comptimePrint("Unsupported cpu for RP2350: \"{s}\"", .{microzig.config.cpu_name})),
 };
+
+pub const has_rp2350b = chip == .RP2350 and @hasDecl(microzig.board, "has_rp2350b") and microzig.board.has_rp2350b;

--- a/port/raspberrypi/rp2xxx/src/hal/gpio.zig
+++ b/port/raspberrypi/rp2xxx/src/hal/gpio.zig
@@ -94,7 +94,7 @@ pub const Pull = enum {
     disabled,
 };
 
-pub fn num(n: u6) Pin {
+pub fn num(n: u9) Pin {
     switch (chip) {
         .RP2040 => {
             if (n > 29)

--- a/port/raspberrypi/rp2xxx/src/hal/gpio.zig
+++ b/port/raspberrypi/rp2xxx/src/hal/gpio.zig
@@ -38,7 +38,7 @@ pub const Function =
             pio0,
             pio1,
             pio2,
-            gpck,
+            gpck, // Also QMI_CS1 and Trace
             usb,
             uart_alt,
             disabled = 0x1f,
@@ -76,6 +76,11 @@ pub const DriveStrength = enum(u2) {
     @"4mA",
     @"8mA",
     @"12mA",
+};
+
+pub const SchmittTrigger = enum(u1) {
+    enabled,
+    disabled,
 };
 
 pub const Enabled = enum {

--- a/port/raspberrypi/rp2xxx/src/hal/pins.zig
+++ b/port/raspberrypi/rp2xxx/src/hal/pins.zig
@@ -11,6 +11,18 @@ const pwm = @import("pwm.zig");
 const adc = @import("adc.zig");
 const resets = @import("resets.zig");
 
+const compatibility = @import("compatibility.zig");
+const chip = compatibility.chip;
+
+const has_qfn_80 = chip == .RP2350 and @hasDecl(microzig.board, "has_qfn_80") and microzig.board.has_qfn_80;
+
+
+pub const Direction = enum(u2) {
+    in,
+    out,
+    unknown,
+};
+
 pub const Pin = enum {
     GPIO0,
     GPIO1,
@@ -42,37 +54,35 @@ pub const Pin = enum {
     GPIO27,
     GPIO28,
     GPIO29,
-    GPIO30,
-    GPIO31,
-    GPIO32,
-    GPIO33,
-    GPIO34,
-    GPIO35,
-    GPIO36,
-    GPIO37,
-    GPIO38,
-    GPIO39,
-    GPIO40,
-    GPIO41,
-    GPIO42,
-    GPIO43,
-    GPIO44,
-    GPIO45,
-    GPIO46,
-    GPIO47,
+    GPIO30,  // RP2340 qfn_80 only
+    GPIO31,  // RP2340 qfn_80 only
+    GPIO32,  // RP2340 qfn_80 only
+    GPIO33,  // RP2340 qfn_80 only
+    GPIO34,  // RP2340 qfn_80 only
+    GPIO35,  // RP2340 qfn_80 only
+    GPIO36,  // RP2340 qfn_80 only
+    GPIO37,  // RP2340 qfn_80 only
+    GPIO38,  // RP2340 qfn_80 only
+    GPIO39,  // RP2340 qfn_80 only
+    GPIO40,  // RP2340 qfn_80 only
+    GPIO41,  // RP2340 qfn_80 only
+    GPIO42,  // RP2340 qfn_80 only
+    GPIO43,  // RP2340 qfn_80 only
+    GPIO44,  // RP2340 qfn_80 only
+    GPIO45,  // RP2340 qfn_80 only
+    GPIO46,  // RP2340 qfn_80 only
+    GPIO47,  // RP2340 qfn_80 only
 
     pub const Configuration = struct {
         name: ?[:0]const u8 = null,
         function: Function = .SIO,
-        direction: ?gpio.Direction = null,
+        direction: ?Direction = null,
         drive_strength: ?gpio.DriveStrength = null,
         pull: ?gpio.Pull = null,
         slew_rate: ?gpio.SlewRate = null,
-        // input/output enable
-        // schmitt trigger
-        // hysteresis
+        schmitt_trigger: ?gpio.SchmittTrigger = null,
 
-        pub fn get_direction(comptime config: Configuration) gpio.Direction {
+        pub fn get_direction(comptime config: Configuration) Direction {
             return if (config.direction) |direction|
                 direction
             else if (comptime config.function.is_pwm())
@@ -83,8 +93,18 @@ pub const Pin = enum {
                 .in
             else if (comptime config.function.is_adc())
                 .in
+            else if (comptime config.function.is_clock_in())
+                .in
+            else if (comptime config.function.is_clock_out())
+                .out
+            else if (comptime config.function == .USB_OVCUR_DET)
+                .in
+            else if (comptime config.function == .USB_VBUS_DET)
+                .in
+            else if (comptime config.function == .USB_VBUS_EN)
+                .out
             else
-                @panic("TODO");
+                .unknown; // depends on device configuration
         }
     };
 };
@@ -94,7 +114,7 @@ pub const Function = enum {
 
     PIO0,
     PIO1,
-    PIO2,
+    PIO2, // RP2340 only
 
     SPI0_RX,
     SPI0_CSn,
@@ -110,11 +130,15 @@ pub const Function = enum {
     UART0_RX,
     UART0_CTS,
     UART0_RTS,
+    UART0_ALT_TX,  // RP2340 only
+    UART0_ALT_RX,  // RP2340 only
 
     UART1_TX,
     UART1_RX,
     UART1_CTS,
     UART1_RTS,
+    UART1_ALT_TX,
+    UART1_ALT_RX,
 
     I2C0_SDA,
     I2C0_SCL,
@@ -146,6 +170,18 @@ pub const Function = enum {
     PWM7_A,
     PWM7_B,
 
+    PWM8_A, // RP2340 qfn_80 only
+    PWM8_B, // RP2340 qfn_80 only
+
+    PWM9_A, // RP2340 qfn_80 only
+    PWM9_B, // RP2340 qfn_80 only
+
+    PWM10_A, // RP2340 qfn_80 only
+    PWM10_B, // RP2340 qfn_80 only
+
+    PWM11_A, // RP2340 qfn_80 only
+    PWM11_B, // RP2340 qfn_80 only
+
     CLOCK_GPIN0,
     CLOCK_GPIN1,
 
@@ -162,34 +198,12 @@ pub const Function = enum {
     ADC1,
     ADC2,
     ADC3,
-    ADC4,
-    ADC5,
-    ADC6,
-    ADC7,
-    TEMP,
+    ADC4, // RP2340 qfn_80 only
+    ADC5, // RP2340 qfn_80 only
+    ADC6, // RP2340 qfn_80 only
+    ADC7, // RP2340 qfn_80 only
 
-    pub fn is_pwm(function: Function) bool {
-        return switch (function) {
-            .PWM0_A,
-            .PWM0_B,
-            .PWM1_A,
-            .PWM1_B,
-            .PWM2_A,
-            .PWM2_B,
-            .PWM3_A,
-            .PWM3_B,
-            .PWM4_A,
-            .PWM4_B,
-            .PWM5_A,
-            .PWM5_B,
-            .PWM6_A,
-            .PWM6_B,
-            .PWM7_A,
-            .PWM7_B,
-            => true,
-            else => false,
-        };
-    }
+    QMI_CS1, // RP2340 only
 
     pub fn is_uart_tx(function: Function) bool {
         return switch (function) {
@@ -204,6 +218,34 @@ pub const Function = enum {
         return switch (function) {
             .UART0_RX,
             .UART1_RX,
+            => true,
+            else => false,
+        };
+    }
+
+    pub fn is_uart_alt_tx(function: Function) bool {
+        return switch (function) {
+            .UART0_ALT_TX,
+            .UART1_ALT_TX,
+            => true,
+            else => false,
+        };
+    }
+
+    pub fn is_uart_alt_rx(function: Function) bool {
+        return switch (function) {
+            .UART0_ALT_RX,
+            .UART1_ALT_RX,
+            => true,
+            else => false,
+        };
+    }
+
+    pub fn is_pio(function: Function) bool {
+        return switch (function) {
+            .PIO0,
+            .PIO1,
+            .PIO2,
             => true,
             else => false,
         };
@@ -224,12 +266,142 @@ pub const Function = enum {
         };
     }
 
+    pub fn is_spi_rx(function: Function) bool {
+        return switch (function) {
+            .SPI0_RX,
+            .SPI1_RX,
+            => true,
+            else => false,
+        };
+    }
+
+    pub fn is_spi_tx(function: Function) bool {
+        return switch (function) {
+            .SPI0_TX,
+            .SPI1_TX,
+            => true,
+            else => false,
+        };
+    }
+
+    pub fn is_spi_sck(function: Function) bool {
+        return switch (function) {
+            .SPI0_SCK,
+            .SPI1_SCK,
+            => true,
+            else => false,
+        };
+    }
+
+    pub fn is_spi_cs(function: Function) bool {
+        return switch (function) {
+            .SPI0_CSn,
+            .SPI1_CSn,
+            => true,
+            else => false,
+        };
+    }
+
     pub fn is_i2c(function: Function) bool {
         return switch (function) {
             .I2C0_SDA,
             .I2C0_SCL,
             .I2C1_SDA,
             .I2C1_SCL,
+            => true,
+            else => false,
+        };
+    }
+
+    pub fn is_i2c_sda(function: Function) bool {
+        return switch (function) {
+            .I2C0_SDA,
+            .I2C1_SDA,
+            => true,
+            else => false,
+        };
+    }
+
+    pub fn is_i2c_scl(function: Function) bool {
+        return switch (function) {
+            .I2C0_SCL,
+            .I2C1_SCL,
+            => true,
+            else => false,
+        };
+    }
+
+    pub fn is_adc(function: Function) bool {
+        return switch (function) {
+            .ADC0,
+            .ADC1,
+            .ADC2,
+            .ADC3,
+            .ADC4,
+            .ADC5,
+            .ADC6,
+            .ADC7,
+            => true,
+            else => false,
+        };
+    }
+
+    pub fn is_clock_in(function: Function) bool {
+        return switch (function) {
+            .CLOCK_GPIN0,
+            .CLOCK_GPIN1,
+            => true,
+            else => false,
+        };
+    }
+
+    pub fn is_clock_out(function: Function) bool {
+        return switch (function) {
+            .CLOCK_GPOUT0,
+            .CLOCK_GPOUT1,
+            .CLOCK_GPOUT2,
+            .CLOCK_GPOUT3,
+            => true,
+            else => false,
+        };
+    }
+
+    pub fn is_usb(function: Function) bool {
+        return switch (function) {
+            .USB_OVCUR_DET,
+            .USB_VBUS_DET,
+            .USB_VBUS_EN,
+            => true,
+            else => false,
+        };
+    }
+
+    pub fn is_pwm(function: Function) bool {
+        return switch (function) {
+            .PWM0_A,
+            .PWM0_B,
+            .PWM1_A,
+            .PWM1_B,
+            .PWM2_A,
+            .PWM2_B,
+            .PWM3_A,
+            .PWM3_B,
+            .PWM4_A,
+            .PWM4_B,
+            .PWM5_A,
+            .PWM5_B,
+            .PWM6_A,
+            .PWM6_B,
+            .PWM7_A,
+            .PWM7_B,
+            .PWM8_A,
+            .PWM8_B,
+            .PWM9_A,
+            .PWM9_B,
+            .PWM10_A,
+            .PWM10_B,
+            .PWM11_A,
+            .PWM11_B,
             => true,
             else => false,
         };
@@ -245,23 +417,11 @@ pub const Function = enum {
             .PWM5_A, .PWM5_B => 5,
             .PWM6_A, .PWM6_B => 6,
             .PWM7_A, .PWM7_B => 7,
+            .PWM8_A, .PWM8_B => 8,
+            .PWM9_A, .PWM9_B => 9,
+            .PWM10_A, .PWM10_B => 10,
+            .PWM11_A, .PWM11_B => 11,
             else => @compileError("not pwm"),
-        };
-    }
-
-    pub fn is_adc(function: Function) bool {
-        return switch (function) {
-            .ADC0,
-            .ADC1,
-            .ADC2,
-            .ADC3,
-            .ADC4,
-            .ADC5,
-            .ADC6,
-            .ADC7,
-            .TEMP,
-            => true,
-            else => false,
         };
     }
 
@@ -275,6 +435,10 @@ pub const Function = enum {
             .PWM5_A,
             .PWM6_A,
             .PWM7_A,
+            .PWM8_A,
+            .PWM9_A,
+            .PWM10_A,
+            .PWM11_A,
             => .a,
             .PWM0_B,
             .PWM1_B,
@@ -290,88 +454,253 @@ pub const Function = enum {
     }
 };
 
-fn all() [30]u1 {
-    var ret: [30]u1 = undefined;
-    for (&ret) |*elem|
-        elem.* = 1;
+fn all() [48]u1 {
+    var ret: [48]u1 = @splat(1);
+
+    if (!has_qfn_80) {
+        for (30..48) |i|
+            ret[i] = 0;
+    }
 
     return ret;
 }
 
-fn list(gpio_list: []const u5) [30]u1 {
-    var ret = std.mem.zeroes([30]u1);
+fn list(gpio_list: []const u6) [48]u1 {
+    var ret = std.mem.zeroes([48]u1);
     for (gpio_list) |num|
         ret[num] = 1;
-
     return ret;
 }
 
-fn single(gpio_num: u5) [30]u1 {
-    var ret = std.mem.zeroes([30]u1);
+fn single(gpio_num: u6) [48]u1 {
+    var ret = std.mem.zeroes([48]u1);
     ret[gpio_num] = 1;
     return ret;
 }
 
-const function_table = [@typeInfo(Function).@"enum".fields.len][30]u1{
-    all(), // SIO
-    all(), // PIO0
-    all(), // PIO1
-    all(), // PIO2
-    list(&.{ 0, 4, 16, 20, 32, 36 }), // SPI0_RX
-    list(&.{ 1, 5, 17, 21, 33, 37 }), // SPI0_CSn
-    list(&.{ 2, 6, 18, 22, 34, 38 }), // SPI0_SCK
-    list(&.{ 3, 7, 19, 23, 35, 39 }), // SPI0_TX
-    list(&.{ 8, 12, 24, 28, 40, 44 }), // SPI1_RX
-    list(&.{ 9, 13, 25, 29, 37, 41 }), // SPI1_CSn
-    list(&.{ 10, 14, 26, 30, 42 }), // SPI1_SCK
-    list(&.{ 11, 15, 27, 31, 43 }), // SPI1_TX
-    list(&.{ 0, 12, 16, 28, 32, 44 }), // UART0_TX
-    list(&.{ 1, 13, 17, 29, 33, 45 }), // UART0_RX
-    list(&.{ 2, 14, 18, 30, 34, 46 }), // UART0_CTS
-    list(&.{ 3, 15, 19, 31, 35, 47 }), // UART0_RTS
-    list(&.{ 4, 8, 20, 24, 36, 40 }), // UART1_TX
-    list(&.{ 5, 9, 21, 25, 37, 41 }), // UART1_RX
-    list(&.{ 6, 10, 22, 26, 38, 42 }), // UART1_CTS
-    list(&.{ 7, 11, 23, 27, 39, 43 }), // UART1_RTS
-    list(&.{ 0, 4, 8, 12, 16, 20, 24, 28, 32, 36, 40, 44 }), // I2C0_SDA
-    list(&.{ 1, 5, 9, 13, 17, 21, 25, 29, 33, 37, 41, 45 }), // I2C0_SCL
-    list(&.{ 2, 6, 10, 14, 18, 22, 26, 30, 34, 38, 42, 46 }), // I2C1_SDA
-    list(&.{ 3, 7, 11, 15, 19, 23, 27, 31, 35, 39, 43, 47 }), // I2C1_SCL
-    list(&.{ 0, 16 }), // PWM0_A
-    list(&.{ 1, 17 }), // PWM0_B
-    list(&.{ 2, 18 }), // PWM1_A
-    list(&.{ 3, 19 }), // PWM1_B
-    list(&.{ 4, 20 }), // PWM2_A
-    list(&.{ 5, 21 }), // PWM2_B
-    list(&.{ 6, 22 }), // PWM3_A
-    list(&.{ 7, 23 }), // PWM3_B
-    list(&.{ 8, 24 }), // PWM4_A
-    list(&.{ 9, 25 }), // PWM4_B
-    list(&.{ 10, 26 }), // PWM5_A
-    list(&.{ 11, 27 }), // PWM5_B
-    list(&.{ 12, 28 }), // PWM6_A
-    list(&.{ 13, 29 }), // PWM6_B
-    single(14), // PWM7_A
-    single(15), // PWM7_B
-    single(20), // CLOCK_GPIN0
-    single(22), // CLOCK_GPIN1
-    single(21), // CLOCK_GPOUT0
-    single(23), // CLOCK_GPOUT1
-    single(24), // CLOCK_GPOUT2
-    single(25), // CLOCK_GPOUT3
-    list(&.{ 0, 3, 6, 9, 12, 15, 18, 21, 24, 27 }), // USB_OVCUR_DET
-    list(&.{ 1, 4, 7, 10, 13, 16, 19, 22, 25, 28 }), // USB_VBUS_DET
-    list(&.{ 2, 5, 8, 11, 14, 17, 20, 23, 26, 29 }), // USB_VBUS_EN
-    single(40), // ADC0
-    single(41), // ADC1
-    single(42), // ADC2
-    single(43), // ADC3
-    single(44), // ADC4
-    single(45), // ADC5
-    single(46), // ADC6
-    single(47), // ADC7
-    single(48), // TEMP
-};
+fn none() [48]u1 {
+    return std.mem.zeroes([48]u1);
+}
+
+const function_table = if (chip == .RP2040)
+    [@typeInfo(Function).@"enum".fields.len][48]u1{
+        all(), // SIO
+        all(), // PIO0
+        all(), // PIO1
+        none(), // PIO2
+        list(&.{ 0, 4, 16, 20 }), // SPI0_RX
+        list(&.{ 1, 5, 17, 21 }), // SPI0_CSn
+        list(&.{ 2, 6, 18, 22 }), // SPI0_SCK
+        list(&.{ 3, 7, 19, 23 }), // SPI0_TX
+        list(&.{ 8, 12, 24, 28 }), // SPI1_RX
+        list(&.{ 9, 13, 25, 29 }), // SPI1_CSn
+        list(&.{ 10, 14, 26, 30 }), // SPI1_SCK
+        list(&.{ 11, 15, 27, 31 }), // SPI1_TX
+        list(&.{ 0, 12, 16, 28 }), // UART0_TX
+        list(&.{ 1, 13, 17 }), // UART0_RX
+        list(&.{ 2, 14, 18 }), // UART0_CTS
+        list(&.{ 3, 15, 19 }), // UART0_RTS
+        none(), // UART0_ALT_TX
+        none(), // UART0_ALT_RX
+        list(&.{ 4, 8, 20, 24 }), // UART1_TX
+        list(&.{ 5, 9, 21, 25 }), // UART1_RX
+        list(&.{ 6, 10, 22, 26 }), // UART1_CTS
+        list(&.{ 7, 11, 23, 27 }), // UART1_RTS
+        none(), // UART1_ALT_TX
+        none(), // UART1_ALT_RX
+        list(&.{ 0, 4, 8, 12, 16, 20, 24, 28 }), // I2C0_SDA
+        list(&.{ 1, 5, 9, 13, 17, 21, 25, 29 }), // I2C0_SCL
+        list(&.{ 2, 6, 10, 14, 18, 22, 26 }), // I2C1_SDA
+        list(&.{ 3, 7, 11, 15, 19, 23, 27 }), // I2C1_SCL
+        list(&.{ 0, 16 }), // PWM0_A
+        list(&.{ 1, 17 }), // PWM0_B
+        list(&.{ 2, 18 }), // PWM1_A
+        list(&.{ 3, 19 }), // PWM1_B
+        list(&.{ 4, 20 }), // PWM2_A
+        list(&.{ 5, 21 }), // PWM2_B
+        list(&.{ 6, 22 }), // PWM3_A
+        list(&.{ 7, 23 }), // PWM3_B
+        list(&.{ 8, 24 }), // PWM4_A
+        list(&.{ 9, 25 }), // PWM4_B
+        list(&.{ 10, 26 }), // PWM5_A
+        list(&.{ 11, 27 }), // PWM5_B
+        list(&.{ 12, 28 }), // PWM6_A
+        list(&.{ 13, 29 }), // PWM6_B
+        single(14), // PWM7_A
+        single(15), // PWM7_B
+        none(), // PWM8_A
+        none(), // PWM8_B
+        none(), // PWM9_A
+        none(), // PWM9_B
+        none(), // PWM10_A
+        none(), // PWM10_B
+        none(), // PWM11_A
+        none(), // PWM11_B
+        single(20), // CLOCK_GPIN0
+        single(22), // CLOCK_GPIN1
+        single(21), // CLOCK_GPOUT0
+        single(23), // CLOCK_GPOUT1
+        single(24), // CLOCK_GPOUT2
+        single(25), // CLOCK_GPOUT3
+        list(&.{ 0, 3, 6, 9, 12, 15, 18, 21, 24, 27 }), // USB_OVCUR_DET
+        list(&.{ 1, 4, 7, 10, 13, 16, 19, 22, 25, 28 }), // USB_VBUS_DET
+        list(&.{ 2, 5, 8, 11, 14, 17, 20, 23, 26, 29 }), // USB_VBUS_EN
+        single(26), // ADC0
+        single(27), // ADC1
+        single(28), // ADC2
+        single(29), // ADC3
+        none(), // ADC4
+        none(), // ADC5
+        none(), // ADC6
+        none(), // ADC7
+        none(), // QMI_CS1
+    }
+else if (has_qfn_80)
+    [@typeInfo(Function).@"enum".fields.len][48]u1{
+        all(), // SIO
+        all(), // PIO0
+        all(), // PIO1
+        all(), // PIO2
+        list(&.{ 0, 4, 16, 20, 32, 36 }), // SPI0_RX
+        list(&.{ 1, 5, 17, 21, 33, 37 }), // SPI0_CSn
+        list(&.{ 2, 6, 18, 22, 34, 38 }), // SPI0_SCK
+        list(&.{ 3, 7, 19, 23, 35, 39 }), // SPI0_TX
+        list(&.{ 8, 12, 24, 28, 40, 44 }), // SPI1_RX
+        list(&.{ 9, 13, 25, 29, 37, 41 }), // SPI1_CSn
+        list(&.{ 10, 14, 26, 30, 42 }), // SPI1_SCK
+        list(&.{ 11, 15, 27, 31, 43 }), // SPI1_TX
+        list(&.{ 0, 12, 16, 28, 32, 44 }), // UART0_TX
+        list(&.{ 1, 13, 17, 29, 33, 45 }), // UART0_RX
+        list(&.{ 2, 14, 18, 30, 34, 46 }), // UART0_CTS
+        list(&.{ 3, 15, 19, 31, 35, 47 }), // UART0_RTS
+        list(&.{ 2, 14, 18, 30, 34, 46 }), // UART0_ALT_TX
+        list(&.{ 3, 15, 19, 31, 35, 47 }), // UART0_ALT_RX
+        list(&.{ 4,  8, 20, 24, 36, 40 }), // UART1_TX
+        list(&.{ 5,  9, 21, 25, 37, 41 }), // UART1_RX
+        list(&.{ 6, 10, 22, 26, 38, 42 }), // UART1_CTS
+        list(&.{ 7, 11, 23, 27, 39, 43 }), // UART1_RTS
+        list(&.{ 6, 10, 22, 26, 38, 42 }), // UART1_ALT_TX
+        list(&.{ 7, 11, 23, 27, 39, 43 }), // UART1_ALT_RX
+        list(&.{ 0, 4, 8, 12, 16, 20, 24, 28, 32, 36, 40, 44 }), // I2C0_SDA
+        list(&.{ 1, 5, 9, 13, 17, 21, 25, 29, 33, 37, 41, 45 }), // I2C0_SCL
+        list(&.{ 2, 6, 10, 14, 18, 22, 26, 30, 34, 38, 42, 46 }), // I2C1_SDA
+        list(&.{ 3, 7, 11, 15, 19, 23, 27, 31, 35, 39, 43, 47 }), // I2C1_SCL
+        list(&.{ 0, 16 }), // PWM0_A
+        list(&.{ 1, 17 }), // PWM0_B
+        list(&.{ 2, 18 }), // PWM1_A
+        list(&.{ 3, 19 }), // PWM1_B
+        list(&.{ 4, 20 }), // PWM2_A
+        list(&.{ 5, 21 }), // PWM2_B
+        list(&.{ 6, 22 }), // PWM3_A
+        list(&.{ 7, 23 }), // PWM3_B
+        list(&.{ 8, 24 }), // PWM4_A
+        list(&.{ 9, 25 }), // PWM4_B
+        list(&.{ 10, 26 }), // PWM5_A
+        list(&.{ 11, 27 }), // PWM5_B
+        list(&.{ 12, 28 }), // PWM6_A
+        list(&.{ 13, 29 }), // PWM6_B
+        list(&.{ 14, 30 }), // PWM7_A
+        list(&.{ 15, 31 }), // PWM7_B
+        list(&.{ 32, 40 }), // PWM8_A
+        list(&.{ 33, 41 }), // PWM8_B
+        list(&.{ 34, 42 }), // PWM9_A
+        list(&.{ 35, 43 }), // PWM9_B
+        list(&.{ 36, 44 }), // PWM10_A
+        list(&.{ 37, 45 }), // PWM10_B
+        list(&.{ 38, 46 }), // PWM11_A
+        list(&.{ 39, 47 }), // PWM11_B
+        single(20), // CLOCK_GPIN0
+        single(22), // CLOCK_GPIN1
+        single(21), // CLOCK_GPOUT0
+        single(23), // CLOCK_GPOUT1
+        single(24), // CLOCK_GPOUT2
+        single(25), // CLOCK_GPOUT3
+        list(&.{ 0, 3, 6, 9, 12, 15, 18, 21, 24, 27, 30, 33, 36, 39, 42, 45 }), // USB_OVCUR_DET
+        list(&.{ 1, 4, 7, 10, 13, 16, 19, 22, 25, 28, 31, 34, 37, 40, 43, 46 }), // USB_VBUS_DET
+        list(&.{ 2, 5, 8, 11, 14, 17, 20, 23, 26, 29, 32, 35, 38, 41, 44, 47 }), // USB_VBUS_EN
+        single(40), // ADC0
+        single(41), // ADC1
+        single(42), // ADC2
+        single(43), // ADC3
+        single(44), // ADC4
+        single(45), // ADC5
+        single(46), // ADC6
+        single(47), // ADC7
+        list(&.{ 0, 8, 19, 47 }), // QMI_CS1
+    }
+else
+    [@typeInfo(Function).@"enum".fields.len][48]u1{
+        all(), // SIO
+        all(), // PIO0
+        all(), // PIO1
+        all(), // PIO2
+        list(&.{ 0, 4, 16, 20 }), // SPI0_RX
+        list(&.{ 1, 5, 17, 21 }), // SPI0_CSn
+        list(&.{ 2, 6, 18, 22 }), // SPI0_SCK
+        list(&.{ 3, 7, 19, 23 }), // SPI0_TX
+        list(&.{ 8, 12, 24, 28 }), // SPI1_RX
+        list(&.{ 9, 13, 25, 29 }), // SPI1_CSn
+        list(&.{ 10, 14, 26 }), // SPI1_SCK
+        list(&.{ 11, 15, 27 }), // SPI1_TX
+        list(&.{ 0, 2, 12, 14, 16, 18, 28 }), // UART0_TX
+        list(&.{ 1, 3, 13, 15, 17, 19, 29 }), // UART0_RX
+        list(&.{ 2, 14, 18 }), // UART0_CTS
+        list(&.{ 3, 15, 19 }), // UART0_RTS
+        list(&.{ 2, 14, 18 }), // UART0_ALT_TX
+        list(&.{ 3, 15, 19 }), // UART0_ALT_RX
+        list(&.{ 4,  8, 20, 24 }), // UART1_TX
+        list(&.{ 5,  9, 21, 25 }), // UART1_RX
+        list(&.{ 6, 10, 22, 26 }), // UART1_CTS
+        list(&.{ 7, 11, 23, 27 }), // UART1_RTS
+        list(&.{ 6, 10, 22, 26 }), // UART1_ALT_TX
+        list(&.{ 7, 11, 23, 27 }), // UART1_ALT_RX
+        list(&.{ 0, 4, 8, 12, 16, 20, 24, 28 }), // I2C0_SDA
+        list(&.{ 1, 5, 9, 13, 17, 21, 25, 29 }), // I2C0_SCL
+        list(&.{ 2, 6, 10, 14, 18, 22, 26 }), // I2C1_SDA
+        list(&.{ 3, 7, 11, 15, 19, 23, 27 }), // I2C1_SCL
+        list(&.{ 0, 16 }), // PWM0_A
+        list(&.{ 1, 17 }), // PWM0_B
+        list(&.{ 2, 18 }), // PWM1_A
+        list(&.{ 3, 19 }), // PWM1_B
+        list(&.{ 4, 20 }), // PWM2_A
+        list(&.{ 5, 21 }), // PWM2_B
+        list(&.{ 6, 22 }), // PWM3_A
+        list(&.{ 7, 23 }), // PWM3_B
+        list(&.{ 8, 24 }), // PWM4_A
+        list(&.{ 9, 25 }), // PWM4_B
+        list(&.{ 10, 26 }), // PWM5_A
+        list(&.{ 11, 27 }), // PWM5_B
+        list(&.{ 12, 28 }), // PWM6_A
+        list(&.{ 13, 29 }), // PWM6_B
+        single(14), // PWM7_A
+        single(15), // PWM7_B
+        none(), // PWM8_A
+        none(), // PWM8_B
+        none(), // PWM9_A
+        none(), // PWM9_B
+        none(), // PWM10_A
+        none(), // PWM10_B
+        none(), // PWM11_A
+        none(), // PWM11_B
+        single(20), // CLOCK_GPIN0
+        single(22), // CLOCK_GPIN1
+        single(21), // CLOCK_GPOUT0
+        single(23), // CLOCK_GPOUT1
+        single(24), // CLOCK_GPOUT2
+        single(25), // CLOCK_GPOUT3
+        list(&.{ 0, 3, 6, 9, 12, 15, 18, 21, 24, 27 }), // USB_OVCUR_DET
+        list(&.{ 1, 4, 7, 10, 13, 16, 19, 22, 25, 28 }), // USB_VBUS_DET
+        list(&.{ 2, 5, 8, 11, 14, 17, 20, 23, 26, 29 }), // USB_VBUS_EN
+        single(26), // ADC0
+        single(27), // ADC1
+        single(28), // ADC2
+        single(29), // ADC3
+        none(), // ADC4
+        none(), // ADC5
+        none(), // ADC6
+        none(), // ADC7
+        list(&.{ 0, 8, 19 }), // QMI_CS1
+    };
 
 pub const GlobalConfiguration = struct {
     GPIO0: ?Pin.Configuration = null,
@@ -422,7 +751,6 @@ pub const GlobalConfiguration = struct {
     GPIO45: ?Pin.Configuration = null,
     GPIO46: ?Pin.Configuration = null,
     GPIO47: ?Pin.Configuration = null,
-    GPIO48: ?Pin.Configuration = null,
 
     comptime {
         const pin_field_count = @typeInfo(Pin).@"enum".fields.len;
@@ -472,7 +800,9 @@ pub const GlobalConfiguration = struct {
         });
     }
 
-    // Can be called at comptime or runtime
+    /// Populate and return the PinsType struct
+    ///
+    /// Can be called at comptime or runtime
     pub fn pins(comptime self: GlobalConfiguration) self.PinsType() {
         var ret: self.PinsType() = undefined;
         inline for (@typeInfo(GlobalConfiguration).@"struct".fields) |field| {
@@ -494,7 +824,6 @@ pub const GlobalConfiguration = struct {
                         .ADC5 => 5,
                         .ADC6 => 6,
                         .ADC7 => 7,
-                        .TEMP => 8,
                         else => unreachable,
                     }));
                 }
@@ -505,8 +834,8 @@ pub const GlobalConfiguration = struct {
     }
 
     pub fn apply(comptime config: GlobalConfiguration) void {
-        comptime var input_gpios: u32 = 0;
-        comptime var output_gpios: u32 = 0;
+        comptime var input_gpios: u48 = 0;
+        comptime var output_gpios: u48 = 0;
         comptime var has_adc = false;
         comptime var has_pwm = false;
 
@@ -522,6 +851,7 @@ pub const GlobalConfiguration = struct {
                         switch (pin_config.get_direction()) {
                             .in => input_gpios |= 1 << gpio_num,
                             .out => output_gpios |= 1 << gpio_num,
+                            else => {},
                         }
                     }
 
@@ -539,8 +869,13 @@ pub const GlobalConfiguration = struct {
         const used_gpios = comptime input_gpios | output_gpios;
 
         if (used_gpios != 0) {
-            SIO.GPIO_OE_CLR.raw = used_gpios;
-            SIO.GPIO_OUT_CLR.raw = used_gpios;
+            SIO.GPIO_OE_CLR.raw = @truncate(used_gpios);
+            SIO.GPIO_OUT_CLR.raw = @truncate(used_gpios);
+
+            if (chip == .RP2350) {
+                SIO.GPIO_HI_OE_CLR.raw = @intCast(used_gpios >> 32);
+                SIO.GPIO_HI_OUT_CLR.raw = @intCast(used_gpios >> 32);
+            }
         }
 
         inline for (@typeInfo(GlobalConfiguration).@"struct".fields) |field| {
@@ -570,12 +905,25 @@ pub const GlobalConfiguration = struct {
                     pin.set_pull(.disabled);
                     pin.set_input_enabled(false);
                 } else if (comptime func.is_uart_tx() or func.is_uart_rx()) {
-                    // TODO: Handle pins that can be used with an alternate uart function
                     pin.set_function(.uart);
+                } else if (comptime func.is_uart_alt_tx() or func.is_uart_alt_rx()) {
+                    pin.set_function(.uart_alt);
                 } else if (comptime func.is_spi()) {
                     pin.set_function(.spi);
                 } else if (comptime func.is_i2c()) {
                     pin.set_function(.i2c);
+                } else if (comptime func == .PIO0) {
+                    pin.set_function(.pio0);
+                } else if (comptime func == .PIO1) {
+                    pin.set_function(.pio1);
+                } else if (comptime func == .PIO2) {
+                    pin.set_function(.pio2);
+                } else if (comptime func.is_clock_in() or func.is_clock_out()) {
+                    pin.set_function(.gpck);
+                } else if (comptime func == .QMI_CS1) {
+                    pin.set_function(.gpck); // Shares function number with clock
+                } else if (comptime func.is_usb()) {
+                    pin.set_function(.usb);
                 } else {
                     @compileError(std.fmt.comptimePrint("Unimplemented pin function. Please implement setting pin function {s} for GPIO {}", .{
                         @tagName(func),
@@ -585,18 +933,43 @@ pub const GlobalConfiguration = struct {
             }
         }
 
-        if (output_gpios != 0)
-            SIO.GPIO_OE_SET.raw = output_gpios;
+        if (output_gpios != 0) {
+            SIO.GPIO_OE_SET.raw = @truncate(output_gpios);
+            if (chip == .RP2350)
+                SIO.GPIO_HI_OE_SET.raw = @truncate(output_gpios >> 32);
+        }
 
         if (input_gpios != 0) {
             inline for (@typeInfo(GlobalConfiguration).@"struct".fields) |field|
                 if (@field(config, field.name)) |pin_config| {
                     const gpio_num = @intFromEnum(@field(Pin, field.name));
-                    const pull = pin_config.pull orelse continue;
-                    if (comptime pin_config.get_direction() != .in)
-                        @compileError("Only input pins can have pull up/down enabled");
+                    if (pin_config.pull) |pull| {
+                        if (comptime pin_config.get_direction() != .in)
+                            @compileError("Only input pins can have pull up/down enabled");
 
-                    gpio.num(gpio_num).set_pull(pull);
+                        gpio.num(gpio_num).set_pull(pull);
+                    }
+
+                    if (pin_config.schmitt_trigger) |enabled| {
+                        if (comptime pin_config.get_direction() != .in)
+                            @compileError("Only input pins can have schmitt trigger enabled");
+
+                        gpio.num(gpio_num).set_schmitt_trigger(enabled);
+                    }
+
+                    if (pin_config.drive_strength) |drive_strength| {
+                        if (comptime pin_config.get_direction() != .out)
+                            @compileError("Only output pins can have drive strength set");
+
+                        gpio.num(gpio_num).set_drive_strength(drive_strength);
+                    }
+
+                    if (pin_config.slew_rate) |slew_rate| {
+                        if (comptime pin_config.get_direction() != .out)
+                            @compileError("Only output pins can have slew rate set");
+
+                        gpio.num(gpio_num).set_slew_rate(slew_rate);
+                    }
                 };
         }
 

--- a/port/raspberrypi/rp2xxx/src/hal/pins.zig
+++ b/port/raspberrypi/rp2xxx/src/hal/pins.zig
@@ -42,6 +42,24 @@ pub const Pin = enum {
     GPIO27,
     GPIO28,
     GPIO29,
+    GPIO30,
+    GPIO31,
+    GPIO32,
+    GPIO33,
+    GPIO34,
+    GPIO35,
+    GPIO36,
+    GPIO37,
+    GPIO38,
+    GPIO39,
+    GPIO40,
+    GPIO41,
+    GPIO42,
+    GPIO43,
+    GPIO44,
+    GPIO45,
+    GPIO46,
+    GPIO47,
 
     pub const Configuration = struct {
         name: ?[:0]const u8 = null,
@@ -76,7 +94,7 @@ pub const Function = enum {
 
     PIO0,
     PIO1,
-    // TODO: PIO2 for RP2350
+    PIO2,
 
     SPI0_RX,
     SPI0_CSn,
@@ -144,6 +162,11 @@ pub const Function = enum {
     ADC1,
     ADC2,
     ADC3,
+    ADC4,
+    ADC5,
+    ADC6,
+    ADC7,
+    TEMP,
 
     pub fn is_pwm(function: Function) bool {
         return switch (function) {
@@ -232,6 +255,11 @@ pub const Function = enum {
             .ADC1,
             .ADC2,
             .ADC3,
+            .ADC4,
+            .ADC5,
+            .ADC6,
+            .ADC7,
+            .TEMP,
             => true,
             else => false,
         };
@@ -288,26 +316,27 @@ const function_table = [@typeInfo(Function).@"enum".fields.len][30]u1{
     all(), // SIO
     all(), // PIO0
     all(), // PIO1
-    list(&.{ 0, 4, 16, 20 }), // SPI0_RX
-    list(&.{ 1, 5, 17, 21 }), // SPI0_CSn
-    list(&.{ 2, 6, 18, 22 }), // SPI0_SCK
-    list(&.{ 3, 7, 19, 23 }), // SPI0_TX
-    list(&.{ 8, 12, 24, 28 }), // SPI1_RX
-    list(&.{ 9, 13, 25, 29 }), // SPI1_CSn
-    list(&.{ 10, 14, 26 }), // SPI1_SCK
-    list(&.{ 11, 15, 27 }), // SPI1_TX
-    list(&.{ 0, 12, 16, 28 }), // UART0_TX
-    list(&.{ 1, 13, 17, 29 }), // UART0_RX
-    list(&.{ 2, 14, 18 }), // UART0_CTS
-    list(&.{ 3, 15, 19 }), // UART0_RTS
-    list(&.{ 4, 8, 20, 24 }), // UART1_TX
-    list(&.{ 5, 9, 21, 25 }), // UART1_RX
-    list(&.{ 6, 10, 22, 26 }), // UART1_CTS
-    list(&.{ 7, 11, 23, 27 }), // UART1_RTS
-    list(&.{ 0, 4, 8, 12, 16, 20, 24, 28 }), // I2C0_SDA
-    list(&.{ 1, 5, 9, 13, 17, 21, 25, 29 }), // I2C0_SCL
-    list(&.{ 2, 6, 10, 14, 18, 22, 26 }), // I2C1_SDA
-    list(&.{ 3, 7, 11, 15, 19, 23, 27 }), // I2C1_SCL
+    all(), // PIO2
+    list(&.{ 0, 4, 16, 20, 32, 36 }), // SPI0_RX
+    list(&.{ 1, 5, 17, 21, 33, 37 }), // SPI0_CSn
+    list(&.{ 2, 6, 18, 22, 34, 38 }), // SPI0_SCK
+    list(&.{ 3, 7, 19, 23, 35, 39 }), // SPI0_TX
+    list(&.{ 8, 12, 24, 28, 40, 44 }), // SPI1_RX
+    list(&.{ 9, 13, 25, 29, 37, 41 }), // SPI1_CSn
+    list(&.{ 10, 14, 26, 30, 42 }), // SPI1_SCK
+    list(&.{ 11, 15, 27, 31, 43 }), // SPI1_TX
+    list(&.{ 0, 12, 16, 28, 32, 44 }), // UART0_TX
+    list(&.{ 1, 13, 17, 29, 33, 45 }), // UART0_RX
+    list(&.{ 2, 14, 18, 30, 34, 46 }), // UART0_CTS
+    list(&.{ 3, 15, 19, 31, 35, 47 }), // UART0_RTS
+    list(&.{ 4, 8, 20, 24, 36, 40 }), // UART1_TX
+    list(&.{ 5, 9, 21, 25, 37, 41 }), // UART1_RX
+    list(&.{ 6, 10, 22, 26, 38, 42 }), // UART1_CTS
+    list(&.{ 7, 11, 23, 27, 39, 43 }), // UART1_RTS
+    list(&.{ 0, 4, 8, 12, 16, 20, 24, 28, 32, 36, 40, 44 }), // I2C0_SDA
+    list(&.{ 1, 5, 9, 13, 17, 21, 25, 29, 33, 37, 41, 45 }), // I2C0_SCL
+    list(&.{ 2, 6, 10, 14, 18, 22, 26, 30, 34, 38, 42, 46 }), // I2C1_SDA
+    list(&.{ 3, 7, 11, 15, 19, 23, 27, 31, 35, 39, 43, 47 }), // I2C1_SCL
     list(&.{ 0, 16 }), // PWM0_A
     list(&.{ 1, 17 }), // PWM0_B
     list(&.{ 2, 18 }), // PWM1_A
@@ -333,10 +362,15 @@ const function_table = [@typeInfo(Function).@"enum".fields.len][30]u1{
     list(&.{ 0, 3, 6, 9, 12, 15, 18, 21, 24, 27 }), // USB_OVCUR_DET
     list(&.{ 1, 4, 7, 10, 13, 16, 19, 22, 25, 28 }), // USB_VBUS_DET
     list(&.{ 2, 5, 8, 11, 14, 17, 20, 23, 26, 29 }), // USB_VBUS_EN
-    single(26), // ADC0
-    single(27), // ADC1
-    single(28), // ADC2
-    single(29), // ADC3
+    single(40), // ADC0
+    single(41), // ADC1
+    single(42), // ADC2
+    single(43), // ADC3
+    single(44), // ADC4
+    single(45), // ADC5
+    single(46), // ADC6
+    single(47), // ADC7
+    single(48), // TEMP
 };
 
 pub const GlobalConfiguration = struct {
@@ -370,6 +404,25 @@ pub const GlobalConfiguration = struct {
     GPIO27: ?Pin.Configuration = null,
     GPIO28: ?Pin.Configuration = null,
     GPIO29: ?Pin.Configuration = null,
+    GPIO30: ?Pin.Configuration = null,
+    GPIO31: ?Pin.Configuration = null,
+    GPIO32: ?Pin.Configuration = null,
+    GPIO33: ?Pin.Configuration = null,
+    GPIO34: ?Pin.Configuration = null,
+    GPIO35: ?Pin.Configuration = null,
+    GPIO36: ?Pin.Configuration = null,
+    GPIO37: ?Pin.Configuration = null,
+    GPIO38: ?Pin.Configuration = null,
+    GPIO39: ?Pin.Configuration = null,
+    GPIO40: ?Pin.Configuration = null,
+    GPIO41: ?Pin.Configuration = null,
+    GPIO42: ?Pin.Configuration = null,
+    GPIO43: ?Pin.Configuration = null,
+    GPIO44: ?Pin.Configuration = null,
+    GPIO45: ?Pin.Configuration = null,
+    GPIO46: ?Pin.Configuration = null,
+    GPIO47: ?Pin.Configuration = null,
+    GPIO48: ?Pin.Configuration = null,
 
     comptime {
         const pin_field_count = @typeInfo(Pin).@"enum".fields.len;
@@ -437,6 +490,11 @@ pub const GlobalConfiguration = struct {
                         .ADC1 => 1,
                         .ADC2 => 2,
                         .ADC3 => 3,
+                        .ADC4 => 4,
+                        .ADC5 => 5,
+                        .ADC6 => 6,
+                        .ADC7 => 7,
+                        .TEMP => 8,
                         else => unreachable,
                     }));
                 }

--- a/port/raspberrypi/rp2xxx/src/hal/pins.zig
+++ b/port/raspberrypi/rp2xxx/src/hal/pins.zig
@@ -14,14 +14,15 @@ const resets = @import("resets.zig");
 
 const compatibility = @import("compatibility.zig");
 const chip = compatibility.chip;
-
-const has_rp2350b = chip == .RP2350 and @hasDecl(microzig.board, "has_rp2350b") and microzig.board.has_rp2350b;
+const has_rp2350b = compatibility.has_rp2350b;
 
 pub const Direction = enum(u2) {
     in,
     out,
     unknown,
 };
+
+pub const PinFlags = if (has_rp2350b) [48]u1 else [32]u1;
 
 pub const Pin = enum {
     GPIO0,
@@ -54,24 +55,24 @@ pub const Pin = enum {
     GPIO27,
     GPIO28,
     GPIO29,
-    GPIO30, // RP2340B only
-    GPIO31, // RP2340B only
-    GPIO32, // RP2340B only
-    GPIO33, // RP2340B only
-    GPIO34, // RP2340B only
-    GPIO35, // RP2340B only
-    GPIO36, // RP2340B only
-    GPIO37, // RP2340B only
-    GPIO38, // RP2340B only
-    GPIO39, // RP2340B only
-    GPIO40, // RP2340B only
-    GPIO41, // RP2340B only
-    GPIO42, // RP2340B only
-    GPIO43, // RP2340B only
-    GPIO44, // RP2340B only
-    GPIO45, // RP2340B only
-    GPIO46, // RP2340B only
-    GPIO47, // RP2340B only
+    GPIO30, // RP2350B only
+    GPIO31, // RP2350B only
+    GPIO32, // RP2350B only
+    GPIO33, // RP2350B only
+    GPIO34, // RP2350B only
+    GPIO35, // RP2350B only
+    GPIO36, // RP2350B only
+    GPIO37, // RP2350B only
+    GPIO38, // RP2350B only
+    GPIO39, // RP2350B only
+    GPIO40, // RP2350B only
+    GPIO41, // RP2350B only
+    GPIO42, // RP2350B only
+    GPIO43, // RP2350B only
+    GPIO44, // RP2350B only
+    GPIO45, // RP2350B only
+    GPIO46, // RP2350B only
+    GPIO47, // RP2350B only
 
     pub const Configuration = struct {
         name: ?[:0]const u8 = null,
@@ -114,7 +115,7 @@ pub const Function = enum {
 
     PIO0,
     PIO1,
-    PIO2, // RP2340 only
+    PIO2, // RP2350 only
 
     SPI0_RX,
     SPI0_CSn,
@@ -130,8 +131,8 @@ pub const Function = enum {
     UART0_RX,
     UART0_CTS,
     UART0_RTS,
-    UART0_ALT_TX, // RP2340 only
-    UART0_ALT_RX, // RP2340 only
+    UART0_ALT_TX, // RP2350 only
+    UART0_ALT_RX, // RP2350 only
 
     UART1_TX,
     UART1_RX,
@@ -170,17 +171,17 @@ pub const Function = enum {
     PWM7_A,
     PWM7_B,
 
-    PWM8_A, // RP2340B only
-    PWM8_B, // RP2340B only
+    PWM8_A, // RP2350B only
+    PWM8_B, // RP2350B only
 
-    PWM9_A, // RP2340B only
-    PWM9_B, // RP2340B only
+    PWM9_A, // RP2350B only
+    PWM9_B, // RP2350B only
 
-    PWM10_A, // RP2340B only
-    PWM10_B, // RP2340B only
+    PWM10_A, // RP2350B only
+    PWM10_B, // RP2350B only
 
-    PWM11_A, // RP2340B only
-    PWM11_B, // RP2340B only
+    PWM11_A, // RP2350B only
+    PWM11_B, // RP2350B only
 
     CLOCK_GPIN0,
     CLOCK_GPIN1,
@@ -198,10 +199,10 @@ pub const Function = enum {
     ADC1,
     ADC2,
     ADC3,
-    ADC4, // RP2340B only
-    ADC5, // RP2340B only
-    ADC6, // RP2340B only
-    ADC7, // RP2340B only
+    ADC4, // RP2350B only
+    ADC5, // RP2350B only
+    ADC6, // RP2350B only
+    ADC7, // RP2350B only
 
     /// Chip select for QMI memory bank 1
     /// This banks is addressed at 0x1100_0000
@@ -459,36 +460,29 @@ pub const Function = enum {
     }
 };
 
-fn all() [48]u1 {
-    var ret: [48]u1 = @splat(1);
-
-    if (!has_rp2350b) {
-        for (30..48) |i|
-            ret[i] = 0;
-    }
-
-    return ret;
+fn all() PinFlags {
+    return @splat(1);
 }
 
-fn list(gpio_list: []const u6) [48]u1 {
-    var ret = std.mem.zeroes([48]u1);
+fn list(gpio_list: []const u6) PinFlags {
+    var ret = std.mem.zeroes(PinFlags);
     for (gpio_list) |num|
         ret[num] = 1;
     return ret;
 }
 
-fn single(gpio_num: u6) [48]u1 {
-    var ret = std.mem.zeroes([48]u1);
+fn single(gpio_num: u6) PinFlags {
+    var ret = std.mem.zeroes(PinFlags);
     ret[gpio_num] = 1;
     return ret;
 }
 
-fn none() [48]u1 {
-    return std.mem.zeroes([48]u1);
+fn none() PinFlags {
+    return std.mem.zeroes(PinFlags);
 }
 
 const function_table = if (chip == .RP2040)
-    [@typeInfo(Function).@"enum".fields.len][48]u1{
+    [@typeInfo(Function).@"enum".fields.len]PinFlags{
         all(), // SIO
         all(), // PIO0
         all(), // PIO1
@@ -562,7 +556,7 @@ const function_table = if (chip == .RP2040)
         none(), // HSTX
     }
 else if (has_rp2350b)
-    [@typeInfo(Function).@"enum".fields.len][48]u1{
+    [@typeInfo(Function).@"enum".fields.len]PinFlags{
         all(), // SIO
         all(), // PIO0
         all(), // PIO1
@@ -636,7 +630,7 @@ else if (has_rp2350b)
         list(&.{ 12, 13, 14, 15, 16, 17, 18, 19 }), // HSTX
     }
 else
-    [@typeInfo(Function).@"enum".fields.len][48]u1{
+    [@typeInfo(Function).@"enum".fields.len]PinFlags{
         all(), // SIO
         all(), // PIO0
         all(), // PIO1

--- a/port/raspberrypi/rp2xxx/src/hal/pins.zig
+++ b/port/raspberrypi/rp2xxx/src/hal/pins.zig
@@ -14,8 +14,7 @@ const resets = @import("resets.zig");
 const compatibility = @import("compatibility.zig");
 const chip = compatibility.chip;
 
-const has_qfn_80 = chip == .RP2350 and @hasDecl(microzig.board, "has_qfn_80") and microzig.board.has_qfn_80;
-
+const has_rp2350b = chip == .RP2350 and @hasDecl(microzig.board, "has_rp2350b") and microzig.board.has_rp2350b;
 
 pub const Direction = enum(u2) {
     in,
@@ -54,24 +53,24 @@ pub const Pin = enum {
     GPIO27,
     GPIO28,
     GPIO29,
-    GPIO30,  // RP2340 qfn_80 only
-    GPIO31,  // RP2340 qfn_80 only
-    GPIO32,  // RP2340 qfn_80 only
-    GPIO33,  // RP2340 qfn_80 only
-    GPIO34,  // RP2340 qfn_80 only
-    GPIO35,  // RP2340 qfn_80 only
-    GPIO36,  // RP2340 qfn_80 only
-    GPIO37,  // RP2340 qfn_80 only
-    GPIO38,  // RP2340 qfn_80 only
-    GPIO39,  // RP2340 qfn_80 only
-    GPIO40,  // RP2340 qfn_80 only
-    GPIO41,  // RP2340 qfn_80 only
-    GPIO42,  // RP2340 qfn_80 only
-    GPIO43,  // RP2340 qfn_80 only
-    GPIO44,  // RP2340 qfn_80 only
-    GPIO45,  // RP2340 qfn_80 only
-    GPIO46,  // RP2340 qfn_80 only
-    GPIO47,  // RP2340 qfn_80 only
+    GPIO30, // RP2340B only
+    GPIO31, // RP2340B only
+    GPIO32, // RP2340B only
+    GPIO33, // RP2340B only
+    GPIO34, // RP2340B only
+    GPIO35, // RP2340B only
+    GPIO36, // RP2340B only
+    GPIO37, // RP2340B only
+    GPIO38, // RP2340B only
+    GPIO39, // RP2340B only
+    GPIO40, // RP2340B only
+    GPIO41, // RP2340B only
+    GPIO42, // RP2340B only
+    GPIO43, // RP2340B only
+    GPIO44, // RP2340B only
+    GPIO45, // RP2340B only
+    GPIO46, // RP2340B only
+    GPIO47, // RP2340B only
 
     pub const Configuration = struct {
         name: ?[:0]const u8 = null,
@@ -130,8 +129,8 @@ pub const Function = enum {
     UART0_RX,
     UART0_CTS,
     UART0_RTS,
-    UART0_ALT_TX,  // RP2340 only
-    UART0_ALT_RX,  // RP2340 only
+    UART0_ALT_TX, // RP2340 only
+    UART0_ALT_RX, // RP2340 only
 
     UART1_TX,
     UART1_RX,
@@ -170,17 +169,17 @@ pub const Function = enum {
     PWM7_A,
     PWM7_B,
 
-    PWM8_A, // RP2340 qfn_80 only
-    PWM8_B, // RP2340 qfn_80 only
+    PWM8_A, // RP2340B only
+    PWM8_B, // RP2340B only
 
-    PWM9_A, // RP2340 qfn_80 only
-    PWM9_B, // RP2340 qfn_80 only
+    PWM9_A, // RP2340B only
+    PWM9_B, // RP2340B only
 
-    PWM10_A, // RP2340 qfn_80 only
-    PWM10_B, // RP2340 qfn_80 only
+    PWM10_A, // RP2340B only
+    PWM10_B, // RP2340B only
 
-    PWM11_A, // RP2340 qfn_80 only
-    PWM11_B, // RP2340 qfn_80 only
+    PWM11_A, // RP2340B only
+    PWM11_B, // RP2340B only
 
     CLOCK_GPIN0,
     CLOCK_GPIN1,
@@ -198,12 +197,14 @@ pub const Function = enum {
     ADC1,
     ADC2,
     ADC3,
-    ADC4, // RP2340 qfn_80 only
-    ADC5, // RP2340 qfn_80 only
-    ADC6, // RP2340 qfn_80 only
-    ADC7, // RP2340 qfn_80 only
+    ADC4, // RP2340B only
+    ADC5, // RP2340B only
+    ADC6, // RP2340B only
+    ADC7, // RP2340B only
 
     QMI_CS1, // RP2340 only
+
+    HSTX, // RP2350 only
 
     pub fn is_uart_tx(function: Function) bool {
         return switch (function) {
@@ -457,7 +458,7 @@ pub const Function = enum {
 fn all() [48]u1 {
     var ret: [48]u1 = @splat(1);
 
-    if (!has_qfn_80) {
+    if (!has_rp2350b) {
         for (30..48) |i|
             ret[i] = 0;
     }
@@ -554,8 +555,9 @@ const function_table = if (chip == .RP2040)
         none(), // ADC6
         none(), // ADC7
         none(), // QMI_CS1
+        none(), // HSTX
     }
-else if (has_qfn_80)
+else if (has_rp2350b)
     [@typeInfo(Function).@"enum".fields.len][48]u1{
         all(), // SIO
         all(), // PIO0
@@ -575,8 +577,8 @@ else if (has_qfn_80)
         list(&.{ 3, 15, 19, 31, 35, 47 }), // UART0_RTS
         list(&.{ 2, 14, 18, 30, 34, 46 }), // UART0_ALT_TX
         list(&.{ 3, 15, 19, 31, 35, 47 }), // UART0_ALT_RX
-        list(&.{ 4,  8, 20, 24, 36, 40 }), // UART1_TX
-        list(&.{ 5,  9, 21, 25, 37, 41 }), // UART1_RX
+        list(&.{ 4, 8, 20, 24, 36, 40 }), // UART1_TX
+        list(&.{ 5, 9, 21, 25, 37, 41 }), // UART1_RX
         list(&.{ 6, 10, 22, 26, 38, 42 }), // UART1_CTS
         list(&.{ 7, 11, 23, 27, 39, 43 }), // UART1_RTS
         list(&.{ 6, 10, 22, 26, 38, 42 }), // UART1_ALT_TX
@@ -627,6 +629,7 @@ else if (has_qfn_80)
         single(46), // ADC6
         single(47), // ADC7
         list(&.{ 0, 8, 19, 47 }), // QMI_CS1
+        list(&.{ 12, 13, 14, 15, 16, 17, 18, 19 }), // HSTX
     }
 else
     [@typeInfo(Function).@"enum".fields.len][48]u1{
@@ -648,8 +651,8 @@ else
         list(&.{ 3, 15, 19 }), // UART0_RTS
         list(&.{ 2, 14, 18 }), // UART0_ALT_TX
         list(&.{ 3, 15, 19 }), // UART0_ALT_RX
-        list(&.{ 4,  8, 20, 24 }), // UART1_TX
-        list(&.{ 5,  9, 21, 25 }), // UART1_RX
+        list(&.{ 4, 8, 20, 24 }), // UART1_TX
+        list(&.{ 5, 9, 21, 25 }), // UART1_RX
         list(&.{ 6, 10, 22, 26 }), // UART1_CTS
         list(&.{ 7, 11, 23, 27 }), // UART1_RTS
         list(&.{ 6, 10, 22, 26 }), // UART1_ALT_TX
@@ -700,6 +703,7 @@ else
         none(), // ADC6
         none(), // ADC7
         list(&.{ 0, 8, 19 }), // QMI_CS1
+        list(&.{ 12, 13, 14, 15, 16, 17, 18, 19 }), // HSTX
     };
 
 pub const GlobalConfiguration = struct {
@@ -880,54 +884,42 @@ pub const GlobalConfiguration = struct {
 
         inline for (@typeInfo(GlobalConfiguration).@"struct".fields) |field| {
             if (@field(config, field.name)) |pin_config| {
-                const pin = gpio.num(@intFromEnum(@field(Pin, field.name)));
+                const gpio_pin = gpio.num(@intFromEnum(@field(Pin, field.name)));
                 const func = pin_config.function;
 
-                // xip = 0,
-                // spi,
-                // uart,
-                // i2c,
-                // pio0,
-                // pio1,
-                // pio2 (rp2350 only)
-                // gpck,
-                // usb,
-                // uart_alt (rp2350 only)
-                // @"null" = 0x1f,
-
                 if (func == .SIO) {
-                    pin.set_function(.sio);
+                    gpio_pin.set_function(.sio);
                 } else if (comptime func.is_pwm()) {
-                    pin.set_function(.pwm);
-                } else if (comptime func.is_adc()) {
-                    // Matches adc.Input.configure_gpio_pin
-                    pin.set_function(.disabled);
-                    pin.set_pull(.disabled);
-                    pin.set_input_enabled(false);
+                    gpio_pin.set_function(.pwm);
                 } else if (comptime func.is_uart_tx() or func.is_uart_rx()) {
-                    pin.set_function(.uart);
+                    gpio_pin.set_function(.uart);
                 } else if (comptime func.is_uart_alt_tx() or func.is_uart_alt_rx()) {
-                    pin.set_function(.uart_alt);
+                    gpio_pin.set_function(.uart_alt);
                 } else if (comptime func.is_spi()) {
-                    pin.set_function(.spi);
+                    gpio_pin.set_function(.spi);
                 } else if (comptime func.is_i2c()) {
-                    pin.set_function(.i2c);
+                    gpio_pin.set_function(.i2c);
                 } else if (comptime func == .PIO0) {
-                    pin.set_function(.pio0);
+                    gpio_pin.set_function(.pio0);
                 } else if (comptime func == .PIO1) {
-                    pin.set_function(.pio1);
+                    gpio_pin.set_function(.pio1);
                 } else if (comptime func == .PIO2) {
-                    pin.set_function(.pio2);
+                    gpio_pin.set_function(.pio2);
                 } else if (comptime func.is_clock_in() or func.is_clock_out()) {
-                    pin.set_function(.gpck);
+                    gpio_pin.set_function(.gpck);
                 } else if (comptime func == .QMI_CS1) {
-                    pin.set_function(.gpck); // Shares function number with clock
+                    gpio_pin.set_function(.gpck); // Shares function number with clock
                 } else if (comptime func.is_usb()) {
-                    pin.set_function(.usb);
+                    gpio_pin.set_function(.usb);
+                } else if (comptime func == .HSTX) {
+                    gpio_pin.set_function(.hstx);
+                } else if (comptime func.is_adc()) {
+                    const adc_num = @intFromEnum(func) - @intFromEnum(Function.ADC0);
+                    adc.Input.configure_gpio_pin(@as(adc.Input, @enumFromInt(adc_num)));
                 } else {
                     @compileError(std.fmt.comptimePrint("Unimplemented pin function. Please implement setting pin function {s} for GPIO {}", .{
                         @tagName(func),
-                        @intFromEnum(pin),
+                        @intFromEnum(gpio_pin),
                     }));
                 }
             }
@@ -939,39 +931,25 @@ pub const GlobalConfiguration = struct {
                 SIO.GPIO_HI_OE_SET.raw = @truncate(output_gpios >> 32);
         }
 
-        if (input_gpios != 0) {
-            inline for (@typeInfo(GlobalConfiguration).@"struct".fields) |field|
-                if (@field(config, field.name)) |pin_config| {
-                    const gpio_num = @intFromEnum(@field(Pin, field.name));
-                    if (pin_config.pull) |pull| {
-                        if (comptime pin_config.get_direction() != .in)
-                            @compileError("Only input pins can have pull up/down enabled");
+        inline for (@typeInfo(GlobalConfiguration).@"struct".fields) |field|
+            if (@field(config, field.name)) |pin_config| {
+                const gpio_num = @intFromEnum(@field(Pin, field.name));
+                if (pin_config.pull) |pull| {
+                    gpio.num(gpio_num).set_pull(pull);
+                }
 
-                        gpio.num(gpio_num).set_pull(pull);
-                    }
+                if (pin_config.schmitt_trigger) |enabled| {
+                    gpio.num(gpio_num).set_schmitt_trigger(enabled);
+                }
 
-                    if (pin_config.schmitt_trigger) |enabled| {
-                        if (comptime pin_config.get_direction() != .in)
-                            @compileError("Only input pins can have schmitt trigger enabled");
+                if (pin_config.drive_strength) |drive_strength| {
+                    gpio.num(gpio_num).set_drive_strength(drive_strength);
+                }
 
-                        gpio.num(gpio_num).set_schmitt_trigger(enabled);
-                    }
-
-                    if (pin_config.drive_strength) |drive_strength| {
-                        if (comptime pin_config.get_direction() != .out)
-                            @compileError("Only output pins can have drive strength set");
-
-                        gpio.num(gpio_num).set_drive_strength(drive_strength);
-                    }
-
-                    if (pin_config.slew_rate) |slew_rate| {
-                        if (comptime pin_config.get_direction() != .out)
-                            @compileError("Only output pins can have slew rate set");
-
-                        gpio.num(gpio_num).set_slew_rate(slew_rate);
-                    }
-                };
-        }
+                if (pin_config.slew_rate) |slew_rate| {
+                    gpio.num(gpio_num).set_slew_rate(slew_rate);
+                }
+            };
 
         if (has_adc) {
             // FIXME: https://github.com/ZigEmbeddedGroup/microzig/issues/311


### PR DESCRIPTION
Addresses #405, #311 
Supersedes PR #531.

Improves support for RP2350, especially the RP2350B.  Some of the changes:

- Adds support for GPIO pins 30 through 47.
- Adds support for extra ADC pins and the change in location of the ADCs (pin 40-47 vs 26-30)
- Adds basic support for external PSRAM (R/W memory located at 0x1100_0000)
- Adds UART alternate RX an TX pins (also for RP2350A)
- Adds support in `pins.zig` for PI02. (it looks like `pio.zig` already has needed changes) 
- Adds support in `pins.zig` for PWM8 through PWM11 (changes to `pwm.zig` may be needed)
- Adds support for the Adafruit Meto RP2350 board (that uses the RP2350B chip).

Some things that the RP2350 supports that are not (yet) addressed:
- HSTX support (pin type is set in `pins.zig`)
- TRNG support
- Always-On Timer changes from Real Time Clock.
- Repurposing USB and QSPI pins
- Probably others.

@Grazfather was right about the added complexity in adding a new chip type.  This version currently just looks for a specific declaration in the board file to switch over to the rp2340B.  There is probably a better way to do that, but as it's just a flag that is used in relatively few place, it should be easy to change.

It does supply unique `function_table` entries for each chip version, as that was needed due to the change in pin location of the ADCs.  This version supplies unique lists of compatible pins for RP2040, RP2350A and RP2350B.
