### PR TITLE
Ensure RP2040 tx buffer control is respected

### DIFF
--- a/port/raspberrypi/rp2xxx/src/hal/usb.zig
+++ b/port/raspberrypi/rp2xxx/src/hal/usb.zig
@@ -254,7 +254,7 @@ pub fn F(comptime config: UsbConfig) type {
             // TODO: assert!(UsbDir::of_endpoint_addr(ep.descriptor.endpoint_address) == UsbDir::In);
 
             const ep = hardware_endpoint_get_by_address(ep_addr);
-            // wait for controller to give processor ownership of the buffer before writing it. 
+            // wait for controller to give processor ownership of the buffer before writing it.
             while (ep.buffer_control.?.read().AVAILABLE_0 == 1) {}
 
             // TODO: please fixme: https://github.com/ZigEmbeddedGroup/microzig/issues/452

--- a/port/raspberrypi/rp2xxx/src/hal/usb.zig
+++ b/port/raspberrypi/rp2xxx/src/hal/usb.zig
@@ -254,6 +254,8 @@ pub fn F(comptime config: UsbConfig) type {
             // TODO: assert!(UsbDir::of_endpoint_addr(ep.descriptor.endpoint_address) == UsbDir::In);
 
             const ep = hardware_endpoint_get_by_address(ep_addr);
+            // wait for controller to give processor ownership of the buffer before writing it. 
+            while (ep.buffer_control.?.read().AVAILABLE_0 == 1) {}
 
             // TODO: please fixme: https://github.com/ZigEmbeddedGroup/microzig/issues/452
             std.mem.copyForwards(u8, ep.data_buffer[0..buffer.len], buffer);


### PR DESCRIPTION
See also "4.1.2.7.1. Concurrent access" in the RP2040 datasheet.