### PR TITLE
Fix deprecated tokenize->tokenizeAny in PIO assembler

### DIFF
--- a/port/raspberrypi/rp2xxx/src/hal/pio/assembler.zig
+++ b/port/raspberrypi/rp2xxx/src/hal/pio/assembler.zig
@@ -97,7 +97,7 @@ fn format_compile_error(comptime message: []const u8, comptime source: []const u
     var line_str: []const u8 = "";
     var line_num: u32 = 1;
     var column: u32 = 0;
-    var line_it = std.mem.tokenize(u8, source, "\n\r");
+    var line_it = std.mem.tokenizeAny(u8, source, "\n\r");
     while (line_it.next()) |line| : (line_num += 1) {
         line_str = line_str ++ "\n" ++ line;
         if (line_it.index >= index) {

--- a/port/raspberrypi/rp2xxx/src/hal/pio/assembler.zig
+++ b/port/raspberrypi/rp2xxx/src/hal/pio/assembler.zig
@@ -140,3 +140,26 @@ test "tokenizer and encoder" {
 test "comparison" {
     std.testing.refAllDecls(@import("assembler/comparison_tests.zig"));
 }
+
+test "assemble" {
+    // Test that the assembler can compile a simple program
+    // this also verifies that the assemble function can be compiled
+    _ = comptime assemble(.RP2040, ".program testprog", .{})
+        .get_program_by_name("testprog");
+}
+
+test "format compile error" {
+    const result = comptime format_compile_error(
+        "invalid instruction",
+        ".program testprog\n bad",
+        19,
+    );
+    try std.testing.expectEqualStrings(
+        \\failed to assemble PIO code:
+        \\
+        \\ bad
+        \\ ^
+        \\ invalid instruction
+        \\
+    , result);
+}

--- a/port/raspberrypi/rp2xxx/src/hal/pio/assembler/tokenizer.zig
+++ b/port/raspberrypi/rp2xxx/src/hal/pio/assembler/tokenizer.zig
@@ -2278,3 +2278,15 @@ test "tokenize.instr.comment with no whitespace" {
         .delay = .{ .expression = "1" },
     }, tokens.get(0));
 }
+
+test "format tokenizer" {
+    const test_tokenizer = Tokenizer(.RP2040).init("out 1");
+    const string = try std.fmt.allocPrint(std.testing.allocator, "{}", .{test_tokenizer});
+    defer std.testing.allocator.free(string);
+    try std.testing.expectEqualStrings(
+        \\parser:
+        \\  index: 0
+        \\
+        \\out 1
+    ++ "\n\x1b[30;42;1m^\x1b[0m\n", string);
+}

--- a/port/raspberrypi/rp2xxx/src/hal/pio/assembler/tokenizer.zig
+++ b/port/raspberrypi/rp2xxx/src/hal/pio/assembler/tokenizer.zig
@@ -2283,7 +2283,7 @@ test "format tokenizer" {
     const test_tokenizer = Tokenizer(.RP2040).init("out 1");
     const string = try std.fmt.allocPrint(std.testing.allocator, "{}", .{test_tokenizer});
     defer std.testing.allocator.free(string);
-    try std.testing.expectEqualStrings(
+    try expectEqualStrings(
         \\parser:
         \\  index: 0
         \\

--- a/port/raspberrypi/rp2xxx/src/hal/pio/assembler/tokenizer.zig
+++ b/port/raspberrypi/rp2xxx/src/hal/pio/assembler/tokenizer.zig
@@ -87,7 +87,7 @@ pub fn Tokenizer(chip: Chip) type {
             , .{self.index});
 
             var printed_cursor = false;
-            var line_it = std.mem.tokenize(u8, self.source, "\n\r");
+            var line_it = std.mem.tokenizeAny(u8, self.source, "\n\r");
             while (line_it.next()) |line| {
                 try writer.print("{s}\n", .{line});
                 if (!printed_cursor and line_it.index > self.index) {


### PR DESCRIPTION
std.memset.tokenize was deprecated in zig 0.14 https://ziglang.org/download/0.14.0/release-notes.html#List-of-Deprecations

The output when you get a PIO asm compile error still outputs a loot of whitespace before the error, but I'm not sure if something is wrong in the implementation or if this is intended:

```
/home/cortex/Projects/pixelmatrix/microzig/port/raspberrypi/rp2xxx/src/hal/pio/assembler.zig:129:13: error: failed to assemble PIO code:

                                                                                                                out pins 6 side 0 [1]
                                                                                                                ^
                                                                                                                .side_set directive must be specified for program to use side_set

            @compileError(format_compile_error(d.message.slice(), source, d.index));
            ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```