### PR TITLE
fix M7 CFSR and add FPU fault bits to CFSR

### DIFF
--- a/core/src/cpus/cortex_m.zig
+++ b/core/src/cpus/cortex_m.zig
@@ -961,12 +961,14 @@ pub const debug = struct {
             context.return_address,
             context.xpsr,
         });
-        logger.err("  instruction bus error           = {}", .{bfsr.instruction_bus_error});
-        logger.err("  precice data bus error          = {}", .{bfsr.precice_data_bus_error});
-        logger.err("  imprecice data bus error        = {}", .{bfsr.imprecice_data_bus_error});
-        logger.err("  unstacking exception error      = {}", .{bfsr.unstacking_exception_error});
-        logger.err("  exception stacking error        = {}", .{bfsr.exception_stacking_error});
-        logger.err("  busfault address register valid = {}", .{bfsr.busfault_address_register_valid});
+        logger.err("  instruction bus error             = {}", .{bfsr.instruction_bus_error});
+        logger.err("  precice data bus error            = {}", .{bfsr.precice_data_bus_error});
+        logger.err("  imprecice data bus error          = {}", .{bfsr.imprecice_data_bus_error});
+        logger.err("  unstacking exception error        = {}", .{bfsr.unstacking_exception_error});
+        logger.err("  exception stacking error          = {}", .{bfsr.exception_stacking_error});
+        if (has_fpu)
+            logger.err("  fpu lazy state preservation fault = {}", .{bfsr.fpu_lazy_state_preservation_fault});
+        logger.err("  busfault address register valid   = {}", .{bfsr.busfault_address_register_valid});
         if (bfsr.busfault_address_register_valid) {
             const address = peripherals.scb.BFAR;
             logger.err("    busfault address register = 0x{X:0>8}", .{address});

--- a/core/src/cpus/cortex_m/m7.zig
+++ b/core/src/cpus/cortex_m/m7.zig
@@ -99,7 +99,14 @@ pub const SystemControlBlock = extern struct {
     /// System Handler Contol and State Register
     SHCSR: mmio.Mmio(shared.scb.SHCSR),
     /// Configurable Fault Status Register
-    CFSR: u32,
+    CFSR: mmio.Mmio(packed struct(u32) {
+        /// MemManage Fault Register.
+        MMFSR: shared.scb.MMFSR,
+        /// BusFault Status Register.
+        BFSR: shared.scb.BFSR,
+        /// Usage Fault Status Register.
+        UFSR: shared.scb.UFSR,
+    }),
     /// MemManage Fault Status Register
     MMSR: u32,
     /// BusFault Status Register

--- a/core/src/cpus/cortex_m/shared_types.zig
+++ b/core/src/cpus/cortex_m/shared_types.zig
@@ -158,8 +158,12 @@ pub const scb = struct {
         /// When this bit is 1, the SP is still adjusted but the values in the context area on the stack might be incorrect. The processor has not written a fault address to the MMAR.
         MSTKERR: u1, // [4], RW
 
+        /// 0: No MemManage fault occurred during floating-point lazy state preservation.
+        /// 1: A MemManage fault occurred during floating-point lazy state preservation.
+        MLSPERR: u1, // [5], RW (FPU only)
+
         /// Reserved.
-        _reserved0: u2, // [6:5], RW
+        _reserved0: u1, // [6], RW
 
         /// MemManage Fault Address Register (MMFAR) valid flag:
         ///     0 = value in MMAR is not a valid fault address
@@ -202,8 +206,12 @@ pub const scb = struct {
         /// When the processor sets this bit to 1, the SP is still adjusted but the values in the context area on the stack might be incorrect. The processor does not write a fault address to the BFAR.
         exception_stacking_error: bool, // [4], RW
 
+        /// 0: No bus fault occurred during floating-point lazy state preservation.
+        /// 1: A bus fault occurred during floating-point lazy state preservation.
+        fpu_lazy_state_preservation_fault: bool, // [5], RW (FPU only)
+
         /// Reserved.
-        _reserved0: u2, // [6:5], RW
+        _reserved0: u1, // [6], RW
 
         /// BusFault Address Register (BFAR) valid flag:
         ///     0 = value in BFAR is not a valid fault address


### PR DESCRIPTION
- fix: M7 missing CFSR type.
- add: missing FPU fault bits in CFSR.