### PR TITLE
rp2xxx: fix incorrect parameter in define name comparison

### DIFF
--- a/port/raspberrypi/rp2xxx/src/hal/pio/assembler.zig
+++ b/port/raspberrypi/rp2xxx/src/hal/pio/assembler.zig
@@ -49,7 +49,7 @@ pub const Output = struct {
         comptime name: []const u8,
     ) u32 {
         return for (output.defines) |define| {
-            if (std.mem.eql(u8, define.name, define))
+            if (std.mem.eql(u8, name, define.name))
                 break define;
         } else @panic(std.fmt.comptimePrint("define '{s}' not found", .{name}));
     }


### PR DESCRIPTION
Just a small oversight I ran into while trying to get a define by name from an assembled PIO program. Clearly, the comparison is supposed to be between the desired `name` and the current `define.name`, just as in `get_program_by_name`.