### PR TITLE
stm32f303: examples: hts221: Fix

### DIFF
--- a/examples/stmicro/stm32/src/stm32f303/hts221.zig
+++ b/examples/stmicro/stm32/src/stm32f303/hts221.zig
@@ -33,9 +33,9 @@ pub noinline fn main() !void {
         },
     }).apply();
 
-    var i2c1 = stm32.i2c.I2CDevice.init(.I2C1);
+    var i2c1 = stm32.i2c.I2C_Device.init(.I2C1);
     try i2c1.apply();
-    var device = i2c1.as_device();
+    var device = i2c1.i2c_device();
 
     var hts221 = HTS221.init(&device);
     try hts221.configure(.{


### PR DESCRIPTION
#748 was merged just a touch too early, it was waiting for #746 to get merged to fix the name of the function and type, but got merged right after, so that example uses the old name.