### PR TITLE
Miscellaneous cleanup

### DIFF
--- a/drivers/sensor/ICM-20948.zig
+++ b/drivers/sensor/ICM-20948.zig
@@ -432,7 +432,7 @@ pub const ICM_20948 = struct {
     }
 
     /// Read the register and modify the matching fields as provided
-    pub inline fn modify_register(self: *Self, reg: Self.Register, reg_t: type, fields: anytype) Error!void {
+    pub inline fn modify_register(self: *Self, reg: Self.Register, T: type, fields: anytype) Error!void {
         // Read the current value
         const current_val = self.read_byte(reg) catch |err| {
             log.err("Failed to read register 0x{X:02} for modification: {}", .{ reg.value(), err });
@@ -440,7 +440,7 @@ pub const ICM_20948 = struct {
         };
 
         // Cast to the correct type and modify the named fields
-        var val: reg_t = @bitCast(current_val);
+        var val: T = @bitCast(current_val);
         inline for (@typeInfo(@TypeOf(fields)).@"struct".fields) |field| {
             @field(val, field.name) = @field(fields, field.name);
         }

--- a/examples/nordic/nrf5x/src/i2c_bus_scan.zig
+++ b/examples/nordic/nrf5x/src/i2c_bus_scan.zig
@@ -4,8 +4,6 @@ const time = microzig.drivers.time;
 const board = microzig.board;
 const nrf = microzig.hal;
 
-const I2CError = microzig.drivers.base.I2C_Device.Error;
-
 const gpio = nrf.gpio;
 const i2c = nrf.i2c;
 const i2cdma = nrf.i2cdma;
@@ -47,8 +45,8 @@ pub fn main() !void {
 
         var rx_data: [1]u8 = undefined;
         _ = i2c0.read_blocking(a, &rx_data, null) catch |e| {
-            if (e != I2CError.DeviceNotPresent and
-                e != I2CError.TargetAddressReserved)
+            if (e != i2c.Error.DeviceNotPresent and
+                e != i2c.Error.IllegalAddress)
                 std.log.info("Error {any}", .{e});
             continue;
         };
@@ -69,8 +67,8 @@ pub fn main() !void {
 
         var rx_data: [1]u8 = undefined;
         _ = i2c0dma.read_blocking(a, &rx_data, null) catch |e| {
-            if (e != I2CError.DeviceNotPresent and
-                e != I2CError.TargetAddressReserved)
+            if (e != i2c.Error.DeviceNotPresent and
+                e != i2c.Error.IllegalAddress)
                 std.log.info("Error {any}", .{e});
             continue;
         };

--- a/examples/raspberrypi/rp2xxx/src/i2c_bus_scan.zig
+++ b/examples/raspberrypi/rp2xxx/src/i2c_bus_scan.zig
@@ -5,7 +5,6 @@ const time = microzig.drivers.time;
 const rp2xxx = microzig.hal;
 const i2c = rp2xxx.i2c;
 const gpio = rp2xxx.gpio;
-const peripherals = microzig.chip.peripherals;
 
 const uart = rp2xxx.uart.instance.num(0);
 const baud_rate = 115200;

--- a/examples/raspberrypi/rp2xxx/src/i2c_bus_scan.zig
+++ b/examples/raspberrypi/rp2xxx/src/i2c_bus_scan.zig
@@ -43,7 +43,12 @@ pub fn main() !void {
         const a: i2c.Address = @enumFromInt(addr);
 
         var rx_data: [1]u8 = undefined;
-        _ = i2c0.read_blocking(a, &rx_data, time.Duration.from_ms(100)) catch continue;
+        _ = i2c0.read_blocking(a, &rx_data, null) catch |e| {
+            if (e != i2c.Error.DeviceNotPresent and
+                e != i2c.Error.IllegalAddress)
+                std.log.info("Error {any}", .{e});
+            continue;
+        };
 
         std.log.info("I2C device found at address {X}.", .{addr});
     }

--- a/tools/uf2/src/uf2.zig
+++ b/tools/uf2/src/uf2.zig
@@ -201,10 +201,6 @@ pub const Flags = packed struct(u32) {
     md5_checksum_present: bool,
     extension_tags_present: bool,
     padding: u16 = 0,
-
-    comptime {
-        assert(@sizeOf(Flags) == @sizeOf(u32));
-    }
 };
 
 const first_magic = 0x0a324655;


### PR DESCRIPTION
* Fix error checks in bus scan (Read returns illegal address, not reserved)
* Rename `get_register` in the ICM-20948 driver to `get_reg` for consistency
* Remove redundant comptime size check: The size is verified because the packed struct has a size