### PR TITLE
Fixed rp2350_arm.ld

### DIFF
--- a/port/raspberrypi/rp2xxx/rp2350_arm.ld
+++ b/port/raspberrypi/rp2xxx/rp2350_arm.ld
@@ -18,7 +18,7 @@ SECTIONS
 
   .vectortable :
   {
-     KEEP(*(microzig_flash_start))
+     KEEP(*(.isr_vector))
   } > flash0
 
   .bootmeta :


### PR DESCRIPTION
With the changes to support flash boot on rp2040 one of the code sections was renamed.  This makes the required change to the rp2350_arm.ld file too.