### PR TITLE
regz: optional enum in `set_enum_type` patch

### DIFF
--- a/tools/regz/src/patch.zig
+++ b/tools/regz/src/patch.zig
@@ -31,7 +31,7 @@ pub const Patch = union(enum) {
     /// context
     set_enum_type: struct {
         of: []const u8,
-        to: []const u8,
+        to: ?[]const u8,
     },
     add_interrupt: struct {
         device_name: []const u8,


### PR DESCRIPTION
Can be useful if you want to remove an enum from a field.