### PR TITLE
ch32v: i2c: Fix setting NACK

### DIFF
--- a/port/wch/ch32v/src/hals/i2c.zig
+++ b/port/wch/ch32v/src/hals/i2c.zig
@@ -368,13 +368,9 @@ pub const I2C = enum(u1) {
             while (iter.next_element_ptr()) |element| {
                 bytes_remaining -= 1;
 
-                // For the second-to-last byte, disable ACK
-                if (bytes_remaining == 1) {
-                    i2c.set_ack(false);
-                }
-
-                // For the last byte, generate STOP
+                // For the last byte, disable ACK and generate STOP before reading
                 if (bytes_remaining == 0) {
+                    i2c.set_ack(false);
                     i2c.generate_stop();
                 }
 


### PR DESCRIPTION
The ch32v chips borrow a lot from the STM32 peripherals, and so I was able to take a lot from the stm32 hal. It seems, however, that they diverge in the behaviour here: The STM32 I2C HALs I read check signal BTF, rather than RxNE, and they set the NACK a byte earlier.

Noticed this while playing with the ICM-20948 driver. My original PR was only tested lightly with i2c-bus-scan, which never had to do reads over 1 byte.