### PR TITLE
esp32c3: Fix alignment of ram text

### DIFF
--- a/port/espressif/esp/ld/esp32_c3/direct_boot_sections.ld
+++ b/port/espressif/esp/ld/esp32_c3/direct_boot_sections.ld
@@ -26,6 +26,7 @@ SECTIONS
     microzig_ram_text_end = .;
   } > IRAM
 
+  . = ALIGN(4);
   _iram_size = . - microzig_ram_text_start;
 
   _dram_start = ORIGIN(DRAM) + _iram_size;


### PR DESCRIPTION
Fix this issue that was made apparent in #750, only because it happens to change the size of code just so.

```
install
└─ install generated to esp32_c3_direct_boot_i2c_bus_scan.elf
   └─ compile exe esp32_c3_direct_boot_i2c_bus_scan Debug riscv32-freestanding-eabi failure
error: warning(link): unexpected LLD stderr:
ld.lld: warning: address (0x3fc805ee) of section .data is not a multiple of alignment (4)


install
└─ install generated to esp32_c3_direct_boot_i2c_display_sh1106.elf
   └─ compile exe esp32_c3_direct_boot_i2c_display_sh1106 Debug riscv32-freestanding-eabi failure
error: warning(link): unexpected LLD stderr:
ld.lld: warning: address (0x3fc805ee) of section .data is not a multiple of alignment (4)


install
└─ install generated to esp32_c3_direct_boot_i2c_temp.elf
   └─ compile exe esp32_c3_direct_boot_i2c_temp Debug riscv32-freestanding-eabi failure
error: warning(link): unexpected LLD stderr:
ld.lld: warning: address (0x3fc805ee) of section .data is not a multiple of alignment (4)
```