### PR TITLE
rp2xxx: Remove SchmittTrigger, use  Enabled

### DIFF
--- a/port/raspberrypi/rp2xxx/src/hal/gpio.zig
+++ b/port/raspberrypi/rp2xxx/src/hal/gpio.zig
@@ -146,12 +146,12 @@ pub const Mask =
                 }
             }
 
-            pub fn set_schmitt_trigger(self: Mask, enabled: bool) void {
+            pub fn set_schmitt_trigger_enabled(self: Mask, enabled: bool) void {
                 const raw_mask = @intFromEnum(self);
                 for (0..@bitSizeOf(Mask)) |i| {
                     const bit = @as(u5, @intCast(i));
                     if (0 != raw_mask & (@as(u32, 1) << bit))
-                        num(bit).set_schmitt_trigger(enabled);
+                        num(bit).set_schmitt_trigger_enabled(enabled);
                 }
             }
 
@@ -225,12 +225,12 @@ pub const Mask =
                 }
             }
 
-            pub fn set_schmitt_trigger(self: Mask, enabled: bool) void {
+            pub fn set_schmitt_trigger_enabled(self: Mask, enabled: bool) void {
                 const raw_mask = @intFromEnum(self);
                 for (0..@bitSizeOf(Mask)) |i| {
                     const bit = @as(u6, @intCast(i));
                     if (0 != raw_mask & (@as(u48, 1) << bit))
-                        num(bit).set_schmitt_trigger(enabled);
+                        num(bit).set_schmitt_trigger_enabled(enabled);
                 }
             }
 
@@ -479,7 +479,7 @@ pub const Pin = enum(u6) {
         });
     }
 
-    pub fn set_schmitt_trigger(gpio: Pin, enabled: bool) void {
+    pub fn set_schmitt_trigger_enabled(gpio: Pin, enabled: bool) void {
         const pads_reg = gpio.get_pads_reg();
         pads_reg.modify(.{
             .SCHMITT = @intFromBool(enabled),

--- a/port/raspberrypi/rp2xxx/src/hal/gpio.zig
+++ b/port/raspberrypi/rp2xxx/src/hal/gpio.zig
@@ -432,7 +432,7 @@ pub const Pin = enum(u6) {
         }
     }
 
-    pub inline fn set_input_enabled(pin: Pin, enabled: true) void {
+    pub inline fn set_input_enabled(pin: Pin, enabled: bool) void {
         const pads_reg = pin.get_pads_reg();
         pads_reg.modify(.{ .IE = @intFromBool(enabled) });
     }

--- a/port/raspberrypi/rp2xxx/src/hal/gpio.zig
+++ b/port/raspberrypi/rp2xxx/src/hal/gpio.zig
@@ -72,11 +72,6 @@ pub const SlewRate = enum(u1) {
 
 pub const DriveStrength = microzig.chip.types.peripherals.PADS_BANK0.DriveStrength;
 
-pub const Enabled = enum(u1) {
-    enabled,
-    disabled,
-};
-
 pub const Pull = enum {
     up,
     down,
@@ -151,7 +146,7 @@ pub const Mask =
                 }
             }
 
-            pub fn set_schmitt_trigger(self: Mask, enabled: Enabled) void {
+            pub fn set_schmitt_trigger(self: Mask, enabled: bool) void {
                 const raw_mask = @intFromEnum(self);
                 for (0..@bitSizeOf(Mask)) |i| {
                     const bit = @as(u5, @intCast(i));
@@ -230,7 +225,7 @@ pub const Mask =
                 }
             }
 
-            pub fn set_schmitt_trigger(self: Mask, enabled: Enabled) void {
+            pub fn set_schmitt_trigger(self: Mask, enabled: bool) void {
                 const raw_mask = @intFromEnum(self);
                 for (0..@bitSizeOf(Mask)) |i| {
                     const bit = @as(u6, @intCast(i));
@@ -437,9 +432,9 @@ pub const Pin = enum(u6) {
         }
     }
 
-    pub inline fn set_input_enabled(pin: Pin, enabled: Enabled) void {
+    pub inline fn set_input_enabled(pin: Pin, enabled: true) void {
         const pads_reg = pin.get_pads_reg();
-        pads_reg.modify(.{ .IE = @intFromEnum(enabled) });
+        pads_reg.modify(.{ .IE = @intFromBool(enabled) });
     }
 
     pub inline fn set_output_disabled(pin: Pin, disabled: bool) void {
@@ -484,13 +479,10 @@ pub const Pin = enum(u6) {
         });
     }
 
-    pub fn set_schmitt_trigger(gpio: Pin, enabled: Enabled) void {
+    pub fn set_schmitt_trigger(gpio: Pin, enabled: bool) void {
         const pads_reg = gpio.get_pads_reg();
         pads_reg.modify(.{
-            .SCHMITT = switch (enabled) {
-                .enabled => @as(u1, 1),
-                .disabled => @as(u1, 0),
-            },
+            .SCHMITT = @intFromBool(enabled),
         });
     }
 

--- a/port/raspberrypi/rp2xxx/src/hal/gpio.zig
+++ b/port/raspberrypi/rp2xxx/src/hal/gpio.zig
@@ -77,11 +77,6 @@ pub const SchmittTrigger = enum(u1) {
     disabled,
 };
 
-pub const Enabled = enum {
-    disabled,
-    enabled,
-};
-
 pub const Pull = enum {
     up,
     down,
@@ -156,7 +151,7 @@ pub const Mask =
                 }
             }
 
-            pub fn set_schmitt_trigger(self: Mask, enabled: Enabled) void {
+            pub fn set_schmitt_trigger(self: Mask, enabled: SchmittTrigger) void {
                 const raw_mask = @intFromEnum(self);
                 for (0..@bitSizeOf(Mask)) |i| {
                     const bit = @as(u5, @intCast(i));
@@ -235,7 +230,7 @@ pub const Mask =
                 }
             }
 
-            pub fn set_schmitt_trigger(self: Mask, enabled: Enabled) void {
+            pub fn set_schmitt_trigger(self: Mask, enabled: SchmittTrigger) void {
                 const raw_mask = @intFromEnum(self);
                 for (0..@bitSizeOf(Mask)) |i| {
                     const bit = @as(u6, @intCast(i));
@@ -489,7 +484,7 @@ pub const Pin = enum(u6) {
         });
     }
 
-    pub fn set_schmitt_trigger(gpio: Pin, enabled: Enabled) void {
+    pub fn set_schmitt_trigger(gpio: Pin, enabled: SchmittTrigger) void {
         const pads_reg = gpio.get_pads_reg();
         pads_reg.modify(.{
             .SCHMITT = switch (enabled) {

--- a/port/raspberrypi/rp2xxx/src/hal/gpio.zig
+++ b/port/raspberrypi/rp2xxx/src/hal/gpio.zig
@@ -72,7 +72,7 @@ pub const SlewRate = enum(u1) {
 
 pub const DriveStrength = microzig.chip.types.peripherals.PADS_BANK0.DriveStrength;
 
-pub const SchmittTrigger = enum(u1) {
+pub const Enabled = enum(u1) {
     enabled,
     disabled,
 };
@@ -151,7 +151,7 @@ pub const Mask =
                 }
             }
 
-            pub fn set_schmitt_trigger(self: Mask, enabled: SchmittTrigger) void {
+            pub fn set_schmitt_trigger(self: Mask, enabled: Enabled) void {
                 const raw_mask = @intFromEnum(self);
                 for (0..@bitSizeOf(Mask)) |i| {
                     const bit = @as(u5, @intCast(i));
@@ -230,7 +230,7 @@ pub const Mask =
                 }
             }
 
-            pub fn set_schmitt_trigger(self: Mask, enabled: SchmittTrigger) void {
+            pub fn set_schmitt_trigger(self: Mask, enabled: Enabled) void {
                 const raw_mask = @intFromEnum(self);
                 for (0..@bitSizeOf(Mask)) |i| {
                     const bit = @as(u6, @intCast(i));
@@ -437,9 +437,9 @@ pub const Pin = enum(u6) {
         }
     }
 
-    pub inline fn set_input_enabled(pin: Pin, enabled: bool) void {
+    pub inline fn set_input_enabled(pin: Pin, enabled: Enabled) void {
         const pads_reg = pin.get_pads_reg();
-        pads_reg.modify(.{ .IE = @intFromBool(enabled) });
+        pads_reg.modify(.{ .IE = @intFromEnum(enabled) });
     }
 
     pub inline fn set_output_disabled(pin: Pin, disabled: bool) void {
@@ -484,7 +484,7 @@ pub const Pin = enum(u6) {
         });
     }
 
-    pub fn set_schmitt_trigger(gpio: Pin, enabled: SchmittTrigger) void {
+    pub fn set_schmitt_trigger(gpio: Pin, enabled: Enabled) void {
         const pads_reg = gpio.get_pads_reg();
         pads_reg.modify(.{
             .SCHMITT = switch (enabled) {

--- a/port/raspberrypi/rp2xxx/src/hal/pins.zig
+++ b/port/raspberrypi/rp2xxx/src/hal/pins.zig
@@ -22,6 +22,11 @@ pub const Direction = enum(u2) {
     unknown,
 };
 
+pub const Enabled = enum(u1) {
+    enabled,
+    disabled,
+};
+
 pub const PinFlags = if (has_rp2350b) [48]u1 else [32]u1;
 
 pub const Pin = enum {
@@ -81,7 +86,7 @@ pub const Pin = enum {
         drive_strength: ?gpio.DriveStrength = null,
         pull: ?gpio.Pull = null,
         slew_rate: ?gpio.SlewRate = null,
-        schmitt_trigger: ?gpio.Enabled = null,
+        schmitt_trigger: ?Enabled = null,
 
         pub fn get_direction(comptime config: Configuration) Direction {
             return if (config.direction) |direction|
@@ -941,7 +946,12 @@ pub const GlobalConfiguration = struct {
                 }
 
                 if (pin_config.schmitt_trigger) |enabled| {
-                    gpio.num(gpio_num).set_schmitt_trigger(enabled);
+                    gpio.num(gpio_num).set_schmitt_trigger(
+                        switch (enabled) {
+                            Enabled.enabled => true,
+                            else => false,
+                        },
+                    );
                 }
 
                 if (pin_config.drive_strength) |drive_strength| {

--- a/port/raspberrypi/rp2xxx/src/hal/pins.zig
+++ b/port/raspberrypi/rp2xxx/src/hal/pins.zig
@@ -946,12 +946,7 @@ pub const GlobalConfiguration = struct {
                 }
 
                 if (pin_config.schmitt_trigger) |enabled| {
-                    gpio.num(gpio_num).set_schmitt_trigger(
-                        switch (enabled) {
-                            Enabled.enabled => true,
-                            else => false,
-                        },
-                    );
+                    gpio.num(gpio_num).set_schmitt_trigger(enabled == .enabled);
                 }
 
                 if (pin_config.drive_strength) |drive_strength| {

--- a/port/raspberrypi/rp2xxx/src/hal/pins.zig
+++ b/port/raspberrypi/rp2xxx/src/hal/pins.zig
@@ -81,7 +81,7 @@ pub const Pin = enum {
         drive_strength: ?gpio.DriveStrength = null,
         pull: ?gpio.Pull = null,
         slew_rate: ?gpio.SlewRate = null,
-        schmitt_trigger: ?gpio.SchmittTrigger = null,
+        schmitt_trigger: ?gpio.Enabled = null,
 
         pub fn get_direction(comptime config: Configuration) Direction {
             return if (config.direction) |direction|


### PR DESCRIPTION
Code:
```zig
const pin_config = rp2xxx.pins.GlobalConfiguration{
    .GPIO29 = .{
        .name = "relay",
        .direction = .out,
    },
    .GPIO28 = .{
        .name = "sensor",
        .direction = .in,
    },
    .GPIO27 = .{
        .name = "capacitor",
        .direction = .in,
    },
    .GPIO4 = .{
        .name = "SDA",
        .function = .I2C0_SDA,
        .schmitt_trigger = .enabled,
        .slew_rate = .slow,
    },
    .GPIO5 = .{
        .name = "SCL",
        .function = .I2C0_SCL,
        .schmitt_trigger = .enabled,
        .slew_rate = .slow,
    },
};

pub fn main() void {
    pin_config.apply();
}
```

Causing:
```sh
install
└─ install generated to light-mcu.uf2
   └─ run elf2uf2 (light-mcu.uf2)
      └─ zig build-exe light-mcu ReleaseSmall thumb-freestanding-eabi 1 errors
/home/guney/.cache/zig/p/mz_port_raspberrypi_rp2xxx-0.0.0-wCvtidmzDQDWXpsuqBY_8dkz96PsJ_rrMKX04haxvjRt/src/hal/pins.zig:944:60: error: expected type 'hal.gpio.Enabled', found 'hal.gpio.SchmittTrigger'
                    gpio.num(gpio_num).set_schmitt_trigger(enabled);
```

When I dig into the code base. I realized that gpio config uses `SchmittTrigger` but `set_schmitt_trigger` in `pins.zig` uses `Enabled` so if you pass `SchmittTrigger` enum the pins.zig fails, if you pass `Enabled` then `gpio.zig` fails.

I honestly couldn't see if there was a purpose of having them twice(ish), but looks like causing trouble if I'm not really doing something completely stupid.