### PR TITLE
nRF5x: Add basic timer support

### DIFF
--- a/examples/nordic/nrf5x/src/blinky.zig
+++ b/examples/nordic/nrf5x/src/blinky.zig
@@ -1,27 +1,23 @@
 const std = @import("std");
 const microzig = @import("microzig");
 const board = microzig.board;
-
-fn delay(cycles: u32) void {
-    var i: u32 = 0;
-    while (i < cycles) : (i += 1) {
-        std.mem.doNotOptimizeAway(i);
-    }
-}
+const nrf = microzig.hal;
+const time = nrf.time;
 
 pub fn main() !void {
     board.init();
+    nrf.time.init();
 
     while (true) {
         board.led1.toggle();
-        delay(2000000);
+        time.sleep_ms(500);
 
         board.led1.toggle();
         board.led2.toggle();
-        delay(2000000);
+        time.sleep_ms(500);
 
         board.led2.toggle();
         board.led3.toggle();
-        delay(2000000);
+        time.sleep_ms(500);
     }
 }

--- a/examples/nordic/nrf5x/src/blinky.zig
+++ b/examples/nordic/nrf5x/src/blinky.zig
@@ -6,7 +6,6 @@ const time = nrf.time;
 
 pub fn main() !void {
     board.init();
-    nrf.time.init();
 
     while (true) {
         board.led1.toggle();

--- a/examples/nordic/nrf5x/src/uart.zig
+++ b/examples/nordic/nrf5x/src/uart.zig
@@ -12,6 +12,7 @@ pub const microzig_options = microzig.Options{
 
 pub fn main() !void {
     board.init();
+    nrf.time.init();
 
     uart.apply(.{
         .tx_pin = board.uart_tx,

--- a/examples/nordic/nrf5x/src/uart.zig
+++ b/examples/nordic/nrf5x/src/uart.zig
@@ -12,7 +12,6 @@ pub const microzig_options = microzig.Options{
 
 pub fn main() !void {
     board.init();
-    nrf.time.init();
 
     uart.apply(.{
         .tx_pin = board.uart_tx,

--- a/port/nordic/nrf5x/src/hal.zig
+++ b/port/nordic/nrf5x/src/hal.zig
@@ -6,6 +6,10 @@ pub const time = @import("hal/time.zig");
 pub const uart = @import("hal/uart.zig");
 // TODO: adc, timers, pwm, rng, rtc, spi, interrupts, i2c, wdt, wifi, nfc, bt, zigbee
 
+pub fn init() void {
+    time.init();
+}
+
 test "hal tests" {
     _ = gpio;
     _ = time;

--- a/port/nordic/nrf5x/src/hal.zig
+++ b/port/nordic/nrf5x/src/hal.zig
@@ -2,9 +2,12 @@ const microzig = @import("microzig");
 
 pub const compatibility = @import("hal/compatibility.zig");
 pub const gpio = @import("hal/gpio.zig");
+pub const time = @import("hal/time.zig");
 pub const uart = @import("hal/uart.zig");
 // TODO: adc, timers, pwm, rng, rtc, spi, interrupts, i2c, wdt, wifi, nfc, bt, zigbee
 
 test "hal tests" {
     _ = gpio;
+    _ = time;
+    _ = uart;
 }

--- a/port/nordic/nrf5x/src/hal/time.zig
+++ b/port/nordic/nrf5x/src/hal/time.zig
@@ -1,0 +1,48 @@
+const std = @import("std");
+const microzig = @import("microzig");
+const time = microzig.drivers.time;
+
+const timer = microzig.chip.peripherals.TIMER0;
+
+var overflow_count: u32 = 0;
+
+// TODO: Who calls this?
+pub fn init() void {
+    // Stop timer while we set it up
+    timer.TASKS_STOP.write(.{ .TASKS_STOP = .Trigger });
+    defer timer.TASKS_START.write(.{ .TASKS_START = .Trigger });
+
+    // Clear the time
+    timer.TASKS_CLEAR.write(.{ .TASKS_CLEAR = .Trigger });
+
+    timer.MODE.write(.{ .MODE = .Timer });
+    timer.BITMODE.write(.{ .BITMODE = .@"32Bit" });
+    // 16Mhz / 2^4 = 1MHz: us resolution
+    timer.PRESCALER.write(.{ .PRESCALER = 4 });
+
+    // TODO: Set an interrupt to fire when the timer overflows, and keep track of the count, that
+    // way we get more than 2^32 us.
+    // timer.INTENSET.modify(.{COMPARE0 = .Enabled});
+
+    timer.SHORTS.modify(.{ .COMPARE0_CLEAR = .Enabled });
+
+    timer.EVENTS_COMPARE[0].write(.{ .EVENTS_COMPARE = .NotGenerated });
+}
+
+pub fn get_time_since_boot() time.Absolute {
+    // TODO: Check for overflow here? Probably want to disable interrupts, and them and clear, just
+    // in case an interrupt for an overflow comes in right after we check the count.
+    // Trigger a 'capture' to get the timer value copied into the corresponding CC register.
+    timer.TASKS_CAPTURE[0].write(.{ .TASKS_CAPTURE = .Trigger });
+    return @enumFromInt(@as(u64, overflow_count) << 32 | timer.CC[0].raw);
+}
+
+pub fn sleep_ms(time_ms: u32) void {
+    sleep_us(time_ms * 1000);
+}
+
+pub fn sleep_us(time_us: u64) void {
+    const end_time = time.make_timeout_us(get_time_since_boot(), time_us);
+    std.log.info("End time is: {d}", .{@intFromEnum(end_time)});
+    while (!end_time.is_reached_by(get_time_since_boot())) {}
+}

--- a/port/nordic/nrf5x/src/hal/time.zig
+++ b/port/nordic/nrf5x/src/hal/time.zig
@@ -1,12 +1,18 @@
+///
+/// Basic timekeeping for the nRF5x series MCUs.
+///
+/// This module hogs TIMER0.
+/// It uses CC1 as the register to read the current count from.
 const std = @import("std");
 const microzig = @import("microzig");
 const time = microzig.drivers.time;
 
 const timer = microzig.chip.peripherals.TIMER0;
+// const INTERRUPT_INDEX = 0;
+const READ_INDEX = 1;
 
 var overflow_count: u32 = 0;
 
-// TODO: Who calls this?
 pub fn init() void {
     // Stop timer while we set it up
     timer.TASKS_STOP.write(.{ .TASKS_STOP = .Trigger });
@@ -22,19 +28,17 @@ pub fn init() void {
 
     // TODO: Set an interrupt to fire when the timer overflows, and keep track of the count, that
     // way we get more than 2^32 us.
-    // timer.INTENSET.modify(.{COMPARE0 = .Enabled});
-
-    timer.SHORTS.modify(.{ .COMPARE0_CLEAR = .Enabled });
-
-    timer.EVENTS_COMPARE[0].write(.{ .EVENTS_COMPARE = .NotGenerated });
+    // timer.INTENSET.modify(.{ .COMPARE0 = .Enabled });
+    // timer.SHORTS.modify(.{ .COMPARE0_CLEAR = .Enabled });
+    // timer.EVENTS_COMPARE[0].write(.{ .EVENTS_COMPARE = .NotGenerated });
 }
 
 pub fn get_time_since_boot() time.Absolute {
     // TODO: Check for overflow here? Probably want to disable interrupts, and them and clear, just
     // in case an interrupt for an overflow comes in right after we check the count.
     // Trigger a 'capture' to get the timer value copied into the corresponding CC register.
-    timer.TASKS_CAPTURE[0].write(.{ .TASKS_CAPTURE = .Trigger });
-    return @enumFromInt(@as(u64, overflow_count) << 32 | timer.CC[0].raw);
+    timer.TASKS_CAPTURE[READ_INDEX].write(.{ .TASKS_CAPTURE = .Trigger });
+    return @enumFromInt(@as(u64, overflow_count) << 32 | timer.CC[READ_INDEX].raw);
 }
 
 pub fn sleep_ms(time_ms: u32) void {

--- a/port/nordic/nrf5x/src/hal/time.zig
+++ b/port/nordic/nrf5x/src/hal/time.zig
@@ -8,7 +8,6 @@ const microzig = @import("microzig");
 const time = microzig.drivers.time;
 
 const timer = microzig.chip.peripherals.TIMER0;
-// const INTERRUPT_INDEX = 0;
 const READ_INDEX = 1;
 
 var overflow_count: u32 = 0;
@@ -25,18 +24,9 @@ pub fn init() void {
     timer.BITMODE.write(.{ .BITMODE = .@"32Bit" });
     // 16Mhz / 2^4 = 1MHz: us resolution
     timer.PRESCALER.write(.{ .PRESCALER = 4 });
-
-    // TODO: Set an interrupt to fire when the timer overflows, and keep track of the count, that
-    // way we get more than 2^32 us.
-    // timer.INTENSET.modify(.{ .COMPARE0 = .Enabled });
-    // timer.SHORTS.modify(.{ .COMPARE0_CLEAR = .Enabled });
-    // timer.EVENTS_COMPARE[0].write(.{ .EVENTS_COMPARE = .NotGenerated });
 }
 
 pub fn get_time_since_boot() time.Absolute {
-    // TODO: Check for overflow here? Probably want to disable interrupts, and them and clear, just
-    // in case an interrupt for an overflow comes in right after we check the count.
-    // Trigger a 'capture' to get the timer value copied into the corresponding CC register.
     timer.TASKS_CAPTURE[READ_INDEX].write(.{ .TASKS_CAPTURE = .Trigger });
     return @enumFromInt(@as(u64, overflow_count) << 32 | timer.CC[READ_INDEX].raw);
 }

--- a/port/nordic/nrf5x/src/hal/time.zig
+++ b/port/nordic/nrf5x/src/hal/time.zig
@@ -47,6 +47,5 @@ pub fn sleep_ms(time_ms: u32) void {
 
 pub fn sleep_us(time_us: u64) void {
     const end_time = time.make_timeout_us(get_time_since_boot(), time_us);
-    std.log.info("End time is: {d}", .{@intFromEnum(end_time)});
     while (!end_time.is_reached_by(get_time_since_boot())) {}
 }

--- a/port/nordic/nrf5x/src/hal/uart.zig
+++ b/port/nordic/nrf5x/src/hal/uart.zig
@@ -9,6 +9,7 @@ const types = microzig.chip.types;
 const UART_Regs = types.peripherals.UART0;
 
 const gpio = @import("gpio.zig");
+const time = @import("time.zig");
 
 var uart_logger: ?UART.Writer = null;
 
@@ -37,20 +38,18 @@ pub fn logFn(
     comptime format: []const u8,
     args: anytype,
 ) void {
-    const level_prefix = comptime level.asText();
-    // const level_prefix = comptime "[{}.{:0>6}] " ++ level.asText();
+    const level_prefix = comptime "[{}.{:0>6}] " ++ level.asText();
     const prefix = comptime level_prefix ++ switch (scope) {
         .default => ": ",
         else => " (" ++ @tagName(scope) ++ "): ",
     };
 
     if (uart_logger) |uart| {
-        // const current_time = time.get_time_since_boot();
-        // const seconds = current_time.to_us() / std.time.us_per_s;
-        // const microseconds = current_time.to_us() % std.time.us_per_s;
+        const current_time = time.get_time_since_boot();
+        const seconds = current_time.to_us() / std.time.us_per_s;
+        const microseconds = current_time.to_us() % std.time.us_per_s;
 
-        // uart.print(prefix ++ format ++ "\r\n", .{ seconds, microseconds } ++ args) catch {};
-        uart.print(prefix ++ format ++ "\r\n", args) catch {};
+        uart.print(prefix ++ format ++ "\r\n", .{ seconds, microseconds } ++ args) catch {};
     }
 }
 


### PR DESCRIPTION
TODO:
* Add interrupt handler for this timer that lets us keep time for more than 4 billion microseconds
* Call the initializer from some chip-specific file