### PR TITLE
rp2xxx: PIO: Fix sideset having no way to account for optional bit

### DIFF
--- a/port/raspberrypi/rp2xxx/src/hal/pio/common.zig
+++ b/port/raspberrypi/rp2xxx/src/hal/pio/common.zig
@@ -517,11 +517,9 @@ pub fn PioImpl(EnumType: type, chip: Chip) type {
             program: Program,
             options: LoadAndStartProgramOptions(chip),
         ) !void {
+            // We don't account for the optional bit here because it's not known to the pin_mappings
             const expected_side_set_pins = if (program.side_set) |side_set|
-                if (side_set.optional)
-                    side_set.count + 1
-                else
-                    side_set.count
+                side_set.count
             else
                 0;
 


### PR DESCRIPTION
If sideset is optional, then SIDESET_COUNT needs to account for that extra bit.

Because that option was not available to `sm_set_pin_mappings`, I had to plumb it through.