### PR TITLE
STM32F103 Small APIS and changes

### DIFF
--- a/examples/stmicro/stm32/build.zig
+++ b/examples/stmicro/stm32/build.zig
@@ -39,6 +39,7 @@ pub fn build(b: *std.Build) void {
         .{ .target = stm32.chips.STM32F103CB, .name = "STM32F1xx_rcc", .file = "src/stm32f1xx/rcc.zig" },
         .{ .target = stm32.chips.STM32F103CB, .name = "STM32F1xx_timer", .file = "src/stm32f1xx/timer.zig" },
         .{ .target = stm32.chips.STM32F103CB, .name = "STM32F1xx_timer_capture", .file = "src/stm32f1xx/timer_capture.zig" },
+        .{ .target = stm32.chips.STM32F103CB, .name = "STM32F1xx_rtc", .file = "src/stm32f1xx/rtc.zig" },
     };
 
     for (available_examples) |example| {

--- a/examples/stmicro/stm32/src/stm32f1xx/rtc.zig
+++ b/examples/stmicro/stm32/src/stm32f1xx/rtc.zig
@@ -1,0 +1,74 @@
+const std = @import("std");
+const microzig = @import("microzig");
+const hal = microzig.hal;
+const rtc = hal.rtc;
+const rcc = hal.rcc;
+const bkp = hal.backup;
+const gpio = hal.gpio;
+
+pub const microzig_options = microzig.Options{
+    .interrupts = .{ .RTC = .{ .c = rtc_handler } },
+};
+
+pub fn rtc_handler() callconv(.C) void {
+    const events = rtc.read_events();
+    if (events.second) {
+        led.toggle();
+    }
+    rtc.clear_events(events);
+}
+
+/// LED used to indicate that the RTC is running.
+/// On the WeAct BluePill+ board, this is the built-in LED.
+/// On other BluePill boards, you need to connect an LED to pin PB2,
+/// (NOTE: PC13 is the TAMPER pin, which is used for output RTC events on this example)
+const led = gpio.Pin.from_port(.B, 2);
+
+pub fn main() !void {
+
+    //RTC is part of the backup domain, therefore it is not reset (except for interrupt config)
+    //by the system reset, so we need to check if it is already running.
+    //If it is not running, we will configure it and enable it.
+    if (fresh_start()) {
+        try rcc.clock_init(.{ .RTCClkSource = .RCC_RTCCLKSOURCE_LSE });
+        rcc.enable_clock(.PWR);
+        rcc.enable_clock(.BKP);
+
+        //disable the backup domain protection
+        //this is necessary to write to the backup registers
+        bkp.set_data_protection(false);
+
+        bkp.BackupData1[0].data = 0xBEEF;
+        bkp.BackupData1[1].data = 0xDEAD;
+
+        //enable the RTC event output on the TAMPER pin (PC13)
+        bkp.rtc_event_output(.Second);
+        bkp.set_rtc_event_output(true);
+
+        rtc.enable(true);
+        rtc.apply(.{ .prescaler = 32_768 });
+
+        //enable the backup domain write protection
+        bkp.set_data_protection(true);
+    }
+    rtc.busy_sync(); // wait for RTC to be ready
+
+    //RTC interrupt need to be applied every time the system is reset
+    //even if the RTC is already running.
+    rtc.apply_interrupts(.{ .second_interrupt = true });
+
+    rcc.enable_clock(.GPIOB); // enable GPIOB clock for LED
+    rcc.enable_clock(.GPIOC); // enable GPIOC clock for TAMPER pin
+    led.set_output_mode(.general_purpose_push_pull, .max_10MHz);
+    microzig.interrupt.enable(.RTC);
+    microzig.interrupt.enable_interrupts();
+    while (true) {}
+}
+
+fn fresh_start() bool {
+    rcc.enable_clock(.PWR);
+    rcc.enable_clock(.BKP);
+    const data: u32 = (@as(u32, bkp.BackupData1[1].data) << 16) | bkp.BackupData1[0].data;
+    rcc.disable_all_clocks();
+    return data != 0xDEADBEEF;
+}

--- a/port/stmicro/stm32/src/hals/STM32F103/backup.zig
+++ b/port/stmicro/stm32/src/hals/STM32F103/backup.zig
@@ -1,0 +1,90 @@
+const microzig = @import("microzig");
+const backup_domain_protection = microzig.hal.power.backup_domain_protection;
+
+const bkp = microzig.chip.peripherals.BKP;
+pub const ASOS = microzig.chip.types.peripherals.bkp_v1.ASOS;
+pub const TPAL = microzig.chip.types.peripherals.bkp_v1.TPAL;
+
+const bkp_addr = @intFromPtr(bkp);
+const BKPData = packed struct(u32) {
+    data: u16,
+    __pad: u16 = 0,
+};
+
+///This function is used to reset the backup domain and the RTC.
+/// its is the same as `hal.rcc.reset_backup_domain()` and is here for convenience.
+pub const reset = @import("rcc.zig").reset_backup_domain;
+
+/// this data is retained as long as the backup domain is powered. (by VDD or VBAT)
+/// it also can by cleared by the TAMPER pin event.
+pub const BackupData1: *[10]BKPData = @ptrFromInt(bkp_addr + 0x04);
+pub const BackupData2: *[31]BKPData = @ptrFromInt(bkp_addr + 0x40);
+
+///enable/disable the backup domain write protection.
+///
+/// note: this is the same function as `hal.power.backup_domain_protection` and is hare for convenience.
+pub inline fn set_data_protection(on: bool) void {
+    backup_domain_protection(on);
+}
+
+///reset the entire backup domain.
+pub inline fn reset_backup_domain() void {
+    microzig.chip.peripherals.RCC.BDCR.modify_one("BDRST", 1);
+    microzig.chip.peripherals.RCC.BDCR.modify_one("BDRST", 0);
+}
+
+///enable the tamper detection feature.
+/// when tamper pin is activated, the backup domain is reset and the tamper detection flag is set.
+/// the backup domain will ramain in reset state until the tamper event flag is cleared by `tamper_event_clear`.
+pub inline fn enable_tamper_detection(trigger_level: TPAL) void {
+    bkp.CR.modify(.{
+        .TPE = 1,
+        .TPAL = trigger_level,
+    });
+}
+
+pub inline fn disable_tamper_detection() void {
+    bkp.CR.modify_one("TPE", 0);
+}
+
+pub inline fn set_tamper_interrupt(on: bool) void {
+    bkp.CSR.modify_one("TPIE", @intFromBool(on));
+}
+
+pub inline fn check_tamper_event() bool {
+    return bkp.CSR.read().TEF != 0;
+}
+
+pub inline fn tamper_event_clear() void {
+    bkp.CSR.modify_one("CTE", 1);
+}
+
+pub inline fn tamper_interrupt_clear() void {
+    bkp.CSR.modify_one("CTI", 1);
+}
+
+//----- RTC Functions -----
+
+///select the RTC event output on the TAMPER pin.
+///tamper function must be disabled to avoid activation of the tamper detection feature.
+pub inline fn rtc_event_output(event: ASOS) void {
+    bkp.RTCCR.modify_one("ASOS", event);
+}
+
+///enable/disable the RTC event output on the TAMPER pin.
+pub inline fn set_rtc_event_output(on: bool) void {
+    bkp.RTCCR.modify_one("ASOE", @intFromBool(on));
+}
+
+///enable/disable the RTC clock output on the TAMPER pin.
+/// if enabled, the (RTC clock)/64 is output on the TAMPER pin.
+///
+/// note: tamper function must be disabled to avoid activation of the tamper detection feature.
+pub inline fn set_RTC_clock_output(on: bool) void {
+    bkp.RTCCR.modify_one("CCO", @intFromBool(on));
+}
+
+///This value indicates the number of clock pulses that will be ignored every 2^20 clock pulses.
+pub inline fn RTC_calibration(CAL: u7) void {
+    bkp.RTCCR.modify_one("CAL", CAL);
+}

--- a/port/stmicro/stm32/src/hals/STM32F103/crc.zig
+++ b/port/stmicro/stm32/src/hals/STM32F103/crc.zig
@@ -1,0 +1,29 @@
+const std = @import("std");
+const microzig = @import("microzig");
+
+const crc = microzig.chip.peripherals.CRC;
+
+///load a 32-bit value into the CRC data register
+pub inline fn load(val: u32) void {
+    crc.DR = val;
+}
+
+///read the current CRC value
+pub inline fn read() u32 {
+    return crc.DR;
+}
+
+///reset the CRC calculation unit
+pub inline fn reset() void {
+    crc.CR.raw = 0x1; // reset bit
+}
+
+///load a value into the CRC independent data register (just a single byte)
+pub inline fn idr_load(val: u8) void {
+    crc.IDR = val;
+}
+
+///read the current value of the CRC independent data register
+pub inline fn idr_read() u8 {
+    return @intCast(crc.IDR);
+}

--- a/port/stmicro/stm32/src/hals/STM32F103/hal.zig
+++ b/port/stmicro/stm32/src/hals/STM32F103/hal.zig
@@ -8,6 +8,8 @@ pub const drivers = @import("drivers.zig");
 pub const timer = @import("timer.zig");
 pub const usb = @import("usb.zig");
 pub const adc = @import("adc.zig");
+pub const crc = @import("crc.zig");
+pub const power = @import("power.zig");
 
 pub var RESET: rcc.ResetReason = .POR_or_PDR;
 pub fn init() void {

--- a/port/stmicro/stm32/src/hals/STM32F103/hal.zig
+++ b/port/stmicro/stm32/src/hals/STM32F103/hal.zig
@@ -10,6 +10,8 @@ pub const usb = @import("usb.zig");
 pub const adc = @import("adc.zig");
 pub const crc = @import("crc.zig");
 pub const power = @import("power.zig");
+pub const backup = @import("backup.zig");
+pub const rtc = @import("rtc.zig");
 
 pub var RESET: rcc.ResetReason = .POR_or_PDR;
 pub fn init() void {

--- a/port/stmicro/stm32/src/hals/STM32F103/power.zig
+++ b/port/stmicro/stm32/src/hals/STM32F103/power.zig
@@ -1,0 +1,77 @@
+const std = @import("std");
+const microzig = @import("microzig");
+
+const pwd = microzig.chip.peripherals.PWR;
+const PDDS = microzig.chip.types.peripherals.pwr_f1.PDDS;
+
+pub const PDVThreshold = enum(u3) {
+    V2_2,
+    V2_3,
+    V2_4,
+    V2_5,
+    V2_6,
+    V2_7,
+    V2_8,
+    V2_9,
+};
+
+pub const DeepsleepModes = enum(u1) {
+    stop,
+    standby,
+};
+
+pub const VoltRegulatorMode = enum(u1) {
+    on,
+    off,
+};
+
+pub const Events = packed struct(u2) {
+    Standby: bool = false,
+    Wakeup: bool = false,
+};
+
+pub const PowerConfig = struct {
+    pdv_trhreshold: PDVThreshold = .V2_9,
+    deepsleep_mode: DeepsleepModes = .stop, //define the deepsleep behavior
+    volt_regulator_mode: VoltRegulatorMode = .on, //define the voltage regulator behavior , only used if `deepsleep_mode` is set to `stop`
+    wakeup_pin: bool = false, //enable/disable the wakeup pin
+};
+
+pub inline fn apply(config: PowerConfig) void {
+    pwd.CR.modify(.{
+        .PLS = @intFromEnum(config.pdv_trhreshold),
+        .PDDS = @as(PDDS, @enumFromInt(@intFromEnum(config.deepsleep_mode))),
+        .LPDS = @intFromEnum(config.volt_regulator_mode),
+    });
+    pwd.CSR.modify(.{ .EWUP = @intFromBool(config.wakeup_pin) });
+}
+
+///enable/disable the power detection peripheral.
+pub inline fn set_pdv(set: bool) void {
+    pwd.CR.modify(.{ .PVDE = @intFromBool(set) });
+}
+
+///get the current power detection status.
+/// 0 = VDD/VDDA is higher than the threshold.
+/// 1 = VDD/VDDA is lower than the threshold.
+pub inline fn pdv_status() u1 {
+    return pwd.CSR.read().PVDO;
+}
+
+///enable/disable the backup domain write protection.
+/// this is used to protect the RTC and backup registers.
+pub inline fn backup_domain_protection(set: bool) void {
+    pwd.CR.modify(.{ .DBP = @intFromBool(set) });
+}
+
+pub inline fn get_events() Events {
+    const csr = pwd.CSR.read();
+    return Events{
+        .Standby = csr.SBF != 0,
+        .Wakeup = csr.WUF != 0,
+    };
+}
+
+pub inline fn clear_events() void {
+    pwd.CR.modify(.{ .CWUF = 1, .CSBF = 1 });
+}

--- a/port/stmicro/stm32/src/hals/STM32F103/power.zig
+++ b/port/stmicro/stm32/src/hals/STM32F103/power.zig
@@ -60,8 +60,10 @@ pub inline fn pdv_status() u1 {
 
 ///enable/disable the backup domain write protection.
 /// this is used to protect the RTC and backup registers.
+///
+/// this function also exist in the `hal.backup` module.
 pub inline fn backup_domain_protection(set: bool) void {
-    pwd.CR.modify(.{ .DBP = @intFromBool(set) });
+    pwd.CR.modify(.{ .DBP = @intFromBool(!set) });
 }
 
 pub inline fn get_events() Events {

--- a/port/stmicro/stm32/src/hals/STM32F103/rcc.zig
+++ b/port/stmicro/stm32/src/hals/STM32F103/rcc.zig
@@ -5,6 +5,7 @@ const microzig = @import("microzig");
 
 const find_clocktree = @import("util.zig").find_clock_tree;
 const ClockTree = find_clocktree(microzig.config.chip_name);
+const power = @import("power.zig");
 
 //expose only the configuration structs
 pub const Config = ClockTree.Config;
@@ -330,24 +331,35 @@ fn init_pll() void {
 
 fn config_RTC(comptime config: ClockTree.Config) ClockInitError!void {
     if (config.RTCClkSource) |src| {
-        var rtc: RTCSEL = .DISABLE;
+        //enable backup domain
+        enable_clock(.PWR);
+        enable_clock(.BKP);
+        power.backup_domain_protection(false);
+
+        var rtcs: RTCSEL = .DISABLE;
         switch (src) {
             .RCC_RTCCLKSOURCE_HSE_DIV128 => {
-                rtc = .HSE;
+                rtcs = .HSE;
                 try config_HSE(config);
             },
             .RCC_RTCCLKSOURCE_LSE => {
-                rtc = .LSE;
+                rtcs = .LSE;
                 try config_LSE(config);
             },
             .RCC_RTCCLKSOURCE_LSI => {
-                rtc = .LSI;
+                rtcs = .LSI;
                 config_LSI();
             },
-            else => {},
         }
 
-        rcc.BDCR.modify(.{ .RTCSEL = rtc });
+        rcc.BDCR.modify(.{ .RTCSEL = rtcs });
+        power.backup_domain_protection(true);
+
+        // Disable and reset clocks to avoid potential conflicts with the main application
+        disable_clock(.BKP);
+        reset_clock(.BKP);
+        disable_clock(.PWR);
+        reset_clock(.PWR);
     }
 }
 
@@ -364,6 +376,7 @@ fn config_MCO(comptime config: ClockTree.Config) void {
 }
 
 ///after the reset, the BDRD becomes read_only until access is released by the power register
+/// this function can also be called from `backup.reset()`
 pub fn reset_backup_domain() void {
     rcc.BDCR.modify(.{ .BDRST = 1 });
     for (0..5) |i| {
@@ -373,8 +386,15 @@ pub fn reset_backup_domain() void {
 }
 
 ///configure the power and clock registers before enabling the RTC
-pub fn enable_RTC() void {
-    rcc.BDCR.modify(.{ .RTCEN = 1 });
+/// this function also can be called from `rtc.enable()`
+pub fn enable_RTC(on: bool) void {
+    rcc.BDCR.modify(.{ .RTCEN = @intFromBool(on) });
+}
+
+/// backup domain is not reset with the rest of the system
+/// so this function can be used to check if the RTC is already running.
+pub fn rtc_running() bool {
+    return rcc.BDCR.read().RTCEN != 0;
 }
 
 ///This function is called internally by the HAL, the RESET value should only be read after the RESET
@@ -395,16 +415,9 @@ pub fn get_reset_reason() ResetReason {
     return rst;
 }
 
-pub fn disable_clock(peri: RccPeriferals) void {
+///NOTE: AHB bus cannot be reset, so this function only resets the APB1 and APB2 peripherals
+pub fn reset_clock(peri: RccPeriferals) void {
     switch (peri) {
-        .DMA1 => rcc.AHBRSTR.modify(.{ .DMA1RST = 1 }),
-        .DMA2 => rcc.AHBRSTR.modify(.{ .DMA2RST = 1 }),
-        .SRAM => rcc.AHBRSTR.modify(.{ .SRAMRST = 1 }),
-        .FLASH => rcc.AHBRSTR.modify(.{ .FLASHRST = 1 }),
-        .CRC => rcc.AHBRSTR.modify(.{ .CRCRST = 1 }),
-        .FSMC => rcc.AHBRSTR.modify(.{ .FSMCRST = 1 }), //F103xE
-        .SDIO => rcc.AHBRSTR.modify(.{ .SDIORST = 1 }), //F103xC/D/E
-
         // APB2RSTR (APB2 peripherals)
         .AFIO => rcc.APB2RSTR.modify(.{ .AFIORST = 1 }),
         .GPIOA => rcc.APB2RSTR.modify(.{ .GPIOARST = 1 }),
@@ -441,56 +454,68 @@ pub fn disable_clock(peri: RccPeriferals) void {
         .BKP => rcc.APB1RSTR.modify(.{ .BKPRST = 1 }),
         .PWR => rcc.APB1RSTR.modify(.{ .PWRRST = 1 }),
         .DAC => rcc.APB1RSTR.modify(.{ .DACRST = 1 }), //F103xE
+        else => {},
+    }
+    //release reset
+    rcc.APB2RSTR.raw = 0;
+    rcc.APB1RSTR.raw = 0;
+}
+
+pub fn set_clock(peri: RccPeriferals, state: u1) void {
+    switch (peri) {
+        .DMA1 => rcc.AHBENR.modify(.{ .DMA1EN = state }),
+        .DMA2 => rcc.AHBENR.modify(.{ .DMA2EN = state }),
+        .SRAM => rcc.AHBENR.modify(.{ .SRAMEN = state }),
+        .FLASH => rcc.AHBENR.modify(.{ .FLASHEN = state }),
+        .CRC => rcc.AHBENR.modify(.{ .CRCEN = state }),
+        .FSMC => rcc.AHBENR.modify(.{ .FSMCEN = state }), //F103xE
+        .SDIO => rcc.AHBENR.modify(.{ .SDIOEN = state }), //F103xC/D/E
+
+        // APB2ENR (APB2 peripherals)
+        .AFIO => rcc.APB2ENR.modify(.{ .AFIOEN = state }),
+        .GPIOA => rcc.APB2ENR.modify(.{ .GPIOAEN = state }),
+        .GPIOB => rcc.APB2ENR.modify(.{ .GPIOBEN = state }),
+        .GPIOC => rcc.APB2ENR.modify(.{ .GPIOCEN = state }),
+        .GPIOD => rcc.APB2ENR.modify(.{ .GPIODEN = state }),
+        .GPIOE => rcc.APB2ENR.modify(.{ .GPIOEEN = state }),
+        .GPIOF => rcc.APB2ENR.modify(.{ .GPIOFEN = state }), //F103xE
+        .GPIOG => rcc.APB2ENR.modify(.{ .GPIOGEN = state }), //F103xE
+        .ADC1 => rcc.APB2ENR.modify(.{ .ADC1EN = state }),
+        .ADC2 => rcc.APB2ENR.modify(.{ .ADC2EN = state }),
+        .TIM1 => rcc.APB2ENR.modify(.{ .TIM1EN = state }),
+        .SPI1 => rcc.APB2ENR.modify(.{ .SPI1EN = state }),
+        .USART1 => rcc.APB2ENR.modify(.{ .USART1EN = state }),
+
+        // APB1ENR (APB1 peripherals)
+        .TIM2 => rcc.APB1ENR.modify(.{ .TIM2EN = state }),
+        .TIM3 => rcc.APB1ENR.modify(.{ .TIM3EN = state }),
+        .TIM4 => rcc.APB1ENR.modify(.{ .TIM4EN = state }),
+        .TIM5 => rcc.APB1ENR.modify(.{ .TIM5EN = state }), //F103xE
+        .TIM6 => rcc.APB1ENR.modify(.{ .TIM6EN = state }), //F103xE
+        .TIM7 => rcc.APB1ENR.modify(.{ .TIM7EN = state }), //F103xE
+        .WWDG => rcc.APB1ENR.modify(.{ .WWDGEN = state }),
+        .SPI2 => rcc.APB1ENR.modify(.{ .SPI2EN = state }),
+        .SPI3 => rcc.APB1ENR.modify(.{ .SPI3EN = state }), //F103xD/E
+        .USART2 => rcc.APB1ENR.modify(.{ .USART2EN = state }),
+        .USART3 => rcc.APB1ENR.modify(.{ .USART3EN = state }),
+        .UART4 => rcc.APB1ENR.modify(.{ .UART4EN = state }), //F103xC/D/E
+        .UART5 => rcc.APB1ENR.modify(.{ .UART5EN = state }), //F103xC/D/E
+        .I2C1 => rcc.APB1ENR.modify(.{ .I2C1EN = state }),
+        .I2C2 => rcc.APB1ENR.modify(.{ .I2C2EN = state }),
+        .USB => rcc.APB1ENR.modify(.{ .USBEN = state }),
+        .CAN => rcc.APB1ENR.modify(.{ .CANEN = state }),
+        .BKP => rcc.APB1ENR.modify(.{ .BKPEN = state }),
+        .PWR => rcc.APB1ENR.modify(.{ .PWREN = state }),
+        .DAC => rcc.APB1ENR.modify(.{ .DACEN = state }), //F103xE
     }
 }
 
 pub fn enable_clock(peri: RccPeriferals) void {
-    switch (peri) {
-        .DMA1 => rcc.AHBENR.modify(.{ .DMA1EN = 1 }),
-        .DMA2 => rcc.AHBENR.modify(.{ .DMA2EN = 1 }),
-        .SRAM => rcc.AHBENR.modify(.{ .SRAMEN = 1 }),
-        .FLASH => rcc.AHBENR.modify(.{ .FLASHEN = 1 }),
-        .CRC => rcc.AHBENR.modify(.{ .CRCEN = 1 }),
-        .FSMC => rcc.AHBENR.modify(.{ .FSMCEN = 1 }), //F103xE
-        .SDIO => rcc.AHBENR.modify(.{ .SDIOEN = 1 }), //F103xC/D/E
+    set_clock(peri, 1);
+}
 
-        // APB2ENR (APB2 peripherals)
-        .AFIO => rcc.APB2ENR.modify(.{ .AFIOEN = 1 }),
-        .GPIOA => rcc.APB2ENR.modify(.{ .GPIOAEN = 1 }),
-        .GPIOB => rcc.APB2ENR.modify(.{ .GPIOBEN = 1 }),
-        .GPIOC => rcc.APB2ENR.modify(.{ .GPIOCEN = 1 }),
-        .GPIOD => rcc.APB2ENR.modify(.{ .GPIODEN = 1 }),
-        .GPIOE => rcc.APB2ENR.modify(.{ .GPIOEEN = 1 }),
-        .GPIOF => rcc.APB2ENR.modify(.{ .GPIOFEN = 1 }), //F103xE
-        .GPIOG => rcc.APB2ENR.modify(.{ .GPIOGEN = 1 }), //F103xE
-        .ADC1 => rcc.APB2ENR.modify(.{ .ADC1EN = 1 }),
-        .ADC2 => rcc.APB2ENR.modify(.{ .ADC2EN = 1 }),
-        .TIM1 => rcc.APB2ENR.modify(.{ .TIM1EN = 1 }),
-        .SPI1 => rcc.APB2ENR.modify(.{ .SPI1EN = 1 }),
-        .USART1 => rcc.APB2ENR.modify(.{ .USART1EN = 1 }),
-
-        // APB1ENR (APB1 peripherals)
-        .TIM2 => rcc.APB1ENR.modify(.{ .TIM2EN = 1 }),
-        .TIM3 => rcc.APB1ENR.modify(.{ .TIM3EN = 1 }),
-        .TIM4 => rcc.APB1ENR.modify(.{ .TIM4EN = 1 }),
-        .TIM5 => rcc.APB1ENR.modify(.{ .TIM5EN = 1 }), //F103xE
-        .TIM6 => rcc.APB1ENR.modify(.{ .TIM6EN = 1 }), //F103xE
-        .TIM7 => rcc.APB1ENR.modify(.{ .TIM7EN = 1 }), //F103xE
-        .WWDG => rcc.APB1ENR.modify(.{ .WWDGEN = 1 }),
-        .SPI2 => rcc.APB1ENR.modify(.{ .SPI2EN = 1 }),
-        .SPI3 => rcc.APB1ENR.modify(.{ .SPI3EN = 1 }), //F103xD/E
-        .USART2 => rcc.APB1ENR.modify(.{ .USART2EN = 1 }),
-        .USART3 => rcc.APB1ENR.modify(.{ .USART3EN = 1 }),
-        .UART4 => rcc.APB1ENR.modify(.{ .UART4EN = 1 }), //F103xC/D/E
-        .UART5 => rcc.APB1ENR.modify(.{ .UART5EN = 1 }), //F103xC/D/E
-        .I2C1 => rcc.APB1ENR.modify(.{ .I2C1EN = 1 }),
-        .I2C2 => rcc.APB1ENR.modify(.{ .I2C2EN = 1 }),
-        .USB => rcc.APB1ENR.modify(.{ .USBEN = 1 }),
-        .CAN => rcc.APB1ENR.modify(.{ .CANEN = 1 }),
-        .BKP => rcc.APB1ENR.modify(.{ .BKPEN = 1 }),
-        .PWR => rcc.APB1ENR.modify(.{ .PWREN = 1 }),
-        .DAC => rcc.APB1ENR.modify(.{ .DACEN = 1 }), //F103xE
-    }
+pub fn disable_clock(peri: RccPeriferals) void {
+    set_clock(peri, 0);
 }
 
 pub fn enable_all_clocks() void {
@@ -505,6 +530,14 @@ pub fn disable_all_clocks() void {
     rcc.AHBENR.raw = 0;
     rcc.APB1ENR.raw = 0;
     rcc.APB2ENR.raw = 0;
+}
+
+/// Reset all clocks to their default state
+pub fn reset_all_clocks() void {
+    rcc.APB2RSTR.raw = std.math.maxInt(u32);
+    rcc.APB2RSTR.raw = 0;
+    rcc.APB1RSTR.raw = std.math.maxInt(u32);
+    rcc.APB1RSTR.raw = 0;
 }
 //NOTE: should we panic on invalid clocks?
 //errors at comptime appear for peripherals manually configured like USB.

--- a/port/stmicro/stm32/src/hals/STM32F103/rtc.zig
+++ b/port/stmicro/stm32/src/hals/STM32F103/rtc.zig
@@ -1,0 +1,120 @@
+const microzig = @import("microzig");
+const rcc = @import("rcc.zig");
+const rtc = microzig.chip.peripherals.RTC;
+
+///enable the RTC clock.
+/// this function is the same as `hal.rcc.enable_RTC()`.
+/// it is here for convenience.
+pub const enable = rcc.enable_RTC;
+pub const is_running = rcc.rtc_running;
+
+///RTC clock source is selected in the clock configs
+pub const Config = struct {
+    prescaler: u20 = 0,
+    alarm: u32 = 0,
+    conter_start_value: u32 = 0,
+};
+
+pub const InterruptConfig = struct {
+    second_interrupt: bool = false,
+    alarm_interrupt: bool = false,
+    overflow_interrupt: bool = false,
+};
+
+pub const Events = packed struct(u3) {
+    overflow: bool = false,
+    alarm: bool = false,
+    second: bool = false,
+};
+
+pub fn enter_config_mode() void {
+    while (rtc.CRL.read().RTOFF == .Ongoing) asm volatile ("" ::: "memory");
+    //enter in config mode
+    rtc.CRL.modify_one("CNF", 1);
+}
+
+pub fn exit_config_mode() void {
+    //exit config mode
+    rtc.CRL.modify_one("CNF", 0);
+    //wait for the config to finish
+    while (rtc.CRL.read().RTOFF == .Ongoing) asm volatile ("" ::: "memory");
+}
+
+pub fn apply(config: Config) void {
+    const pll_high: u4 = @truncate(config.prescaler >> 16);
+    const pll_low: u16 = @truncate(config.prescaler);
+
+    const alarm = config.alarm;
+    const alr_high: u16 = @truncate(alarm >> 16);
+    const alr_low: u16 = @truncate(alarm);
+
+    const start = config.conter_start_value;
+    const str_high: u16 = @truncate(start >> 16);
+    const str_low: u16 = @truncate(start);
+
+    enter_config_mode();
+
+    //config prescaler
+    rtc.PRLH.modify_one("PRLH", pll_high);
+    rtc.PRLL.modify_one("PRLL", pll_low);
+
+    //config alarm
+    rtc.ALRH.modify_one("ALRH", alr_high);
+    rtc.ALRL.modify_one("ALRL", alr_low);
+
+    //config counter
+    rtc.CNTH.modify_one("CNTH", str_high);
+    rtc.CNTL.modify_one("CNTL", str_low);
+
+    exit_config_mode();
+}
+
+///Interrups are one of the only things that is reset by the system reset,
+///so we need to apply them every time a reset occurs.
+pub fn apply_interrupts(config: InterruptConfig) void {
+    enter_config_mode();
+    rtc.CRH.modify(.{
+        .SECIE = @intFromBool(config.second_interrupt),
+        .ALRIE = @intFromBool(config.alarm_interrupt),
+        .OWIE = @intFromBool(config.overflow_interrupt),
+    });
+    exit_config_mode();
+}
+
+/// Wait for RTC registers to synchronize.
+/// After a reset, reading RTC registers may return unsynchronized or corrupted data.
+pub fn busy_sync() void {
+    const cr = rtc.CRL.read();
+    while (cr.RSF == 0) asm volatile ("" ::: "memory");
+    rtc.CRL.modify_one("RSF", 0);
+}
+
+pub fn read_events() Events {
+    const crl = rtc.CRL.read();
+    return Events{
+        .alarm = crl.ALRF == 1,
+        .overflow = crl.OWF == 1,
+        .second = crl.SECF == 1,
+    };
+}
+
+pub fn clear_events(events: Events) void {
+    rtc.CRL.modify(.{
+        .ALRF = @intFromBool(!events.alarm),
+
+        .OWF = @intFromBool(!events.overflow),
+
+        .SECF = @intFromBool(!events.second),
+    });
+}
+
+///read the corrent frac of the RTC counter.
+pub fn read_frac() u20 {
+    return @truncate(rtc.DIVL.read().DIVL | (@as(u32, (rtc.DIVH.read().DIVH)) << 16));
+}
+
+pub fn read_counter() u32 {
+    const low = rtc.CNTL.read().CNTL;
+    const high = rtc.CNTH.read().CNTH;
+    return low | (@as(u32, (high)) << 16);
+}


### PR DESCRIPTION
Add support for small APIs such as:
- [ ] DMA
- [x] POWER
- [x] BACKUP
- [x] RTC
- [x] CRC
- [ ] AFIO

And small bug fixes and typo corrections:

- Fix: config_RTC on rcc.clock_init: The backup domain was not activated, resulting in configuration failure