### PR TITLE
tools: Add printer tool

### DIFF
--- a/tools/printer/README.md
+++ b/tools/printer/README.md
@@ -1,0 +1,14 @@
+# Printer
+
+Printer is supposed to process logging output from your microzig code and show
+it in a readable format.
+
+## Features:
+- [x] pretty stack traces (similar to those of a non freestanding zig binary)
+- [ ] defmt support
+
+## Use it like a library!
+
+You can easily write a small zig script that flashes the device and then prints
+pretty logs to console on `zig build run`. Checkout
+[](examples/rp2xxx_runner.zig)

--- a/tools/printer/build.zig
+++ b/tools/printer/build.zig
@@ -1,0 +1,45 @@
+const std = @import("std");
+
+pub fn build(b: *std.Build) void {
+    const target = b.standardTargetOptions(.{});
+    const optimize = b.standardOptimizeOption(.{});
+
+    const serial_dep = b.dependency("serial", .{
+        .target = target,
+        .optimize = optimize,
+    });
+
+    const printer_mod = b.addModule("printer", .{
+        .root_source_file = b.path("src/root.zig"),
+        .target = target,
+        .optimize = optimize,
+    });
+
+    const printer_exe = b.addExecutable(.{
+        .name = "printer",
+        .root_module = b.createModule(.{
+            .root_source_file = b.path("src/main.zig"),
+            .imports = &.{
+                .{ .name = "printer", .module = printer_mod },
+                .{ .name = "serial", .module = serial_dep.module("serial") },
+            },
+            .target = target,
+            .optimize = optimize,
+        }),
+    });
+    b.installArtifact(printer_exe);
+
+    const example_exe = b.addExecutable(.{
+        .name = "rp2xxx_runner",
+        .root_module = b.createModule(.{
+            .root_source_file = b.path("examples/rp2xxx_runner.zig"),
+            .imports = &.{
+                .{ .name = "printer", .module = printer_mod },
+                .{ .name = "serial", .module = serial_dep.module("serial") },
+            },
+            .target = target,
+            .optimize = optimize,
+        }),
+    });
+    b.installArtifact(example_exe);
+}

--- a/tools/printer/build.zig.zon
+++ b/tools/printer/build.zig.zon
@@ -1,0 +1,19 @@
+.{
+    .name = .tools_printer,
+    .version = "0.0.0",
+    .fingerprint = 0x72009d00e5692d30,
+    .minimum_zig_version = "0.14.1",
+    .dependencies = .{
+        .serial = .{
+            .url = "git+https://github.com/ZigEmbeddedGroup/serial#ad338133eda8d86332718bbdc58c641a66307c84",
+            .hash = "serial-0.0.1-PoeRzI20AABcp4FffI6HXKOL6LcGPKmeqfN4Bna4-YYm",
+        },
+    },
+    .paths = .{
+        "build.zig",
+        "build.zig.zon",
+        "README.md",
+        "src",
+        "examples",
+    },
+}

--- a/tools/printer/examples/rp2xxx_runner.zig
+++ b/tools/printer/examples/rp2xxx_runner.zig
@@ -1,0 +1,64 @@
+const std = @import("std");
+const printer = @import("printer");
+const serial = @import("serial");
+
+pub fn main() !void {
+    var debug_allocator: std.heap.DebugAllocator(.{}) = .init;
+    defer _ = debug_allocator.deinit();
+    const allocator = debug_allocator.allocator();
+
+    const args = try std.process.argsAlloc(allocator);
+    defer std.process.argsFree(allocator, args);
+
+    if (args.len != 4) return error.UsageError;
+
+    const elf_path = args[1];
+    const serial_device_path = args[2];
+    const baud_rate = try std.fmt.parseInt(u32, args[3], 10);
+
+    const elf_file = try std.fs.cwd().openFile(elf_path, .{});
+    defer elf_file.close();
+
+    var elf = try printer.Elf.init(allocator, elf_file);
+    defer elf.deinit(allocator);
+
+    var debug_info = try printer.DebugInfo.init(allocator, elf);
+    defer debug_info.deinit(allocator);
+
+    var annotator: printer.Annotator = .init;
+
+    const serial_device = try std.fs.cwd().openFile(serial_device_path, .{});
+    defer serial_device.close();
+    try serial.configureSerialPort(serial_device, .{
+        .baud_rate = baud_rate,
+    });
+    try serial.flushSerialPort(serial_device, .both);
+
+    {
+        var flash_cmd: std.process.Child = .init(&.{
+            "picotool",
+            "load",
+            "-u",
+            "-v",
+            "-x",
+            "-t",
+            "elf",
+            elf_path,
+        }, allocator);
+        const term = try flash_cmd.spawnAndWait();
+        switch (term) {
+            .Exited => |code| if (code != 0) return error.FlashCommandFailed,
+            else => {},
+        }
+    }
+
+    const stdout = std.io.getStdOut();
+    const out_stream = stdout.writer();
+    const out_tty_config = std.io.tty.detectConfig(stdout);
+
+    var buf: [4096]u8 = undefined;
+    while (true) {
+        const n = try serial_device.read(&buf);
+        try annotator.process(allocator, buf[0..n], elf, &debug_info, out_stream, out_tty_config);
+    }
+}

--- a/tools/printer/src/DebugInfo.zig
+++ b/tools/printer/src/DebugInfo.zig
@@ -1,0 +1,794 @@
+const std = @import("std");
+const dwarf = std.dwarf;
+const ArrayListUnmanaged = std.ArrayListUnmanaged;
+const Elf = @import("Elf.zig");
+
+const DebugInfo = @This();
+
+directories: []const []const u8,
+files: []const File,
+loc_list: []const SourceLocation,
+compile_unit_names: []const []const u8,
+functions: []const Function,
+
+pub const File = struct {
+    path: []const u8,
+    dir_index: usize,
+};
+
+pub const SourceLocation = struct {
+    address: u64,
+    line: u32,
+    column: u32,
+    file_index: usize,
+};
+
+pub const Function = struct {
+    name: ?[]const u8,
+    cu_index: usize,
+    start_address: u64,
+    end_address: u64,
+};
+
+pub fn init(allocator: std.mem.Allocator, elf: Elf) !DebugInfo {
+    var arena_allocator: std.heap.ArenaAllocator = .init(allocator);
+    defer arena_allocator.deinit();
+
+    var parser: Parser = .{ .arena = arena_allocator.allocator() };
+    try parser.parse_elf(elf);
+
+    const directories = try allocator.dupe([]const u8, parser.directories.items);
+    errdefer allocator.free(directories);
+
+    const files = try allocator.dupe(File, parser.files.items);
+    errdefer allocator.free(files);
+
+    const loc_list = try allocator.dupe(SourceLocation, parser.loc_list.items);
+    errdefer allocator.free(loc_list);
+
+    const compile_unit_names = try allocator.dupe([]const u8, parser.compile_unit_names.items);
+    errdefer allocator.free(compile_unit_names);
+
+    const functions = try allocator.dupe(Function, parser.functions.items);
+    errdefer allocator.free(functions);
+
+    return .{
+        .directories = directories,
+        .files = files,
+        .loc_list = loc_list,
+        .compile_unit_names = compile_unit_names,
+        .functions = functions,
+    };
+}
+
+pub fn deinit(self: *DebugInfo, allocator: std.mem.Allocator) void {
+    allocator.free(self.directories);
+    allocator.free(self.files);
+    allocator.free(self.loc_list);
+    allocator.free(self.compile_unit_names);
+    allocator.free(self.functions);
+}
+
+/// The `file_path` field has the same lifetime as `DebugInfo`.
+pub const QueryResult = struct {
+    line: ?u32 = null,
+    column: ?u32 = null,
+    file_path: ?[]const u8 = null,
+    function_name: ?[]const u8 = null,
+    module_name: ?[]const u8 = null,
+};
+
+/// Caller must free file_path if present in `QueryResult`.
+pub fn query(self: *DebugInfo, allocator: std.mem.Allocator, address: u64) !QueryResult {
+    var result: QueryResult = .{};
+
+    const index = std.sort.upperBound(SourceLocation, self.loc_list, address, struct {
+        pub fn compare(ctx: usize, item: SourceLocation) std.math.Order {
+            return std.math.order(ctx, item.address);
+        }
+    }.compare);
+
+    if (index == 0 or index != self.loc_list.len) {
+        const src_loc = self.loc_list[index - 1];
+        const file = &self.files[src_loc.file_index];
+        const dir_path = self.directories[file.dir_index];
+
+        result.line = src_loc.line;
+        result.column = src_loc.column;
+        result.file_path = try std.fs.path.join(allocator, &.{ dir_path, file.path });
+    }
+
+    for (self.functions) |function| {
+        if (address >= function.start_address and address <= function.end_address) {
+            result.function_name = function.name;
+            result.module_name = self.compile_unit_names[function.cu_index];
+            break;
+        }
+    }
+
+    return result;
+}
+
+// Implementation heavly based on `std.debug.Dwarf` but should support any
+// target (even 64 bit architectures).
+
+const Parser = struct {
+    arena: std.mem.Allocator,
+    directories: ArrayListUnmanaged([]const u8) = .empty,
+    files: ArrayListUnmanaged(File) = .empty,
+    loc_list: ArrayListUnmanaged(SourceLocation) = .empty,
+    compile_unit_names: ArrayListUnmanaged([]const u8) = .empty,
+    functions: ArrayListUnmanaged(Function) = .empty,
+
+    fn parse_elf(self: *Parser, elf: Elf) !void {
+        const data = elf.sections.get(.@".debug_info") orelse return bad();
+        var reader: std.debug.FixedBufferReader = .{
+            .buf = data,
+            .endian = .little,
+        };
+
+        var current_cu_index: ?usize = null;
+
+        while (reader.pos < data.len) {
+            var length: u64 = try reader.readInt(u32);
+            var dwarf_format: dwarf.Format = .@"32";
+
+            if (length == std.math.maxInt(u32)) {
+                length = try reader.readInt(u64);
+                dwarf_format = .@"64";
+            }
+
+            const version = try reader.readInt(u16);
+
+            var address_size: u8 = 0;
+            var abbrev_table_offset: u64 = 0;
+            if (version >= 5) {
+                const unit_type = try reader.readByte();
+                if (unit_type != dwarf.UT.compile) return bad();
+
+                address_size = try reader.readByte();
+                abbrev_table_offset = try reader.readAddress(dwarf_format);
+            } else {
+                abbrev_table_offset = try reader.readAddress(dwarf_format);
+                address_size = try reader.readByte();
+            }
+
+            var abbrev_table = try self.get_abbrev_table(elf.sections, abbrev_table_offset);
+
+            var depth: usize = 0;
+            while (true) {
+                const abbrev_code = try reader.readUleb128(u64);
+                if (abbrev_code == 0) {
+                    if (depth == 1) {
+                        break;
+                    }
+                    depth -= 1;
+                    continue;
+                }
+
+                const abbrev_decl = abbrev_table.get(abbrev_code) orelse return bad();
+
+                var parsed_attribs: std.AutoHashMapUnmanaged(u64, FormValue) = .empty;
+                for (abbrev_decl.attrs) |attr| {
+                    const form_value = try FormValue.parse(
+                        &reader,
+                        attr.form_id,
+                        elf.format,
+                        dwarf_format,
+                        attr.implicit_const_val,
+                    );
+                    try parsed_attribs.put(self.arena, attr.id, form_value);
+                }
+
+                const TAG = dwarf.TAG;
+                switch (abbrev_decl.tag) {
+                    TAG.compile_unit => {
+                        // register current compile unit
+                        const name_attrib = parsed_attribs.get(dwarf.AT.name) orelse return bad();
+
+                        current_cu_index = self.compile_unit_names.items.len;
+                        try self.compile_unit_names.append(
+                            self.arena,
+                            try name_attrib.get_string(elf.sections),
+                        );
+
+                        // parse line number info
+                        const stmt_list_attrib = parsed_attribs.get(dwarf.AT.stmt_list) orelse return bad();
+                        const cu_cwd_attrib = parsed_attribs.get(dwarf.AT.comp_dir) orelse return bad();
+
+                        try self.parse_line_number_info(
+                            elf,
+                            try stmt_list_attrib.get_sec_offset(),
+                            try cu_cwd_attrib.get_string(elf.sections),
+                        );
+                    },
+                    TAG.subprogram, TAG.inlined_subroutine, TAG.entry_point => {
+                        // in `std.debug.Dwarf` they do more complicated things to
+                        // get the name if it isn't specified
+
+                        const maybe_name_attrib = parsed_attribs.get(dwarf.AT.name);
+
+                        if (parsed_attribs.get(dwarf.AT.low_pc)) |low_pc_attrib| {
+                            const low_pc_address = switch (low_pc_attrib) {
+                                .addr => |addr| addr,
+                                else => return bad(),
+                            };
+
+                            if (parsed_attribs.get(dwarf.AT.high_pc)) |high_pc_attrib| {
+                                const high_pc_address = switch (high_pc_attrib) {
+                                    .addr => |addr| addr,
+                                    .udata => |offset| low_pc_address + offset,
+                                    else => return bad(),
+                                };
+
+                                try self.functions.append(self.arena, .{
+                                    .name = if (maybe_name_attrib) |name_attrib| try name_attrib.get_string(elf.sections) else null,
+                                    .cu_index = current_cu_index orelse return bad(),
+                                    .start_address = low_pc_address,
+                                    .end_address = high_pc_address,
+                                });
+                            }
+                        } else {
+                            // TODO: should use `ranges` attribute
+                        }
+                    },
+                    else => {},
+                }
+
+                if (abbrev_decl.has_children) {
+                    depth += 1;
+                }
+            }
+        }
+
+        std.mem.sortUnstable(SourceLocation, self.loc_list.items, {}, struct {
+            pub fn less_than(_: void, lhs: SourceLocation, rhs: SourceLocation) bool {
+                return lhs.address < rhs.address;
+            }
+        }.less_than);
+    }
+
+    fn get_abbrev_table(self: *Parser, sections: Elf.Sections, offset: usize) !AbbrevTable {
+        var reader: std.debug.FixedBufferReader = .{
+            .buf = sections.get(.@".debug_abbrev") orelse return bad(),
+            .pos = offset,
+            .endian = .little,
+        };
+
+        var abbrev_table: std.AutoHashMapUnmanaged(u64, AbbrevDecl) = .empty;
+
+        while (true) {
+            const code = try reader.readUleb128(u64);
+            if (code == 0) {
+                break;
+            }
+
+            const tag = try reader.readUleb128(u64);
+            const has_children = try reader.readByte();
+
+            var attrs: ArrayListUnmanaged(AbbrevDecl.Attrib) = .empty;
+
+            while (true) {
+                const id = try reader.readUleb128(u64);
+                const form_id = try reader.readUleb128(u64);
+                if (id == 0 and form_id == 0) {
+                    break;
+                }
+
+                var implicit_const_val: ?i64 = null;
+                if (form_id == dwarf.FORM.implicit_const) {
+                    implicit_const_val = try reader.readIleb128(i64);
+                }
+
+                try attrs.append(self.arena, .{
+                    .id = id,
+                    .form_id = form_id,
+                    .implicit_const_val = implicit_const_val,
+                });
+            }
+
+            try abbrev_table.put(self.arena, code, .{
+                .tag = tag,
+                .has_children = has_children != 0,
+                .attrs = try attrs.toOwnedSlice(self.arena),
+            });
+        }
+
+        return abbrev_table;
+    }
+
+    const AbbrevDecl = struct {
+        tag: u64,
+        has_children: bool,
+        attrs: []const Attrib,
+
+        const Attrib = struct {
+            id: u64,
+            form_id: u64,
+            implicit_const_val: ?i64,
+        };
+    };
+
+    const AbbrevTable = std.AutoHashMapUnmanaged(u64, AbbrevDecl);
+
+    fn parse_line_number_info(
+        self: *Parser,
+        elf: Elf,
+        offset: usize,
+        cu_cwd: []const u8,
+    ) !void {
+        var reader: std.debug.FixedBufferReader = .{
+            .buf = elf.sections.get(.@".debug_line") orelse return bad(),
+            .pos = offset,
+            .endian = .little,
+        };
+
+        var unit_length: u64 = try reader.readInt(u32);
+        var dwarf_format: dwarf.Format = .@"32";
+        if (unit_length == std.math.maxInt(u32)) {
+            unit_length = try reader.readInt(u64);
+            dwarf_format = .@"64";
+        }
+        if (unit_length == 0) {
+            return;
+        }
+
+        const next_unit_offset = reader.pos + unit_length;
+
+        const version = try reader.readInt(u16);
+        if (version < 2) return bad();
+
+        if (version >= 5) {
+            _ = try reader.readByte(); // address size
+            _ = try reader.readByte(); // segment size
+        }
+
+        const prologue_length = try reader.readAddress(dwarf_format);
+        const prog_start_offset = reader.pos + prologue_length;
+
+        const minimum_instruction_length = try reader.readByte();
+        if (minimum_instruction_length == 0) return bad();
+
+        if (version >= 4) {
+            _ = try reader.readByte();
+        }
+
+        const default_is_stmt = (try reader.readByte()) != 0;
+        const line_base = try reader.readByteSigned();
+
+        const line_range = try reader.readByte();
+        if (line_range == 0) return bad();
+
+        const opcode_base = try reader.readByte();
+
+        const standard_opcode_lengths = try reader.readBytes(opcode_base - 1);
+
+        const dir_index_offset = self.directories.items.len;
+        const file_index_offset = self.files.items.len;
+
+        if (version < 5) {
+            try self.directories.append(self.arena, cu_cwd);
+
+            while (true) {
+                const dir = try reader.readBytesTo(0);
+                if (dir.len == 0) break;
+                try self.directories.append(self.arena, dir);
+            }
+
+            while (true) {
+                const file_name = try reader.readBytesTo(0);
+                if (file_name.len == 0) break;
+                const dir_index = try reader.readUleb128(usize);
+                _ = try reader.readUleb128(u64); // timestamp
+                _ = try reader.readUleb128(u64); // size
+                try self.files.append(self.arena, .{
+                    .path = file_name,
+                    .dir_index = dir_index_offset + dir_index,
+                    // .timestamp = timestamp,
+                });
+            }
+        } else {
+            const LNCT = dwarf.LNCT;
+
+            const FileEntFmt = struct {
+                content_type_code: u16,
+                form_code: u16,
+            };
+
+            {
+                const directory_entry_format_count = try reader.readByte();
+                const dir_ent_fmt_buf = try self.arena.alloc(FileEntFmt, directory_entry_format_count);
+
+                for (dir_ent_fmt_buf[0..directory_entry_format_count]) |*ent_fmt| {
+                    ent_fmt.* = .{
+                        .content_type_code = try reader.readUleb128(u8),
+                        .form_code = try reader.readUleb128(u16),
+                    };
+                }
+
+                const directories_count = try reader.readUleb128(usize);
+
+                for (try self.directories.addManyAsSlice(self.arena, directories_count)) |*e| {
+                    e.* = &.{};
+                    for (dir_ent_fmt_buf[0..directory_entry_format_count]) |ent_fmt| {
+                        const form_value = try FormValue.parse(
+                            &reader,
+                            ent_fmt.form_code,
+                            elf.format,
+                            dwarf_format,
+                            null,
+                        );
+
+                        switch (ent_fmt.content_type_code) {
+                            LNCT.path => e.* = try form_value.get_string(elf.sections),
+                            else => continue,
+                        }
+                    }
+                }
+            }
+
+            {
+                const file_entry_format_count = try reader.readByte();
+                const file_ent_fmt_buf = try self.arena.alloc(FileEntFmt, file_entry_format_count);
+
+                for (file_ent_fmt_buf[0..file_entry_format_count]) |*ent_fmt| {
+                    ent_fmt.* = .{
+                        .content_type_code = try reader.readUleb128(u16),
+                        .form_code = try reader.readUleb128(u16),
+                    };
+                }
+
+                const file_names_count = try reader.readUleb128(usize);
+
+                for (try self.files.addManyAsSlice(self.arena, file_names_count)) |*e| {
+                    e.* = .{ .path = &.{}, .dir_index = 0 };
+                    for (file_ent_fmt_buf[0..file_entry_format_count]) |ent_fmt| {
+                        const form_value = try FormValue.parse(
+                            &reader,
+                            ent_fmt.form_code,
+                            elf.format,
+                            dwarf_format,
+                            null,
+                        );
+                        switch (ent_fmt.content_type_code) {
+                            LNCT.path => e.path = try form_value.get_string(elf.sections),
+                            LNCT.directory_index => e.dir_index = dir_index_offset + try form_value.get_uint(usize),
+                            // LNCT.timestamp => e.timestamp = try form_value.get_uint(u64),
+                            // LNCT.MD5 => e.md5 = switch (form_value) {
+                            //     .data16 => |data16| data16.*,
+                            //     else => return bad(),
+                            // },
+                            else => continue,
+                        }
+                    }
+                }
+            }
+        }
+
+        var prog = LineNumberProgram.init(default_is_stmt, version);
+
+        try reader.seekTo(prog_start_offset);
+
+        const LNE = dwarf.LNE;
+        const LNS = dwarf.LNS;
+
+        while (reader.pos < next_unit_offset) {
+            const opcode = try reader.readByte();
+
+            if (opcode == LNS.extended_op) {
+                const op_size = try reader.readUleb128(u64);
+                if (op_size < 1) return bad();
+                const sub_op = try reader.readByte();
+                switch (sub_op) {
+                    LNE.end_sequence => {
+                        // The row being added here is an "end" address, meaning
+                        // that it does not map to the source location here -
+                        // rather it marks the previous address as the last address
+                        // that maps to this source location.
+
+                        // In this implementation we don't mark end of addresses.
+                        // This is a performance optimization based on the fact
+                        // that we don't need to know if an address is missing
+                        // source location info; we are only interested in being
+                        // able to look up source location info for addresses that
+                        // are known to have debug info.
+                        prog.reset();
+                    },
+                    LNE.set_address => {
+                        const addr = switch (elf.format) {
+                            .@"32" => try reader.readInt(u32),
+                            .@"64" => try reader.readInt(u64),
+                        };
+                        prog.address = addr;
+                    },
+                    LNE.define_file => {
+                        const path = try reader.readBytesTo(0);
+                        const dir_index = try reader.readUleb128(usize);
+                        _ = try reader.readUleb128(u64);
+                        _ = try reader.readUleb128(u64);
+                        try self.files.append(self.arena, .{
+                            .path = path,
+                            .dir_index = dir_index_offset + dir_index,
+                            // .timestamp = timestamp,
+                        });
+                    },
+                    else => try reader.seekForward(op_size - 1),
+                }
+            } else if (opcode >= opcode_base) {
+                // special opcodes
+                const adjusted_opcode = opcode - opcode_base;
+                const inc_addr = minimum_instruction_length * (adjusted_opcode / line_range);
+                const inc_line = @as(i32, line_base) + @as(i32, adjusted_opcode % line_range);
+                prog.line += inc_line;
+                prog.address += inc_addr;
+                try prog.add_row(self, elf, file_index_offset);
+                prog.basic_block = false;
+            } else {
+                switch (opcode) {
+                    LNS.copy => {
+                        try prog.add_row(self, elf, file_index_offset);
+                        prog.basic_block = false;
+                    },
+                    LNS.advance_pc => {
+                        const arg = try reader.readUleb128(usize);
+                        prog.address += arg * minimum_instruction_length;
+                    },
+                    LNS.advance_line => {
+                        const arg = try reader.readIleb128(i64);
+                        prog.line += arg;
+                    },
+                    LNS.set_file => {
+                        const arg = try reader.readUleb128(usize);
+                        prog.file = arg;
+                    },
+                    LNS.set_column => {
+                        const arg = try reader.readUleb128(u64);
+                        prog.column = arg;
+                    },
+                    LNS.negate_stmt => {
+                        prog.is_stmt = !prog.is_stmt;
+                    },
+                    LNS.set_basic_block => {
+                        prog.basic_block = true;
+                    },
+                    LNS.const_add_pc => {
+                        const inc_addr = minimum_instruction_length * ((255 - opcode_base) / line_range);
+                        prog.address += inc_addr;
+                    },
+                    LNS.fixed_advance_pc => {
+                        const arg = try reader.readInt(u16);
+                        prog.address += arg;
+                    },
+                    LNS.set_prologue_end => {},
+                    else => {
+                        if (opcode - 1 >= standard_opcode_lengths.len) return bad();
+                        try reader.seekForward(standard_opcode_lengths[opcode - 1]);
+                    },
+                }
+            }
+        }
+    }
+
+    const LineNumberProgram = struct {
+        address: u64,
+        file: usize,
+        line: i64,
+        column: u64,
+        version: u16,
+        is_stmt: bool,
+        basic_block: bool,
+
+        default_is_stmt: bool,
+
+        // Reset the state machine following the DWARF specification
+        fn reset(self: *LineNumberProgram) void {
+            self.address = 0;
+            self.file = 1;
+            self.line = 1;
+            self.column = 0;
+            self.is_stmt = self.default_is_stmt;
+            self.basic_block = false;
+        }
+
+        fn init(is_stmt: bool, version: u16) LineNumberProgram {
+            return .{
+                .address = 0,
+                .file = 1,
+                .line = 1,
+                .column = 0,
+                .version = version,
+                .is_stmt = is_stmt,
+                .basic_block = false,
+                .default_is_stmt = is_stmt,
+            };
+        }
+
+        fn add_row(
+            prog: *LineNumberProgram,
+            parser: *Parser,
+            elf: Elf,
+            index_offset: usize,
+        ) !void {
+            if (prog.line == 0) {
+                return;
+            }
+
+            if (!elf.is_address_executable(prog.address)) {
+                return;
+            }
+
+            try parser.loc_list.append(parser.arena, .{
+                .address = prog.address,
+                .line = std.math.cast(u32, prog.line) orelse return bad(),
+                .column = std.math.cast(u32, prog.column) orelse return bad(),
+                .file_index = index_offset + (std.math.cast(
+                    usize,
+                    if (prog.version < 5) prog.file -| 1 else prog.file,
+                ) orelse return bad()),
+            });
+        }
+    };
+
+    const FormValue = union(enum) {
+        addr: u64,
+        addrx: u64,
+        block: []const u8,
+        udata: u64,
+        data16: *const [16]u8,
+        sdata: i64,
+        exprloc: []const u8,
+        flag: bool,
+        sec_offset: u64,
+        ref: u64,
+        ref_addr: u64,
+        string: [:0]const u8,
+        strp: u64,
+        strx: u64,
+        line_strp: u64,
+        loclistx: u64,
+        rnglistx: u64,
+
+        fn parse(
+            reader: anytype,
+            form_id: u64,
+            elf_format: Elf.Format,
+            dwarf_format: dwarf.Format,
+            implicit_const_val: ?i64,
+        ) !FormValue {
+            const FORM = dwarf.FORM;
+
+            // TODO: check the use of `readAddress`
+            return switch (form_id) {
+                FORM.addr => .{ .addr = switch (elf_format) {
+                    .@"32" => try reader.readInt(u32),
+                    .@"64" => try reader.readInt(u64),
+                } },
+                FORM.addrx1 => .{ .addrx = try reader.readInt(u8) },
+                FORM.addrx2 => .{ .addrx = try reader.readInt(u16) },
+                FORM.addrx3 => .{ .addrx = try reader.readInt(u24) },
+                FORM.addrx4 => .{ .addrx = try reader.readInt(u32) },
+                FORM.addrx => .{ .addrx = try reader.readUleb128(u64) },
+
+                FORM.block1,
+                FORM.block2,
+                FORM.block4,
+                FORM.block,
+                => .{ .block = try reader.readBytes(switch (form_id) {
+                    FORM.block1 => try reader.readInt(u8),
+                    FORM.block2 => try reader.readInt(u16),
+                    FORM.block4 => try reader.readInt(u32),
+                    FORM.block => try reader.readUleb128(u64),
+                    else => unreachable,
+                }) },
+
+                FORM.data1 => .{ .udata = try reader.readInt(u8) },
+                FORM.data2 => .{ .udata = try reader.readInt(u16) },
+                FORM.data4 => .{ .udata = try reader.readInt(u32) },
+                FORM.data8 => .{ .udata = try reader.readInt(u64) },
+                FORM.data16 => .{ .data16 = (try reader.readBytes(16))[0..16] },
+                FORM.udata => .{ .udata = try reader.readUleb128(u64) },
+                FORM.sdata => .{ .sdata = try reader.readIleb128(i64) },
+                FORM.exprloc => .{ .exprloc = try reader.readBytes(try reader.readUleb128(u64)) },
+                FORM.flag => .{ .flag = (try reader.readByte()) != 0 },
+                FORM.flag_present => .{ .flag = true },
+                FORM.sec_offset => .{ .sec_offset = try reader.readAddress(dwarf_format) },
+
+                FORM.ref1 => .{ .ref = try reader.readInt(u8) },
+                FORM.ref2 => .{ .ref = try reader.readInt(u16) },
+                FORM.ref4 => .{ .ref = try reader.readInt(u32) },
+                FORM.ref8 => .{ .ref = try reader.readInt(u64) },
+                FORM.ref_udata => .{ .ref = try reader.readUleb128(u64) },
+
+                FORM.ref_addr => .{ .ref_addr = try reader.readAddress(dwarf_format) },
+                FORM.ref_sig8 => .{ .ref = try reader.readInt(u64) },
+
+                FORM.string => .{ .string = try reader.readBytesTo(0) },
+                FORM.strp => .{ .strp = try reader.readAddress(dwarf_format) },
+                FORM.strx1 => .{ .strx = try reader.readInt(u8) },
+                FORM.strx2 => .{ .strx = try reader.readInt(u16) },
+                FORM.strx3 => .{ .strx = try reader.readInt(u24) },
+                FORM.strx4 => .{ .strx = try reader.readInt(u32) },
+                FORM.strx => .{ .strx = try reader.readUleb128(u64) },
+                FORM.line_strp => .{ .line_strp = try reader.readAddress(dwarf_format) },
+                FORM.implicit_const => .{ .sdata = implicit_const_val orelse return bad() },
+                FORM.loclistx => .{ .loclistx = try reader.readUleb128(u64) },
+                FORM.rnglistx => .{ .rnglistx = try reader.readUleb128(u64) },
+                else => {
+                    std.log.err("unimplemented form id: 0x{x}", .{form_id});
+                    return unimplemented();
+                },
+            };
+        }
+
+        fn get_string(
+            self: FormValue,
+            sections: Elf.Sections,
+        ) ![]const u8 {
+            switch (self) {
+                .string => |value| return value,
+                .strp => |offset| {
+                    const data = sections.get(.@".debug_str") orelse return bad();
+                    var reader: std.debug.FixedBufferReader = .{
+                        .buf = data[offset..],
+                        .endian = .little,
+                    };
+                    return try reader.readBytesTo(0);
+                },
+                .line_strp => |offset| {
+                    const data = sections.get(.@".debug_line_str") orelse return bad();
+                    var reader: std.debug.FixedBufferReader = .{
+                        .buf = data[offset..],
+                        .endian = .little,
+                    };
+                    return try reader.readBytesTo(0);
+                },
+                .strx => |index| {
+                    _ = index;
+                    // const debug_str_offsets = di.section(.debug_str_offsets) orelse return bad();
+                    // if (compile_unit.str_offsets_base == 0) return bad();
+                    // switch (compile_unit.format) {
+                    //     .@"32" => {
+                    //         const byte_offset = compile_unit.str_offsets_base + 4 * index;
+                    //         if (byte_offset + 4 > debug_str_offsets.len) return bad();
+                    //         const offset = mem.readInt(u32, debug_str_offsets[byte_offset..][0..4], di.endian);
+                    //         return getStringGeneric(opt_str, offset);
+                    //     },
+                    //     .@"64" => {
+                    //         const byte_offset = compile_unit.str_offsets_base + 8 * index;
+                    //         if (byte_offset + 8 > debug_str_offsets.len) return bad();
+                    //         const offset = mem.readInt(u64, debug_str_offsets[byte_offset..][0..8], di.endian);
+                    //         return getStringGeneric(opt_str, offset);
+                    //     },
+                    // }
+                    return unimplemented();
+                },
+                else => return bad(),
+            }
+        }
+
+        fn get_sec_offset(self: FormValue) !u64 {
+            switch (self) {
+                .sec_offset => return self.sec_offset,
+                else => return bad(),
+            }
+        }
+
+        fn get_uint(fv: FormValue, comptime U: type) !U {
+            return switch (fv) {
+                inline .udata,
+                .sdata,
+                .sec_offset,
+                => |c| std.math.cast(U, c) orelse bad(),
+                else => bad(),
+            };
+        }
+    };
+};
+
+fn bad() error{InvalidDebugInfo} {
+    return error.InvalidDebugInfo;
+}
+
+fn unimplemented() error{Unimplemented} {
+    return error.Unimplemented;
+}

--- a/tools/printer/src/Elf.zig
+++ b/tools/printer/src/Elf.zig
@@ -1,0 +1,149 @@
+const std = @import("std");
+
+const Elf = @This();
+
+format: Format,
+sections: Sections,
+loaded_regions: []const Region,
+
+pub const Format = enum {
+    @"32",
+    @"64",
+};
+
+pub const Sections = std.EnumMap(SectionTypes, []const u8);
+
+pub const SectionTypes = enum {
+    @".debug_info",
+    @".debug_abbrev",
+    @".debug_str",
+    @".debug_line_str",
+    @".debug_line",
+    @".debug_ranges",
+};
+
+pub const Region = struct {
+    start_address: usize,
+    end_address: usize,
+    flags: Flags,
+
+    pub const Flags = packed struct {
+        read: bool,
+        write: bool,
+        exec: bool,
+    };
+};
+
+pub fn init(allocator: std.mem.Allocator, source: anytype) !Elf {
+    var elf_header = try std.elf.Header.read(source);
+
+    const format: Format = if (elf_header.is_64) .@"64" else .@"32";
+
+    const string_table_data = blk: {
+        var shdr: std.elf.Elf64_Shdr = undefined;
+        if (format == .@"32") {
+            var shdr32: std.elf.Elf32_Shdr = undefined;
+            const offset = elf_header.shoff + @sizeOf(std.elf.Elf32_Shdr) * elf_header.shstrndx;
+            try source.seekableStream().seekTo(offset);
+            try source.reader().readNoEof(std.mem.asBytes(&shdr32));
+
+            shdr = .{
+                .sh_name = shdr32.sh_name,
+                .sh_type = shdr32.sh_type,
+                .sh_flags = shdr32.sh_flags,
+                .sh_addr = shdr32.sh_addr,
+                .sh_offset = shdr32.sh_offset,
+                .sh_size = shdr32.sh_size,
+                .sh_link = shdr32.sh_link,
+                .sh_info = shdr32.sh_info,
+                .sh_addralign = shdr32.sh_addralign,
+                .sh_entsize = shdr32.sh_entsize,
+            };
+        } else {
+            const offset = elf_header.shoff + @sizeOf(std.elf.Elf64_Shdr) * elf_header.shstrndx;
+            try source.seekableStream().seekTo(offset);
+            try source.reader().readNoEof(std.mem.asBytes(&shdr));
+        }
+
+        const section_data = try allocator.alloc(u8, shdr.sh_size);
+        errdefer allocator.free(section_data);
+
+        try source.seekableStream().seekTo(shdr.sh_offset);
+        try source.reader().readNoEof(section_data);
+
+        break :blk section_data;
+    };
+    defer allocator.free(string_table_data);
+
+    var sections: Sections = .{};
+    errdefer {
+        var it = sections.iterator();
+        while (it.next()) |entry| {
+            allocator.free(entry.value.*);
+        }
+    }
+
+    var section_header_it = elf_header.section_header_iterator(source);
+    while (try section_header_it.next()) |shdr| {
+        const name = std.mem.span(@as([*:0]const u8, @ptrCast(string_table_data[shdr.sh_name..])));
+        inline for (@typeInfo(SectionTypes).@"enum".fields) |section_field| {
+            if (std.mem.eql(u8, name, section_field.name)) {
+                const section_data = try allocator.alloc(u8, shdr.sh_size);
+                errdefer allocator.free(section_data);
+
+                try source.seekableStream().seekTo(shdr.sh_offset);
+                try source.reader().readNoEof(section_data);
+
+                sections.put(@enumFromInt(section_field.value), section_data);
+            }
+        }
+    }
+
+    var loaded_regions: std.ArrayListUnmanaged(Region) = .empty;
+    defer loaded_regions.deinit(allocator);
+
+    var program_header_iterator = elf_header.program_header_iterator(source);
+    while (try program_header_iterator.next()) |phdr| {
+        if (phdr.p_type != std.elf.PT_LOAD) continue;
+
+        try loaded_regions.append(allocator, .{
+            .start_address = phdr.p_vaddr,
+            .end_address = phdr.p_vaddr + phdr.p_memsz,
+            .flags = .{
+                .read = phdr.p_flags & std.elf.PF_R != 0,
+                .write = phdr.p_flags & std.elf.PF_W != 0,
+                .exec = phdr.p_flags & std.elf.PF_X != 0,
+            },
+        });
+    }
+
+    return .{
+        .format = format,
+        .sections = sections,
+        .loaded_regions = try loaded_regions.toOwnedSlice(allocator),
+    };
+}
+
+pub fn deinit(self: *Elf, allocator: std.mem.Allocator) void {
+    var it = self.sections.iterator();
+    while (it.next()) |entry| {
+        allocator.free(entry.value.*);
+    }
+
+    allocator.free(self.loaded_regions);
+}
+
+pub fn is_address_executable(self: Elf, address: u64) bool {
+    var inside_memory_map = false;
+    for (self.loaded_regions) |region| {
+        if (!region.flags.exec) {
+            continue;
+        }
+
+        if (address >= region.start_address and address < region.end_address) {
+            inside_memory_map = true;
+            break;
+        }
+    }
+    return inside_memory_map;
+}

--- a/tools/printer/src/main.zig
+++ b/tools/printer/src/main.zig
@@ -1,0 +1,56 @@
+const std = @import("std");
+const printer = @import("printer");
+const Elf = printer.Elf;
+const DebugInfo = printer.DebugInfo;
+const Annotator = printer.Annotator;
+
+pub fn main() !void {
+    var debug_allocator: std.heap.DebugAllocator(.{}) = .init;
+    defer _ = debug_allocator.deinit();
+    const allocator = debug_allocator.allocator();
+
+    const args = try std.process.argsAlloc(allocator);
+    defer std.process.argsFree(allocator, args);
+
+    if (args.len <= 1) {
+        return error.UsageError;
+    }
+
+    const elf_file = try std.fs.cwd().openFile(args[1], .{});
+    defer elf_file.close();
+
+    const input_file = if (args.len <= 2 or std.mem.eql(u8, args[2], "-"))
+        std.io.getStdIn()
+    else
+        try std.fs.cwd().openFile(args[2], .{});
+    defer input_file.close();
+
+    var elf = try Elf.init(allocator, elf_file);
+    defer elf.deinit(allocator);
+
+    var debug_info = try DebugInfo.init(allocator, elf);
+    defer debug_info.deinit(allocator);
+
+    const in_stream = input_file.reader();
+
+    const stdout = std.io.getStdOut();
+    const out_stream = stdout.writer();
+    const out_tty_config = std.io.tty.detectConfig(stdout);
+
+    var buf: [1024]u8 = undefined;
+    var annotator: Annotator = .init;
+
+    while (true) {
+        const n = try in_stream.read(&buf);
+
+        try annotator.process(
+            allocator,
+            buf[0..n],
+            elf,
+            &debug_info,
+            out_stream,
+            out_tty_config,
+        );
+    }
+}
+

--- a/tools/printer/src/root.zig
+++ b/tools/printer/src/root.zig
@@ -1,0 +1,195 @@
+const std = @import("std");
+
+pub const Elf = @import("Elf.zig");
+pub const DebugInfo = @import("DebugInfo.zig");
+
+/// Takes data and displays it, as well as annotating addresses where it's
+/// necessary.
+pub const Annotator = struct {
+    state: State,
+
+    pub const init: Annotator = .{ .state = .waiting };
+
+    pub const State = union(enum) {
+        waiting,
+        reading_address: struct {
+            buf: [16]u8,
+            digit_count: usize,
+        },
+        print_address: u64,
+    };
+
+    pub fn process(
+        self: *Annotator,
+        allocator: std.mem.Allocator,
+        data: []const u8,
+        elf: Elf,
+        debug_info: *DebugInfo,
+        out_stream: anytype,
+        out_tty_config: std.io.tty.Config,
+    ) !void {
+        var index: usize = 0;
+
+        loop: switch (self.state) {
+            .waiting => {
+                if (std.mem.indexOf(u8, data[index..], "0x")) |start_hex_index| {
+                    try out_stream.writeAll(data[index..][0..start_hex_index + 2]);
+                    index += start_hex_index + 2;
+
+                    continue :loop .{ .reading_address = .{
+                        .buf = undefined,
+                        .digit_count = 0,
+                    } };
+                }
+                self.state = .waiting;
+            },
+            .reading_address => |old_state| {
+                var new_state = old_state;
+
+                while (index < data.len) : ({
+                    index += 1;
+                    new_state.digit_count += 1;
+                }) {
+                    if (std.ascii.isHex(data[index])) {
+                        if (new_state.digit_count >= 16) {
+                            continue :loop .waiting;
+                        }
+
+                        new_state.buf[new_state.digit_count] = data[index];
+                    } else {
+                        if (new_state.digit_count == 8 or new_state.digit_count == 16) {
+                            const address = std.fmt.parseInt(
+                                u64,
+                                new_state.buf[0..new_state.digit_count],
+                                16,
+                            ) catch unreachable; // we know this is valid
+
+                            continue :loop .{ .print_address = address };
+                        } else {
+                            continue :loop .waiting;
+                        }
+                    }
+
+                    try out_stream.writeByte(data[index]);
+                }
+
+                self.state = .{ .reading_address = new_state };
+            },
+            .print_address => |address| {
+                if (std.mem.indexOfScalar(u8, data[index..], '\n')) |new_line_index| {
+                    if (elf.is_address_executable(address)) {
+                        const query_result = try debug_info.query(allocator, address);
+                        defer if (query_result.file_path) |path| allocator.free(path);
+
+                        try out_stream.writeAll(data[index..][0..new_line_index + 1]);
+                        index += new_line_index + 1;
+
+                        try output_location_info(out_stream, out_tty_config, address, query_result);
+                        try output_source_line(out_stream, out_tty_config, query_result);
+                    }
+
+                    continue :loop .waiting;
+                }
+
+                self.state = .{ .print_address = address };
+            },
+        }
+
+        try out_stream.writeAll(data[index..]);
+    }
+};
+
+fn output_location_info(
+    out_stream: anytype,
+    out_tty_config: std.io.tty.Config,
+    address: u64,
+    query_result: DebugInfo.QueryResult,
+) !void {
+    try out_tty_config.setColor(out_stream, .bold);
+
+    try out_stream.print("{s}:", .{query_result.file_path orelse "???"});
+
+    if (query_result.line) |line| {
+        try out_stream.print("{}:", .{line});
+    } else {
+        try out_stream.writeAll("?:");
+    }
+
+    if (query_result.column) |column| {
+        try out_stream.print("{}", .{column});
+    } else {
+        try out_stream.writeAll("?");
+    }
+
+    try out_tty_config.setColor(out_stream, .reset);
+    try out_stream.writeAll(": ");
+
+    try out_tty_config.setColor(out_stream, .dim);
+    try out_stream.print("0x{x} in {s} ({s})\n", .{
+        address,
+        query_result.function_name orelse "???",
+        query_result.module_name orelse "???",
+    });
+    try out_tty_config.setColor(out_stream, .reset);
+}
+
+fn output_source_line(
+    out_stream: anytype,
+    out_tty_config: std.io.tty.Config,
+    query_result: DebugInfo.QueryResult,
+) !void {
+    // we need all these to output the source line
+    const column = query_result.column orelse return;
+    const line_no = query_result.line orelse return;
+    const file_path = query_result.file_path orelse return;
+
+    const file = std.fs.cwd().openFile(file_path, .{}) catch {
+        // warn
+        return;
+    };
+    defer file.close();
+
+    var buf_reader = std.io.bufferedReader(file.reader());
+    const in_stream = buf_reader.reader();
+
+    var line_count: u32 = 1;
+    var buf: [150]u8 = undefined;
+    const src_line: struct {
+        line: []const u8,
+        too_long: bool,
+    } = loop: while (true) : (line_count += 1) {
+        var too_long = false;
+
+        const line = in_stream.readUntilDelimiterOrEof(&buf, '\n') catch |err| switch (err) {
+            error.StreamTooLong => blk: {
+                try in_stream.skipUntilDelimiterOrEof('\n');
+                too_long = true;
+                break :blk &buf;
+            },
+            else => return err,
+        } orelse return;
+
+        if (line_no == line_count) {
+            break :loop .{
+                .line = line,
+                .too_long = too_long,
+            };
+        }
+    } else return;
+
+    try out_stream.print("{s}", .{src_line.line});
+    if (src_line.too_long) {
+        try out_stream.writeAll(" [...]");
+    }
+    try out_stream.writeAll("\n");
+
+    if (column > 0) {
+        const space_needed = column - 1;
+
+        try out_stream.writeByteNTimes(' ', space_needed);
+        try out_tty_config.setColor(out_stream, .green);
+        try out_stream.writeAll("^");
+        try out_tty_config.setColor(out_stream, .reset);
+    }
+    try out_stream.writeAll("\n");
+}


### PR DESCRIPTION
Introducing the printer tool (the one that annotates addresses with the source location). It can be extended in the future to also support defmt.