### PR TITLE
Add the ability to create tests which can import microzig.

### DIFF
--- a/examples/raspberrypi/rp2xxx/build.zig
+++ b/examples/raspberrypi/rp2xxx/build.zig
@@ -164,6 +164,22 @@ pub fn build(b: *std.Build) void {
         // For debugging, we also always install the firmware as an ELF file
         mb.install_firmware(firmware, .{ .format = .elf });
     }
+
+    // blinky unit tests
+    const blinky = mb.add_firmware(.{
+        .name = "blinky_test",
+        .target = raspberrypi.pico,
+        .optimize = .Debug,
+        .root_source_file = b.path("src/blinky.zig"),
+    });
+
+    const blinky_test = blinky.add_test(.{
+        .root_source_file = b.path("src/blinky_test.zig"),
+    });
+    const run_test = b.addRunArtifact(blinky_test);
+
+    const test_step = b.step("test", "");
+    test_step.dependOn(&run_test.step);
 }
 
 const Example = struct {

--- a/examples/raspberrypi/rp2xxx/src/blinky_test.zig
+++ b/examples/raspberrypi/rp2xxx/src/blinky_test.zig
@@ -1,0 +1,13 @@
+const std = @import("std");
+const microzig = @import("microzig");
+const rp2xxx = microzig.hal;
+
+// Tests can reference microzig when using the `add_test()` from the Firmware
+// object (returned by `add_firmware()`). The tests will run on your PC, so
+// they won't be able to execute code tightly coupled to the microcontroller
+// hardware. You can access and inspect many things, and when you run into a
+// wall you'll receive a compiler error.
+test "microzig.chip exists" {
+    try std.testing.expect(@hasDecl(microzig, "chip"));
+    try std.testing.expect(@hasDecl(rp2xxx, "gpio"));
+}


### PR DESCRIPTION
Fixes #230

This is really great, but I need some more eyes on whether this is how we want to do things. It seems that we have the limitation that our tests can no longer live within the same file as our executable. Using the modules directly from the Firmware object have linking errors because we are overloading the linker script (no _start symbol). And if I try to make a new module targetting the host using the same path, we get an error that multiple modules aren't allowed to have the same path.

There might be a way around this that I'm not sure of. Otherwise, perhaps having to separate tests into their own files is an acceptable workaround? I imagine even if we magically fixed this, there would be many cases of linker errors, because of code depending on the embedded linkerscripts.

Another pattern we might prefer is requiring any tests in the embedded executable to be run on the hardware itself. that would mean this patch should be providing a new test runner, and if a user wanted to write unit tests that ran on their PC, then they would have to put them elsewhere, which sounds reasonable to me.