### PR TITLE
RP2040 ADC handle the 500Khz sampling case

### DIFF
--- a/port/raspberrypi/rp2xxx/src/hal/adc.zig
+++ b/port/raspberrypi/rp2xxx/src/hal/adc.zig
@@ -60,10 +60,11 @@ pub fn apply(config: Config) void {
     });
 
     if (config.sample_frequency) |sample_frequency| {
+        assert(sample_frequency <= 500_000);
         const cycles = (48_000_000 * 256) / @as(u64, sample_frequency);
         ADC.DIV.write(.{
             .FRAC = @as(u8, @truncate(cycles)),
-            .INT = @as(u16, @intCast((cycles >> 8) - 1)),
+            .INT = @as(u16, @intCast((cycles >> 8))),
         });
     }
 


### PR DESCRIPTION
Setting 500khz causes a 95 to be set in .INT resulting in a one clock too early trigger - while the conversion is still happening.  The minus one is not accurate.

Also adding an assert because (in my opinion)  nobody using this API is intending to set a .INT of less than 96