### PR TITLE
esp32 Trap Dispatch Improvement

### DIFF
--- a/port/espressif/esp/src/cpus/esp_riscv.zig
+++ b/port/espressif/esp/src/cpus/esp_riscv.zig
@@ -426,168 +426,168 @@ fn _vector_table() align(256) linksection(".trap") callconv(.naked) void {
         break :blk s;
     };
 
-    // taken from https://github.com/esp-rs/esp-hal/blob/main/esp-riscv-rt/src/lib.rs
+    // adapted from https://github.com/esp-rs/esp-hal/blob/main/esp-riscv-rt/src/lib.rs
     asm volatile (
         \\    j exception
         \\
     ++ interrupts_jump_asm ++
         \\exception:
-        \\    addi sp, sp, -40*4
+        \\    addi sp, sp, -35*4
         \\    sw ra, 0(sp)
         \\    la ra, _exception_handler
         \\    j trap_common
         \\interrupt1:
-        \\    addi sp, sp, -40*4
+        \\    addi sp, sp, -35*4
         \\    sw ra, 0(sp)
         \\    la ra, _interrupt1_handler
         \\    j trap_common
         \\interrupt2:
-        \\    addi sp, sp, -40*4
+        \\    addi sp, sp, -35*4
         \\    sw ra, 0(sp)
         \\    la ra, _interrupt2_handler
         \\    j trap_common
         \\interrupt3:
-        \\    addi sp, sp, -40*4
+        \\    addi sp, sp, -35*4
         \\    sw ra, 0(sp)
         \\    la ra, _interrupt3_handler
         \\    j trap_common
         \\interrupt4:
-        \\    addi sp, sp, -40*4
+        \\    addi sp, sp, -35*4
         \\    sw ra, 0(sp)
         \\    la ra, _interrupt4_handler
         \\    j trap_common
         \\interrupt5:
-        \\    addi sp, sp, -40*4
+        \\    addi sp, sp, -35*4
         \\    sw ra, 0(sp)
         \\    la ra, _interrupt5_handler
         \\    j trap_common
         \\interrupt6:
-        \\    addi sp, sp, -40*4
+        \\    addi sp, sp, -35*4
         \\    sw ra, 0(sp)
         \\    la ra, _interrupt6_handler
         \\    j trap_common
         \\interrupt7:
-        \\    addi sp, sp, -40*4
+        \\    addi sp, sp, -35*4
         \\    sw ra, 0(sp)
         \\    la ra, _interrupt7_handler
         \\    j trap_common
         \\interrupt8:
-        \\    addi sp, sp, -40*4
+        \\    addi sp, sp, -35*4
         \\    sw ra, 0(sp)
         \\    la ra, _interrupt8_handler
         \\    j trap_common
         \\interrupt9:
-        \\    addi sp, sp, -40*4
+        \\    addi sp, sp, -35*4
         \\    sw ra, 0(sp)
         \\    la ra, _interrupt9_handler
         \\    j trap_common
         \\interrupt10:
-        \\    addi sp, sp, -40*4
+        \\    addi sp, sp, -35*4
         \\    sw ra, 0(sp)
         \\    la ra, _interrupt10_handler
         \\    j trap_common
         \\interrupt11:
-        \\    addi sp, sp, -40*4
+        \\    addi sp, sp, -35*4
         \\    sw ra, 0(sp)
         \\    la ra, _interrupt11_handler
         \\    j trap_common
         \\interrupt12:
-        \\    addi sp, sp, -40*4
+        \\    addi sp, sp, -35*4
         \\    sw ra, 0(sp)
         \\    la ra, _interrupt12_handler
         \\    j trap_common
         \\interrupt13:
-        \\    addi sp, sp, -40*4
+        \\    addi sp, sp, -35*4
         \\    sw ra, 0(sp)
         \\    la ra, _interrupt13_handler
         \\    j trap_common
         \\interrupt14:
-        \\    addi sp, sp, -40*4
+        \\    addi sp, sp, -35*4
         \\    sw ra, 0(sp)
         \\    la ra, _interrupt14_handler
         \\    j trap_common
         \\interrupt15:
-        \\    addi sp, sp, -40*4
+        \\    addi sp, sp, -35*4
         \\    sw ra, 0(sp)
         \\    la ra, _interrupt15_handler
         \\    j trap_common
         \\interrupt16:
-        \\    addi sp, sp, -40*4
+        \\    addi sp, sp, -35*4
         \\    sw ra, 0(sp)
         \\    la ra, _interrupt16_handler
         \\    j trap_common
         \\interrupt17:
-        \\    addi sp, sp, -40*4
+        \\    addi sp, sp, -35*4
         \\    sw ra, 0(sp)
         \\    la ra, _interrupt17_handler
         \\    j trap_common
         \\interrupt18:
-        \\    addi sp, sp, -40*4
+        \\    addi sp, sp, -35*4
         \\    sw ra, 0(sp)
         \\    la ra, _interrupt18_handler
         \\    j trap_common
         \\interrupt19:
-        \\    addi sp, sp, -40*4
+        \\    addi sp, sp, -35*4
         \\    sw ra, 0(sp)
         \\    la ra, _interrupt19_handler
         \\    j trap_common
         \\interrupt20:
-        \\    addi sp, sp, -40*4
+        \\    addi sp, sp, -35*4
         \\    sw ra, 0(sp)
         \\    la ra, _interrupt20_handler
         \\    j trap_common
         \\interrupt21:
-        \\    addi sp, sp, -40*4
+        \\    addi sp, sp, -35*4
         \\    sw ra, 0(sp)
         \\    la ra, _interrupt21_handler
         \\    j trap_common
         \\interrupt22:
-        \\    addi sp, sp, -40*4
+        \\    addi sp, sp, -35*4
         \\    sw ra, 0(sp)
         \\    la ra, _interrupt22_handler
         \\    j trap_common
         \\interrupt23:
-        \\    addi sp, sp, -40*4
+        \\    addi sp, sp, -35*4
         \\    sw ra, 0(sp)
         \\    la ra, _interrupt23_handler
         \\    j trap_common
         \\interrupt24:
-        \\    addi sp, sp, -40*4
+        \\    addi sp, sp, -35*4
         \\    sw ra, 0(sp)
         \\    la ra, _interrupt24_handler
         \\    j trap_common
         \\interrupt25:
-        \\    addi sp, sp, -40*4
+        \\    addi sp, sp, -35*4
         \\    sw ra, 0(sp)
         \\    la ra, _interrupt25_handler
         \\    j trap_common
         \\interrupt26:
-        \\    addi sp, sp, -40*4
+        \\    addi sp, sp, -35*4
         \\    sw ra, 0(sp)
         \\    la ra, _interrupt26_handler
         \\    j trap_common
         \\interrupt27:
-        \\    addi sp, sp, -40*4
+        \\    addi sp, sp, -35*4
         \\    sw ra, 0(sp)
         \\    la ra, _interrupt27_handler
         \\    j trap_common
         \\interrupt28:
-        \\    addi sp, sp, -40*4
+        \\    addi sp, sp, -35*4
         \\    sw ra, 0(sp)
         \\    la ra, _interrupt28_handler
         \\    j trap_common
         \\interrupt29:
-        \\    addi sp, sp, -40*4
+        \\    addi sp, sp, -35*4
         \\    sw ra, 0(sp)
         \\    la ra, _interrupt29_handler
         \\    j trap_common
         \\interrupt30:
-        \\    addi sp, sp, -40*4
+        \\    addi sp, sp, -35*4
         \\    sw ra, 0(sp)
         \\    la ra, _interrupt30_handler
         \\    j trap_common
         \\interrupt31:
-        \\    addi sp, sp, -40*4
+        \\    addi sp, sp, -35*4
         \\    sw ra, 0(sp)
         \\    la ra, _interrupt31_handler
         \\    j trap_common
@@ -621,6 +621,8 @@ fn _vector_table() align(256) linksection(".trap") callconv(.naked) void {
         \\    sw s11, 27*4(sp)
         \\    sw gp, 28*4(sp)
         \\    sw tp, 29*4(sp)
+        \\    addi t1, sp, 35*4  # what sp was on entry to trap
+        \\    sw t1, 30*4(sp)
         \\    csrrs t1, mepc, x0
         \\    sw t1, 31*4(sp)
         \\    csrrs t1, mstatus, x0
@@ -630,22 +632,16 @@ fn _vector_table() align(256) linksection(".trap") callconv(.naked) void {
         \\    csrrs t1, mtval, x0
         \\    sw t1, 34*4(sp)
         \\
-        \\    addi s0, sp, 40*4
-        \\    sw s0, 30*4(sp)
+        \\    mv s0, ra       # Save address of handler function
         \\
-        \\    add a0, sp, zero
-        \\    addi sp, sp, -16 #build stack
-        \\    sw ra, 0(sp)
         \\    jal ra, _update_priority
-        \\    lw ra, 0(sp)
-        \\    sw a0, 0(sp) #reuse old stack, a0 is return of _handle_priority
-        \\    addi a0, sp, 16 #the proper stack pointer is an argument to the HAL handler
+        \\    mv s1, a0       # Save the return of _update_priority
         \\
-        \\    jalr ra, ra #jump to label loaded in _start_trapx
+        \\    mv a0, sp       # Pass a pointer to TrapFrame to the handler function
+        \\    jalr ra, s0     # Call the handler function
         \\
-        \\    lw a0, 0(sp) #load stored priority
+        \\    mv a0, s1       # Pass stored priority to _restore_priority
         \\    jal ra, _restore_priority
-        \\    addi sp, sp, 16 #pop
         \\
         \\    lw t1, 31*4(sp)
         \\    csrrw x0, mepc, t1
@@ -683,10 +679,9 @@ fn _vector_table() align(256) linksection(".trap") callconv(.naked) void {
         \\    lw s11, 27*4(sp)
         \\    lw gp, 28*4(sp)
         \\    lw tp, 29*4(sp)
-        \\    lw sp, 30*4(sp)
+        \\    lw sp, 30*4(sp) # This removes the frame we allocated from the stack
         \\
         \\    mret
-        \\
     );
 }
 


### PR DESCRIPTION
This makes the esp32 trap dispatch a bit more efficient.

The current version initially allocates a 160 byte stack frame (4*40) even though only 140 bytes (4*35) are used.   It then allocates an additional 16 bytes which are only used to preserve various values over function calls.

This change reduces the initial allocation to the required 140 bytes.  It eliminates the second 16 byte allocation entirely, using "s" registers to preserve values.  The "s" registers are themselves preserved by callconv(.c) functions.