### PR TITLE
esp32c3: correctly use END or STOP for I2C reads and writes

### DIFF
--- a/port/espressif/esp/src/hal/i2c.zig
+++ b/port/espressif/esp/src/hal/i2c.zig
@@ -541,6 +541,7 @@ pub const I2C = struct {
         self.reset_fifo();
         self.reset_command_list();
 
+        // See TRM sections 28.5.5.1 and 28.5.8.1 to understand the command structure
         var cmd_idx: usize = 0;
         if (start)
             try self.add_cmd(&cmd_idx, Command.start);
@@ -644,8 +645,8 @@ pub const I2C = struct {
         self.reset_fifo();
         self.reset_command_list();
 
+        // See TRM sections 28.5.1.1 and 28.5.4.1 to understand the command structure
         var cmd_idx: usize = 0;
-
         if (start)
             try self.add_cmd(&cmd_idx, Command.start);
 


### PR DESCRIPTION
This fixes a problem about UnknownAborts (actually Error.ExecutionIncomplete)  on 100KHz I2C.
By looking at the TRM there's a clear distinction between single and multi command sequences, and the HAL now reflects that.
In particular, END command should only be given if we expect more commands to follow, and STOP only when all is done.