### PR TITLE
nrf5x: Use RTC for timekeeping, track overflows for extra bits

### DIFF
--- a/examples/nordic/nrf5x/src/blinky.zig
+++ b/examples/nordic/nrf5x/src/blinky.zig
@@ -4,6 +4,14 @@ const board = microzig.board;
 const nrf = microzig.hal;
 const time = nrf.time;
 
+const rtc_overflow_interrupt = nrf.time.rtc_overflow_interrupt;
+
+pub const microzig_options = microzig.Options{
+    .log_level = .debug,
+    .logFn = nrf.uart.log,
+    .interrupts = .{ .RTC0 = .{ .c = rtc_overflow_interrupt } },
+};
+
 pub fn main() !void {
     board.init();
 

--- a/port/nordic/nrf5x/src/hal.zig
+++ b/port/nordic/nrf5x/src/hal.zig
@@ -8,7 +8,7 @@ pub const spim = @import("hal/spim.zig");
 pub const time = @import("hal/time.zig");
 pub const uart = @import("hal/uart.zig");
 pub const drivers = @import("hal/drivers.zig");
-// TODO: adc, timers, pwm, rng, rtc, interrupts, i2c, wdt, wifi, nfc, bt, zigbee
+// TODO: adc, timers, pwm, rng, rtc alarms, interrupts, wdt, wifi, nfc, bt, zigbee
 
 pub fn init() void {
     time.init();

--- a/port/nordic/nrf5x/src/hal/time.zig
+++ b/port/nordic/nrf5x/src/hal/time.zig
@@ -3,6 +3,10 @@
 ///
 /// This module hogs TIMER0.
 /// It uses CC1 as the register to read the current count from.
+/// It also sets up an interrupt to fire when the 32 bit timer overflows, so that we are able to
+/// count them and keep time for centuries.
+/// It does this by setting up a comparator in CC0, and configures it to fire an interrupt when this
+/// happen. This interrupt handler simply increments the high value.
 const std = @import("std");
 const microzig = @import("microzig");
 const time = microzig.drivers.time;
@@ -18,6 +22,7 @@ const version: enum {
 };
 
 const timer = microzig.chip.peripherals.TIMER0;
+// const INTERRUPT_INDEX = 0;
 const READ_INDEX = 1;
 
 var overflow_count: u32 = 0;
@@ -50,6 +55,17 @@ pub fn init() void {
             timer.PRESCALER.write(.{ .PRESCALER = 4 });
         },
     }
+
+    // TODO: Set an interrupt to fire when the timer overflows, and keep track of the count, that
+    // way we get more than 2^32 us.
+    // Set the comparator to trigger on overflow
+    // timer.CC[INTERRUPT_INDEX].write(.{ .CC = 0xFFFFFFFF });
+    // Enable interrupt firing
+    // timer.INTENSET.modify(.{ .COMPARE0 = .Enabled });
+    // Automatically clear the event on trigger
+    // timer.SHORTS.modify(.{ .COMPARE0_CLEAR = .Enabled });
+    // Clear events
+    // timer.EVENTS_COMPARE[INTERRUPT_INDEX].write(.{ .EVENTS_COMPARE = .NotGenerated });
 }
 
 pub fn get_time_since_boot() time.Absolute {


### PR DESCRIPTION
The nrf TIMER is 32 bits, and with prescaler set to 4, it would count at exactly 1MHz.

This would overflow every 4294 seconds, which is not enough for many uses.

We could increase the prescaler up to 9, splitting the 32MHz clock to 62500Hz, which would still overflow every 68719 seconds, which is still less than a day.

The original plan was to set an interrupt to fire on overflow, to increment a counter, which could be used to add bits to this value, easily getting us 64 bits. The problem is that it introduced a race condition, because we could try to build the time extra when it overflowed, which would yield us an incorrect count (e.g. off by 4294 seconds). The way that [embassy](https://github.com/embassy-rs/embassy/blob/main/embassy-nrf/src/time_driver.rs) gets around this is by incrementing the counter when it overflows, as well as when it hits the halfway point, and then, depending on the value of the extra bits, choose to toggle the top bit of the counter or not.

Unfortunately, the TIMER register does not have the ability to fire an interrupt when it overflows, only when it hits a compare value. We could probably use two compare values (half way and on overflow), but I think it's probably better to follow the lead of embassy and use RTC, which has an explicit overflow event.

By user 23 bits of timer, with an interrupt that fires at 0x800000 and on overflow, we can track the time for 23 + 32 == 55 ticks.

This timer runs at a slower 32'768 Hz, which means we sacrifice granularity, but for timekeeping usually in the ms (not us) scale, it should not be a problem.