### PR TITLE
CircularBuffer fn get_readable_len did not account for full case

### DIFF
--- a/core/src/utilities.zig
+++ b/core/src/utilities.zig
@@ -542,7 +542,8 @@ pub fn CircularBuffer(comptime T: type, comptime len: usize) type {
 
         pub fn get_readable_len(buffer: *const Self) usize {
             buffer.assert_valid();
-
+            if (buffer.full)
+                return len;
             return if (buffer.start <= buffer.end)
                 buffer.end - buffer.start
             else


### PR DESCRIPTION
I've never tried to do a pull request before please let me know if there is a better or more correct way.  

When buffer.start == buffer.end it could be full or empty.