### PR TITLE
refactor "generate_vector_table" and update affected examples

### DIFF
--- a/core/src/microzig.zig
+++ b/core/src/microzig.zig
@@ -88,6 +88,7 @@ pub const Options = struct {
         }
     }.log,
     interrupts: InterruptOptions = .{},
+    overwrite_hal_interrupts: bool = false, //force overwrite the Hal default interrupts
     cpu: CPU_Options = .{},
     hal: HAL_Options = .{},
 

--- a/examples/stmicro/stm32/src/stm32f1xx/timer_capture.zig
+++ b/examples/stmicro/stm32/src/stm32f1xx/timer_capture.zig
@@ -23,6 +23,7 @@ const TX = gpio.Pin.from_port(.A, 9);
 pub const microzig_options = microzig.Options{
     .logFn = stm32.uart.log,
     .interrupts = .{ .TIM2 = .{ .c = isr_tim2 } },
+    .overwrite_hal_interrupts = true,
 };
 
 const comp = GPTimer.init(.TIM2);


### PR DESCRIPTION
The vector generator now checks if the user interrupt overwrites an internal HAL interrupt and generates an error if "overwrite_hal_interrupts" is false.