### PR TITLE
Restore the microzig_flash_start section for ARM

### DIFF
--- a/core/src/cpus/cortex_m.zig
+++ b/core/src/cpus/cortex_m.zig
@@ -691,7 +691,7 @@ pub fn export_startup_logic() void {
 
     @export(&startup_logic._vector_table, .{
         .name = "_vector_table",
-        .section = ".isr_vector",
+        .section = "microzig_flash_start",
         .linkage = .strong,
     });
 }

--- a/port/raspberrypi/rp2xxx/rp2040.ld
+++ b/port/raspberrypi/rp2xxx/rp2040.ld
@@ -26,7 +26,7 @@ SECTIONS
 
   .text :
   {
-     KEEP(*(.isr_vector))
+     KEEP(*(microzig_flash_start))
      *(.text*)
      *(.rodata*)
   } > flash0

--- a/port/raspberrypi/rp2xxx/rp2040_ram_image.ld
+++ b/port/raspberrypi/rp2xxx/rp2040_ram_image.ld
@@ -18,7 +18,7 @@ SECTIONS
 
   .text :
   {
-     KEEP(*(.isr_vector))
+     KEEP(*(microzig_flash_start))
      *(.text*)
      *(.rodata*)
   } > ram0


### PR DESCRIPTION
I changed this to `.isr_vector`, but I missed some targets. This restores it to the name used by the linker script generator.