### PR TITLE
Fixes to interrupt handling

### DIFF
--- a/examples/raspberrypi/rp2xxx/src/interrupts.zig
+++ b/examples/raspberrypi/rp2xxx/src/interrupts.zig
@@ -67,6 +67,11 @@ pub fn main() !void {
 
     interrupt.enable(timer_irq);
 
+    // Enable machine external interrupts on RISC-V
+    if (rp2xxx.compatibility.arch == .riscv) {
+        microzig.cpu.interrupt.core.enable(.MachineExternal);
+    }
+
     microzig.cpu.interrupt.enable_interrupts();
 
     while (true) {

--- a/modules/riscv32-common/src/riscv32_common.zig
+++ b/modules/riscv32-common/src/riscv32_common.zig
@@ -498,7 +498,7 @@ pub const utilities = struct {
                 }
 
                 pub fn is_pending(int: CoreInterruptEnum) bool {
-                    return csr.mip.read() & (@as(u32, 1) << @intFromEnum(int));
+                    return csr.mip.read() & (@as(u32, 1) << @intFromEnum(int)) != 0;
                 }
 
                 pub fn set_pending(int: CoreInterruptEnum) void {

--- a/port/raspberrypi/rp2xxx/src/cpus/hazard3.zig
+++ b/port/raspberrypi/rp2xxx/src/cpus/hazard3.zig
@@ -116,8 +116,8 @@ pub const interrupt = struct {
         const shift: u4 = @intCast(4 * (num & 0x4));
         const set_mask: u16 = @as(u16, @intFromEnum(priority)) << shift;
         const clear_mask: u16 = @as(u16, 0xf) << shift;
-        csr.meifa.clear(.{ .index = index, .window = clear_mask });
-        csr.meifa.set(.{ .index = index, .window = set_mask });
+        csr.meipra.clear(.{ .index = index, .window = clear_mask });
+        csr.meipra.set(.{ .index = index, .window = set_mask });
     }
 
     pub fn get_priority(int: ExternalInterrupt) Priority {
@@ -125,7 +125,7 @@ pub const interrupt = struct {
         const index: u5 = @intCast(num >> 2);
         const shift: u4 = @intCast(4 * (num & 0x4));
         const mask: u16 = @as(u16, 0xf) << shift;
-        return @enumFromInt((csr.meifa.read_set(.{ .index = index }).window & mask) >> shift);
+        return @enumFromInt((csr.meipra.read_set(.{ .index = index }).window & mask) >> shift);
     }
 
     pub inline fn has_ram_vectors() bool {
@@ -218,9 +218,6 @@ pub const startup_logic = struct {
 
             @memcpy(&ram_vectors, &startup_logic.external_interrupt_table);
         }
-
-        // NOTE: tact1m4n3: I don't think it's fine to enable this behind the user's back.
-        interrupt.core.enable(.MachineExternal);
 
         microzig_main();
     }


### PR DESCRIPTION
Fixes:
  - riscv32_common.zig `is_pending` function need a compare to return a `bool`.
  - hazard3.zig interrupt priority registers were incorrect.
  - hazard3.zig removed an interrupt enable that tact1m4n3 didn't like.