### PR TITLE
ch32v: Improve timekeeping

### DIFF
--- a/port/wch/ch32v/src/cpus/main.zig
+++ b/port/wch/ch32v/src/cpus/main.zig
@@ -479,9 +479,4 @@ pub const csr = struct {
     pub const cpmpocr = Csr(0xBC3, u32);
     pub const cmcr = Csr(0xBD0, u32);
     pub const cinfor = Csr(0xFC0, u32);
-
-    // Cycle counters
-    pub const cycle = riscv32_common.csr.cycle;
-    pub const cycleh = riscv32_common.csr.cycleh;
-    pub const mcountinhibit = riscv32_common.csr.mcountinhibit;
 };

--- a/port/wch/ch32v/src/hals/ch32v20x.zig
+++ b/port/wch/ch32v/src/hals/ch32v20x.zig
@@ -6,8 +6,8 @@ pub const clocks = @import("clocks.zig");
 pub const time = @import("time.zig");
 
 pub const default_interrupts: microzig.cpu.InterruptOptions = .{
-    // Default SysTick handler provided by the HAL
-    .SysTick = time.systick_handler,
+    // Default TIM2 handler provided by the HAL for 1ms timekeeping
+    .TIM2 = time.tim2_handler,
 };
 
 pub fn init() void {

--- a/port/wch/ch32v/src/hals/ch32v30x.zig
+++ b/port/wch/ch32v/src/hals/ch32v30x.zig
@@ -6,11 +6,11 @@ pub const time = @import("time.zig");
 
 /// Default interrupt handlers provided by the HAL
 pub const default_interrupts: microzig.cpu.InterruptOptions = .{
-    .SysTick = time.systick_handler,
+    .TIM2 = time.tim2_handler,
 };
 
 /// Initialize HAL subsystems used by default
 pub fn init() void {
-    // Configure SysTick timing driver
+    // Configure TIM2 timing driver
     time.init();
 }


### PR DESCRIPTION
- Remove `SysTick` interrupt setup and handler function
- Add `TIM2` interrupt setup and handler function for `time_since_boot`
- Add `delay_us` and `delay_ms` functions which spin waiting on the `SysTick` counter value.
  - This yield tiny code and doesn't need an interrupt, which can save code space, which is at a premium on these tiny chips.
- Remove CSRs I mistakenly exported from _riscv32_common.zig_, they aren't implemented on these chips!