### PR TITLE
Fix bug in rp2350 hazard3's set_handler

### DIFF
--- a/port/raspberrypi/rp2xxx/src/cpus/hazard3.zig
+++ b/port/raspberrypi/rp2xxx/src/cpus/hazard3.zig
@@ -143,7 +143,7 @@ pub const interrupt = struct {
 
         const old_handler = ram_vectors[@intFromEnum(int)];
         ram_vectors[@intFromEnum(int)] = handler orelse microzig.interrupt.unhandled;
-        return if (old_handler == microzig.interrupt.unhandled) null else old_handler;
+        return if (old_handler.naked == microzig.interrupt.unhandled.naked) null else old_handler;
     }
 };
 


### PR DESCRIPTION
The set_handler function tries to compare two unions, which zig does not permit.
Changed to compare one branch of the union.   Both branches are pointers so it does not matter which one we choose.