### PR TITLE
nrf52: Add rtt example

### DIFF
--- a/examples/nordic/nrf5x/build.zig
+++ b/examples/nordic/nrf5x/build.zig
@@ -29,6 +29,7 @@ pub fn build(b: *std.Build) void {
         .{ .target = nrf52840_mdk, .name = "nrf52840_mdk_i2c_accel", .file = "src/i2c_accel.zig" },
         .{ .target = nrf52840_mdk, .name = "nrf52840_mdk_i2c_hall_effect", .file = "src/i2c_hall_effect.zig" },
         .{ .target = nrf52840_mdk, .name = "nrf52840_mdk_i2c_temp", .file = "src/i2c_temp.zig" },
+        .{ .target = nrf52840_mdk, .name = "nrf52840_mdk_rtt_log", .file = "src/rtt_log.zig" },
         .{ .target = nrf52840_mdk, .name = "nrf52840_mdk_spi_master", .file = "src/spi_master.zig" },
 
         .{ .target = pca10040, .name = "pca10040_blinky", .file = "src/blinky.zig" },

--- a/examples/nordic/nrf5x/src/rtt_log.zig
+++ b/examples/nordic/nrf5x/src/rtt_log.zig
@@ -1,0 +1,92 @@
+const std = @import("std");
+const microzig = @import("microzig");
+const mdf = microzig.drivers;
+const board = microzig.board;
+const nrf = microzig.hal;
+const time = nrf.time;
+
+const rtt = microzig.cpu.rtt;
+// Configure RTT with all default settings:
+const rtt_instance = rtt.RTT(.{});
+
+// Set up RTT channel 0 as a logger
+var rtt_logger: ?rtt_instance.Writer = null;
+
+pub fn log(
+    comptime level: std.log.Level,
+    comptime scope: @TypeOf(.EnumLiteral),
+    comptime format: []const u8,
+    args: anytype,
+) void {
+    const level_prefix = comptime "[{}.{:0>6}] " ++ level.asText();
+    const prefix = comptime level_prefix ++ switch (scope) {
+        .default => ": ",
+        else => " (" ++ @tagName(scope) ++ "): ",
+    };
+    if (rtt_logger) |*writer| {
+        const current_time = time.get_time_since_boot();
+        const seconds = current_time.to_us() / std.time.us_per_s;
+        const microseconds = current_time.to_us() % std.time.us_per_s;
+        writer.interface.print(prefix ++ format ++ "\r\n", .{ seconds, microseconds } ++ args) catch {};
+        // Don't forget to flush! This never returns an error with how the Writer interface is implemented
+        // so unreachable is appropriate here.
+        writer.interface.flush() catch unreachable;
+    }
+}
+
+pub const microzig_options = microzig.Options{
+    .log_level = .debug,
+    .logFn = log,
+};
+
+pub fn main() !void {
+    board.init();
+
+    // Nothing will work if you don't initialize the RTT control block first!
+    rtt_instance.init();
+    // Manually write some bytes to RTT up channel 0 so that it shows up in RTT Viewer
+    _ = rtt_instance.write(0, "Hello RTT!\n");
+    // Use std.log instead by instantiating a Writer our log function can use, here we aren't buffering
+    // so all writes will go immediately to RTT up channel
+    rtt_logger = rtt_instance.writer(0, &.{});
+
+    // Instantiate a Reader for RTT down channel 0, giving it an internal buffer that is as big as the max
+    // line length we expect. This allows us to utilize the std.Io.Reader interface to read until a delimiter.
+    const max_line_len = 64;
+    var rtt_reader_buffer: [max_line_len]u8 = undefined;
+    var reader = rtt_instance.reader(0, &rtt_reader_buffer);
+
+    // For blinking our LED on a timeout without blocking
+    var blink_deadline = mdf.time.make_timeout_us(time.get_time_since_boot(), 500_000);
+    var hello_deadline = mdf.time.make_timeout_us(time.get_time_since_boot(), 2_000_000);
+
+    while (true) {
+        const now = time.get_time_since_boot();
+
+        // Toggle LED every 500 msec
+        if (blink_deadline.is_reached_by(now)) {
+            board.led1.toggle();
+            blink_deadline = mdf.time.make_timeout_us(now, 500_000);
+        }
+        // Say hello every 2 seconds
+        if (hello_deadline.is_reached_by(now)) {
+            std.log.info("Hello!", .{});
+            hello_deadline = mdf.time.make_timeout_us(now, 2_000_000);
+        }
+        // Attempt to read an entire line from RTT
+        const line_maybe: ?[]const u8 = reader.interface.takeDelimiterExclusive('\n') catch |err| switch (err) {
+            error.EndOfStream => null, // EndOfStream can be safely ignored, this just means there wasn't anything in the RTT buffer
+            error.StreamTooLong => v: {
+                std.log.err("Line overflowed internal buffer, discarding buffer", .{});
+                // Need to purge whatever is in the buffer to read more data as takeDelimiterExclusive() on error
+                // leaves the stream state unmodified
+                reader.interface.tossBuffered();
+                break :v null;
+            },
+            else => unreachable,
+        };
+        if (line_maybe) |line| {
+            std.log.info("Got a line: \"{s}\"", .{line});
+        }
+    }
+}

--- a/modules/rtt/README.md
+++ b/modules/rtt/README.md
@@ -4,9 +4,10 @@ An implementation of [Segger's RTT protocol](https://wiki.segger.com/RTT) in pur
 
 ## Installation
 
-This package is included as a part of MicroZig. Currently only Cortex-M CPU targets have RTT support. To access the
-rtt module, import it like so:
-``` Zig
+This package is included as a part of MicroZig. Currently only Cortex-M CPU targets have RTT
+support. To access the rtt module, import it like so:
+
+```zig
 const microzig = @import("microzig");
 const rtt = microzig.cpu.rtt;
 ```
@@ -14,7 +15,7 @@ const rtt = microzig.cpu.rtt;
 ## Configuration
 
 RTT is configured by creating the RTT "type" at `comptime` like so:
-```Zig
+```zig
 // rtt.RTT takes an rtt.Config
 const rtt_instance = rtt.RTT(.{
     // A slice of rtt.channel.Config for target -> probe communication
@@ -47,35 +48,41 @@ original RTT default config which is:
 
 ### Custom Thread Safety
 
-This package exposes a `GenericLock` function that creates a type given lock/unlock functions and a type for "context" to pass
-to each function. This type has a method `any()`, that returns a type erased `AnyLock` that can be passed to a `rtt.Config`.
-Users can utilize this API to specify their own custom lock/unlock behavior for RTT to use if the default behavior isn't desired.
-Assigning `null` to `.exclusive_access` disables thread safety entirely.
+This package exposes a `GenericLock` function that creates a type given lock/unlock functions and a
+type for "context" to pass to each function. This type has a method `any()`, that returns a type
+erased `AnyLock` that can be passed to a `rtt.Config`. Users can utilize this API to specify their
+own custom lock/unlock behavior for RTT to use if the default behavior isn't desired. Assigning
+`null` to `.exclusive_access` disables thread safety entirely.
 
 ## Usage
 
 Once an rtt instance is configured, the API is quite simple:
-- `init()` properly initializes the control block memory, and _must_ be called before any other RTT operations take place
-- `fn write(comptime channel_number: usize, bytes: []const u8) usize` writes bytes to a specific up channel
-(device -> probe), where `channel_number` is validated at compile time to exist, and returns number of bytes written
-(writing less than requested bytes is not an error)
-- `fn writer(comptime channel_number: usize, buf: []u8) Writer` returns a struct that implements the `std.Io.Writer`
-interface for a specific up channel. Allows integration with the standard library functions that use this type.
-A special note is that the `Writer` discards write data when the RTT up channel write buffer is full. While this can
-lead to data loss if the up buffer isn't big enough and getting written too fast/frequently, it prevents the
-undesirable behavior of constantly returning a `WriteError` if a debug probe isn't connected. See the implementation
-code for more details.
-- `fn read(comptime channel_number: usize, bytes: []u8) usize` reads bytes from a specific down channel
-(probe -> device), where `channel_number` is validated at compile time to exist, and returns number of bytes read
-(reading less than requested bytes is not an error)
-- `fn reader(comptime channel_number: usize, buf: []u8) Reader` returns a struct that implements the `std.Io.Reader`
-interface for a specific down channel. See implementation and doc comments for more information on choosing a buffer. 
+- `init()` properly initializes the control block memory, and _must_ be called before any other RTT
+  operations take place
+- `fn write(comptime channel_number: usize, bytes: []const u8) usize` writes bytes to a specific up
+  channel (device -> probe), where `channel_number` is validated at compile time to exist, and
+  returns number of bytes written (writing less than requested bytes is not an error)
+- `fn writer(comptime channel_number: usize, buf: []u8) Writer` returns a struct that implements the
+  `std.Io.Writer` interface for a specific up channel. Allows integration with the standard library
+  functions that use this type. A special note is that the `Writer` discards write data when the RTT
+  up channel write buffer is full. While this can lead to data loss if the up buffer isn't big
+  enough and getting written too fast/frequently, it prevents the undesirable behavior of constantly
+  returning a `WriteError` if a debug probe isn't connected. See the implementation code for more
+  details.
+- `fn read(comptime channel_number: usize, bytes: []u8) usize` reads bytes from a specific down
+  channel (probe -> device), where `channel_number` is validated at compile time to exist, and
+  returns number of bytes read (reading less than requested bytes is not an error)
+- `fn reader(comptime channel_number: usize, buf: []u8) Reader` returns a struct that implements the
+  `std.Io.Reader` interface for a specific down channel. See implementation and doc comments for
+  more information on choosing a buffer.
 
-See the [example](../../examples/raspberrypi/rp2xxx/src/rtt_log.zig) for more information on using this package.
+See the [example](../../examples/raspberrypi/rp2xxx/src/rtt_log.zig) for more information on using
+this package.
 
 ## TODO:
 - Support for CPUs with caches (cache alignment + cache access considerations) to mirror the
-`SEGGER_RTT_CPU_CACHE_LINE_SIZE` and `SEGGER_RTT_UNCACHED_OFF` macros in original Segger source
+  `SEGGER_RTT_CPU_CACHE_LINE_SIZE` and `SEGGER_RTT_UNCACHED_OFF` macros in original Segger source
 - Support for virtual terminals supported by RTT viewer
 - Support for ANSI terminal color escape codes supported by RTT viewer
-- Compile time option for returning a `WriteError` from `Writer` when attempting to write a full RTT buffer
+- Compile time option for returning a `WriteError` from `Writer` when attempting to write a full RTT
+  buffer


### PR DESCRIPTION
Wanted to try out RTT, and I already had my nrf52 connected to the debugger. Confirmed it worked, so figured I'd add an example.

Copied almost exactly from the rp2xxx example.

```
$ pyocd rtt
...
0000355 I 1 up channels and 1 down channels found [rtt_cmd]
0000355 I Reading from up channel 0 ("Terminal") [rtt_cmd]
0000356 I Writing to down channel 0 ("Terminal") [rtt_cmd]
Hello RTT!
[2.000030] info: Hello!
[4.000000] info: Hello!
[6.000000] info: Hello!
[8.000000] info: Hello!
[10.000000] info: Hello!
h[10.476501] info: Got a line: "h"
e[10.911987] info: Got a line: "e"
l[11.229705] info: Got a line: "l"
l[11.391265] info: Got a line: "l"
o[11.476043] info: Got a line: "o"
```