### PR TITLE
rp2xxx: Cleanup linker scripts

### DIFF
--- a/port/raspberrypi/rp2xxx/ld/rp2350/arm_ram_image_sections.ld
+++ b/port/raspberrypi/rp2xxx/ld/rp2350/arm_ram_image_sections.ld
@@ -7,12 +7,3 @@ SECTIONS {
   } > ram0
 }
 INSERT AFTER .ram_start;
-
-SECTIONS {
-  .ram_vectors (NOLOAD) :
-  {
-    KEEP(*(ram_vectors))
-  } > ram0
-}
-INSERT AFTER .bss;
-

--- a/port/raspberrypi/rp2xxx/ld/rp2350/arm_sections.ld
+++ b/port/raspberrypi/rp2xxx/ld/rp2350/arm_sections.ld
@@ -7,12 +7,3 @@ SECTIONS {
   } > flash0
 }
 INSERT AFTER .flash_start;
-
-SECTIONS {
-  .ram_vectors (NOLOAD) :
-  {
-    KEEP(*(ram_vectors))
-  } > ram0
-}
-INSERT AFTER .bss;
-

--- a/port/raspberrypi/rp2xxx/ld/rp2350/riscv_ram_image_sections.ld
+++ b/port/raspberrypi/rp2xxx/ld/rp2350/riscv_ram_image_sections.ld
@@ -5,19 +5,5 @@ SECTIONS {
     KEEP(*(.bootmeta))
     __bootmeta_end__ = .;
   } > ram0
-
-  .vectors :
-  {
-    KEEP(*(core_vectors))
-  } > ram0
 }
 INSERT AFTER .ram_start;
-
-SECTIONS {
-  .ram_vectors (NOLOAD) :
-  {
-    KEEP(*(ram_vectors))
-  } > ram0
-}
-INSERT AFTER .bss;
-

--- a/port/raspberrypi/rp2xxx/ld/rp2350/riscv_sections.ld
+++ b/port/raspberrypi/rp2xxx/ld/rp2350/riscv_sections.ld
@@ -5,20 +5,5 @@ SECTIONS {
     KEEP(*(.bootmeta))
     __bootmeta_end__ = .;
   } > flash0
-
-  .vectors :
-  {
-    KEEP(*(core_vectors))
-    KEEP(*(flash_vectors))
-  } > flash0
 }
 INSERT AFTER .flash_start;
-
-SECTIONS {
-  .ram_vectors (NOLOAD) :
-  {
-    KEEP(*(ram_vectors))
-  } > ram0
-}
-INSERT AFTER .bss;
-


### PR DESCRIPTION
Remove unused `.ram_vectors` and `.core_vectors` sections