### PR TITLE
Add ram_image boolean to mz.Target and expose via microzig.config

### DIFF
--- a/build-internals/build.zig
+++ b/build-internals/build.zig
@@ -43,6 +43,11 @@ pub const Target = struct {
     /// This should always be true except for platforms where compiler_rt cannot be built right now.
     bundle_compiler_rt: bool = true,
 
+    /// Determines whether the artifact produced for this target will exist solely in RAM. This will
+    /// inform whether we need to do any special handling e.g. of vector tables and whether we need
+    /// to explicitly copy .data and clear out .bss
+    ram_image: bool = false,
+
     /// (optional) Provides a default hardware abstraction layer that is used.
     /// If `null`, no `microzig.hal` will be available.
     hal: ?HardwareAbstractionLayer = null,
@@ -71,6 +76,7 @@ pub const Target = struct {
         chip: ?Chip = null,
         single_threaded: ?bool = null,
         bundle_compiler_rt: ?bool = null,
+        ram_image: ?bool = null,
         hal: ?HardwareAbstractionLayer = null,
         board: ?Board = null,
         linker_script: ?LazyPath = null,
@@ -89,6 +95,7 @@ pub const Target = struct {
             .chip = options.chip orelse from.chip,
             .single_threaded = options.single_threaded orelse from.single_threaded,
             .bundle_compiler_rt = options.bundle_compiler_rt orelse from.bundle_compiler_rt,
+            .ram_image = options.ram_image orelse from.ram_image,
             .hal = options.hal orelse from.hal,
             .board = options.board orelse from.board,
             .linker_script = options.linker_script orelse from.linker_script,

--- a/build.zig
+++ b/build.zig
@@ -393,6 +393,7 @@ pub fn MicroBuild(port_select: PortSelect) type {
             config.addOption([]const u8, "chip_name", target.chip.name);
             config.addOption(?[]const u8, "board_name", if (maybe_board) |board| board.name else null);
             config.addOption(usize, "end_of_stack", first_ram.offset + first_ram.length);
+            config.addOption(bool, "ram_image", target.ram_image);
 
             const core_mod = b.createModule(.{
                 .root_source_file = mb.core_dep.path("src/microzig.zig"),

--- a/core/src/cpus/cortex_m.zig
+++ b/core/src/cpus/cortex_m.zig
@@ -675,11 +675,7 @@ pub const startup_logic = struct {
 };
 
 fn is_ramimage() bool {
-    // HACK
-    // TODO: Use microzig_options?
-    if (microzig.config.board_name) |board_name|
-        return std.mem.containsAtLeast(u8, board_name, 1, "ram image");
-    return false;
+    return microzig.config.ram_image;
 }
 
 pub fn export_startup_logic() void {

--- a/port/raspberrypi/rp2xxx/build.zig
+++ b/port/raspberrypi/rp2xxx/build.zig
@@ -167,6 +167,7 @@ pub fn init(dep: *std.Build.Dependency) Self {
                 .pico_flashless = chip_rp2040.derive(.{
                     .entry = .{ .symbol_name = "_entry_point" },
                     .linker_script = b.path("rp2040_ram_image.ld"),
+                    .ram_image = true,
                     .board = .{
                         .name = "RaspberryPi Pico (ram image)",
                         .url = "https://www.raspberrypi.com/products/raspberry-pi-pico/",


### PR DESCRIPTION
This cleans up the hack I just added in #535.

This generalizes better, so it can be used for e.g. esp32c3 ram images.