### PR TITLE
drivers: Cleanup ICM-20948 driver

### DIFF
--- a/examples/nordic/nrf5x/src/i2c_accel.zig
+++ b/examples/nordic/nrf5x/src/i2c_accel.zig
@@ -57,30 +57,12 @@ pub fn main() !void {
     try dev.setup();
 
     while (true) {
-        //   DELETEME>>
-        const ag_data = try dev.get_accel_gyro_data();
-        std.log.info(
-            "accel: x {d: >8.2} y {d: >8.2} z {d: >8.2} " ++
-                "gyro: x {d: >8.2} y {d: >8.2} z {d: >8.2}",
-            .{ ag_data.accel.x, ag_data.accel.y, ag_data.accel.z, ag_data.gyro.x, ag_data.gyro.y, ag_data.gyro.z },
-        );
-
-        const temp_c = try dev.get_temp();
-        std.log.info("temp: {d: >5.2}°C", .{temp_c});
-
-        const mag_data = try dev.get_mag_data();
-        std.log.info(
-            "mag: x {d: >8.2}µT y {d: >8.2}µT z {d: >8.2}µT",
-            .{ mag_data.x, mag_data.y, mag_data.z },
-        );
-
-        //   DELETEME<<
         const data = try dev.get_accel_gyro_mag_data();
         std.log.info(
-            "accel: x {d: >6.2} y {d: >6.2} z {d: >6.2} " ++
-                "gyro: x {d: >6.2} y {d: >6.2} z {d: >6.2} " ++
-                "temp: {d: >5.2}°C" ++
-                "mag: x {d: >6.2}µT y {d: >6.2}µT z {d: >6.2}µT",
+            "accel: x {d: >6.2} y {d: >6.2} z {d: >6.2} (m/s²) " ++
+                "gyro: x {d: >6.2} y {d: >6.2} z {d: >6.2} (rads) " ++
+                "temp: {d: >5.2}°C " ++
+                "mag: x {d: >6.2} y {d: >6.2} z {d: >6.2} (µT)",
             .{ data.accel.x, data.accel.y, data.accel.z, data.gyro.x, data.gyro.y, data.gyro.z, data.temp, data.mag.x, data.mag.y, data.mag.z },
         );
 


### PR DESCRIPTION
I forgot to push a few changes to #591 before it was merged. Mostly just cleanup, but importantly it turns off `ACCEL_CYCLE`, which seems to need to be set to 0.

Before #591 I had a bug in how I set the bitfields for the LP_CONFIG register, which is why I suspect setting it to 1 was OK (it was actually setting another bit).