### PR TITLE
build_system: `stack` option in `Target`

### DIFF
--- a/build-internals/build.zig
+++ b/build-internals/build.zig
@@ -62,6 +62,16 @@ pub const Target = struct {
     /// Provide a custom linker script for the hardware or define a custom generation.
     linker_script: LinkerScript = .{},
 
+    /// Provides the stack end for the target.
+    stack_end: union(enum) {
+        /// Place the stack end at a fixed address.
+        address: usize,
+        /// Place the stack at the end of the n-th ram memory region.
+        ram_region_index: usize,
+        /// Place the stack end at a symbol address.
+        symbol_name: []const u8,
+    } = .{ .ram_region_index = 0 },
+
     /// (optional) Explicitly set the entry point.
     entry: ?Build.Step.Compile.Entry = null,
 

--- a/build-internals/build.zig
+++ b/build-internals/build.zig
@@ -62,7 +62,7 @@ pub const Target = struct {
     /// Provides a custom linker script for the hardware or define a custom generation.
     linker_script: LinkerScript = .{},
 
-    /// Provides the stack end for the target.
+    /// Determines the location of the stack.
     stack: Stack = .{ .ram_region_index = 0 },
 
     /// (optional) Explicitly set the entry point.
@@ -256,7 +256,7 @@ pub const Stack = union(enum) {
     address: usize,
     /// Place the stack at the end of the n-th ram memory region.
     ram_region_index: usize,
-    /// Place the stack end at a symbol address.
+    /// Place the stack at a symbol's address.
     symbol_name: []const u8,
 };
 

--- a/build-internals/build.zig
+++ b/build-internals/build.zig
@@ -59,18 +59,11 @@ pub const Target = struct {
     /// if present.
     board: ?Board = null,
 
-    /// Provide a custom linker script for the hardware or define a custom generation.
+    /// Provides a custom linker script for the hardware or define a custom generation.
     linker_script: LinkerScript = .{},
 
     /// Provides the stack end for the target.
-    stack_end: union(enum) {
-        /// Place the stack end at a fixed address.
-        address: usize,
-        /// Place the stack at the end of the n-th ram memory region.
-        ram_region_index: usize,
-        /// Place the stack end at a symbol address.
-        symbol_name: []const u8,
-    } = .{ .ram_region_index = 0 },
+    stack: Stack = .{ .ram_region_index = 0 },
 
     /// (optional) Explicitly set the entry point.
     entry: ?Build.Step.Compile.Entry = null,
@@ -256,6 +249,15 @@ pub const LinkerScript = struct {
             } = .flash,
         },
     };
+};
+
+pub const Stack = union(enum) {
+    /// Place the stack at a fixed address.
+    address: usize,
+    /// Place the stack at the end of the n-th ram memory region.
+    ram_region_index: usize,
+    /// Place the stack end at a symbol address.
+    symbol_name: []const u8,
 };
 
 /// A descriptor for memory regions in a microcontroller.

--- a/build.zig
+++ b/build.zig
@@ -386,7 +386,7 @@ pub fn MicroBuild(port_select: PortSelect) type {
                 region.validate_tag();
             }
 
-            // TODO: use unions when they are supported
+            // TODO: use unions when they are supported in the build system
             const EndOfStack = struct {
                 address: ?usize = null,
                 symbol_name: ?[]const u8 = null,

--- a/build.zig
+++ b/build.zig
@@ -10,6 +10,7 @@ pub const HardwareAbstractionLayer = internals.HardwareAbstractionLayer;
 pub const Board = internals.Board;
 pub const BinaryFormat = internals.BinaryFormat;
 pub const LinkerScript = internals.LinkerScript;
+pub const Stack = internals.Stack;
 pub const MemoryRegion = internals.MemoryRegion;
 
 const regz = @import("tools/regz");
@@ -333,6 +334,9 @@ pub fn MicroBuild(port_select: PortSelect) type {
             /// If set, overrides the `linker_script` property of the target.
             linker_script: ?LinkerScript = null,
 
+            /// If set, overrides the `stack` property of the target.
+            stack: ?Stack = null,
+
             /// If set, overrides the default `entry` property of the arget.
             entry: ?Build.Step.Compile.Entry = null,
 
@@ -382,12 +386,13 @@ pub fn MicroBuild(port_select: PortSelect) type {
                 region.validate_tag();
             }
 
-            const EndOfStack = union(enum) {
-                address: usize,
-                symbol_name: []const u8,
+            // TODO: use unions when they are supported
+            const EndOfStack = struct {
+                address: ?usize = null,
+                symbol_name: ?[]const u8 = null,
             };
 
-            const end_of_stack: EndOfStack = switch (options.stack_end) {
+            const end_of_stack: EndOfStack = switch (options.stack orelse options.target.stack) {
                 .address => |address| .{ .address = address },
                 .ram_region_index => |index| blk: {
                     var i: usize = 0;

--- a/build.zig
+++ b/build.zig
@@ -382,13 +382,24 @@ pub fn MicroBuild(port_select: PortSelect) type {
                 region.validate_tag();
             }
 
-            // TODO: let the user override which ram section to use the stack on,
-            // for now just using the first ram section in the memory region list
-            const first_ram = blk: {
-                for (target.chip.memory_regions) |region| {
-                    if (region.tag == .ram)
-                        break :blk region;
-                } else @panic("no ram memory region found for setting the end-of-stack address");
+            const EndOfStack = union(enum) {
+                address: usize,
+                symbol_name: []const u8,
+            };
+
+            const end_of_stack: EndOfStack = switch (options.stack_end) {
+                .address => |address| .{ .address = address },
+                .ram_region_index => |index| blk: {
+                    var i: usize = 0;
+                    for (target.chip.memory_regions) |region| {
+                        if (region.tag == .ram) {
+                            if (i == index)
+                                break :blk .{ .address = region.offset + region.length };
+                            i += 1;
+                        }
+                    } else @panic("no ram memory region found for setting the end-of-stack address");
+                },
+                .symbol_name => |name| .{ .symbol_name = name },
             };
 
             const zig_resolved_target = b.resolveTargetQuery(options.zig_target orelse target.zig_target);
@@ -404,7 +415,7 @@ pub fn MicroBuild(port_select: PortSelect) type {
             config.addOption([]const u8, "cpu_name", cpu.name);
             config.addOption([]const u8, "chip_name", target.chip.name);
             config.addOption(?[]const u8, "board_name", if (maybe_board) |board| board.name else null);
-            config.addOption(usize, "end_of_stack", first_ram.offset + first_ram.length);
+            config.addOption(EndOfStack, "end_of_stack", end_of_stack);
             config.addOption(bool, "ram_image", target.ram_image);
 
             const core_mod = b.createModule(.{

--- a/core/src/cpus/cortex_m.zig
+++ b/core/src/cpus/cortex_m.zig
@@ -667,7 +667,7 @@ pub const startup_logic = struct {
     // must be aligned to 256 as VTOR ignores the lower 8 bits of the address.
     pub const _vector_table: VectorTable align(256) = blk: {
         var tmp: VectorTable = .{
-            .initial_stack_pointer = microzig.config.end_of_stack,
+            .initial_stack_pointer = microzig.utilities.get_end_of_stack(),
             .Reset = .{ .c = microzig.cpu.startup_logic._start },
         };
 

--- a/core/src/utilities.zig
+++ b/core/src/utilities.zig
@@ -484,3 +484,13 @@ pub fn dump_stack_trace(trace: *std.builtin.StackTrace) usize {
 
     return frame_count;
 }
+
+pub fn get_end_of_stack() *const anyopaque {
+    if (microzig.config.end_of_stack.address) |address| {
+        return @ptrFromInt(address);
+    } else if (microzig.config.end_of_stack.symbol_name) |sym_name| {
+        return @extern(*const anyopaque, .{ .name = sym_name });
+    } else {
+        @panic("expected at least one of end_of_stack.address or end_of_stack.symbol_name to be set");
+    }
+}

--- a/port/espressif/esp/src/cpus/esp_riscv.zig
+++ b/port/espressif/esp/src/cpus/esp_riscv.zig
@@ -259,9 +259,10 @@ pub const startup_logic = switch (cpu_config.boot_mode) {
         fn _start() linksection("microzig_flash_start") callconv(.c) noreturn {
             interrupt.disable_interrupts();
 
+            const eos = comptime microzig.utilities.get_end_of_stack();
             asm volatile ("mv sp, %[eos]"
                 :
-                : [eos] "r" (@as(u32, microzig.config.end_of_stack)),
+                : [eos] "r" (@as(u32, @intFromPtr(eos))),
             );
 
             asm volatile (
@@ -291,11 +292,12 @@ pub const startup_logic = switch (cpu_config.boot_mode) {
         };
 
         fn _start() callconv(.naked) noreturn {
+            const eos = comptime microzig.utilities.get_end_of_stack();
             asm volatile (
                 \\mv sp, %[eos]
                 \\jal _start_c
                 :
-                : [eos] "r" (@as(u32, microzig.config.end_of_stack)),
+                : [eos] "r" (@as(u32, @intFromPtr(eos))),
             );
         }
 

--- a/port/raspberrypi/rp2xxx/src/cpus/hazard3.zig
+++ b/port/raspberrypi/rp2xxx/src/cpus/hazard3.zig
@@ -178,9 +178,10 @@ pub const startup_logic = struct {
             \\.option pop
         );
 
+        const eos = comptime microzig.utilities.get_end_of_stack();
         asm volatile ("mv sp, %[eos]"
             :
-            : [eos] "r" (@as(u32, microzig.config.end_of_stack)),
+            : [eos] "r" (@as(u32, @intFromPtr(eos))),
         );
 
         asm volatile (

--- a/port/raspberrypi/rp2xxx/src/hal/bootmeta.zig
+++ b/port/raspberrypi/rp2xxx/src/hal/bootmeta.zig
@@ -21,7 +21,7 @@ pub const image_def_block = if (microzig.config.ram_image and arch == .arm) Bloc
         // the vector table at the start of the image.
         .entry_point = .{
             .entry = &microzig.cpu.startup_logic.ram_image_entry_point,
-            .sp = microzig.cpu.startup_logic._vector_table.initial_stack_pointer,
+            .sp = microzig.utilities.get_end_of_stack(),
         },
     },
     .link = microzig.options.hal.bootmeta.next_block,
@@ -107,7 +107,7 @@ pub fn EntryPoint(with_stack_limit: bool) type {
                 padding: u16 = 0,
             } = .{},
             entry: *const anyopaque,
-            sp: u32,
+            sp: *const anyopaque,
             sp_limit: u32,
         };
     } else {
@@ -118,7 +118,7 @@ pub fn EntryPoint(with_stack_limit: bool) type {
                 padding: u16 = 0,
             } = .{},
             entry: *const anyopaque,
-            sp: u32,
+            sp: *const anyopaque,
         };
     }
 }

--- a/port/wch/ch32v/src/cpus/main.zig
+++ b/port/wch/ch32v/src/cpus/main.zig
@@ -218,10 +218,12 @@ pub const startup_logic = struct {
             \\la gp, __global_pointer$
             \\.option pop
         );
+
         // Set stack pointer.
+        const eos = comptime microzig.utilities.get_end_of_stack();
         asm volatile ("mv sp, %[eos]"
             :
-            : [eos] "r" (@as(u32, microzig.config.end_of_stack)),
+            : [eos] "r" (@as(u32, @intFromPtr(eos))),
         );
 
         // NOTE: this can only be called once. Otherwise, we get a linker error for duplicate symbols

--- a/tools/regz/src/arch/arm.zig
+++ b/tools/regz/src/arch/arm.zig
@@ -106,7 +106,7 @@ pub fn write_interrupt_vector(
             \\    const Handler = microzig.interrupt.Handler;
             \\    const unhandled = microzig.interrupt.unhandled;
             \\
-            \\    initial_stack_pointer: u32,
+            \\    initial_stack_pointer: *const anyopaque,
             \\    Reset: Handler,
             \\
         );


### PR DESCRIPTION
* Allow for arbitrary ram sections to be used for stacks as well as the address of a symbol
* Modify regz generated vector table to use `*const anyopaque` instead of `u32` for the initial stack pointer
* Update cpu code to be compatible with this change