### PR TITLE
rp2xxx/ch32v: Fix dma slice handling

### DIFF
--- a/examples/raspberrypi/rp2xxx/src/dma.zig
+++ b/examples/raspberrypi/rp2xxx/src/dma.zig
@@ -12,6 +12,13 @@ const uart_tx_pin = gpio.num(0);
 const hello: []const u8 = "Hello, world! (from DMA)";
 var dst: [hello.len]u8 = undefined;
 
+fn transfer_from_slices(channel: dma.Channel, write_buf: []u8, read_buf: []const u8) !void {
+    try channel.setup_transfer(write_buf, read_buf, .{
+        .trigger = true,
+        .enable = true,
+    });
+}
+
 pub fn panic(message: []const u8, _: ?*std.builtin.StackTrace, _: ?usize) noreturn {
     std.log.err("panic: {s}", .{message});
     @breakpoint();
@@ -34,6 +41,7 @@ pub fn main() !void {
 
     const channel = dma.claim_unused_channel().?;
 
+    // Transfer via pointer to array
     try channel.setup_transfer(dst[0..dst.len], hello[0..hello.len], .{
         .trigger = true,
         .enable = true,
@@ -43,6 +51,7 @@ pub fn main() !void {
     if (!std.mem.eql(u8, &dst, hello))
         @panic("dma failed");
 
+    // Transfer via pointer
     var value: u8 = 0x41;
     try channel.setup_transfer(&dst, &value, .{
         .trigger = true,
@@ -52,6 +61,12 @@ pub fn main() !void {
 
     if (!std.mem.allEqual(u8, &dst, 0x41))
         @panic("dma failed");
+
+    // Transfer via slice. Need helper function so compiler doesn't optimize the slice away
+    var test_dst: [5]u8 = undefined;
+    const test_src = "Test!";
+    try transfer_from_slices(channel, &test_dst, test_src);
+    channel.wait_for_finish_blocking();
 
     while (true) {
         time.sleep_ms(1000);

--- a/port/raspberrypi/rp2xxx/src/hal/dma.zig
+++ b/port/raspberrypi/rp2xxx/src/hal/dma.zig
@@ -196,8 +196,12 @@ pub const Channel = enum(u4) {
                     .@"struct" => {
                         return value.addr;
                     },
-                    .pointer => {
-                        return @intFromPtr(value);
+                    .pointer => |ptr| {
+                        switch (ptr.size) {
+                            .slice, .many => return @intFromPtr(value.ptr),
+                            .one => return @intFromPtr(value),
+                            else => comptime unreachable,
+                        }
                     },
                     else => comptime unreachable,
                 }

--- a/port/wch/ch32v/src/hals/dma.zig
+++ b/port/wch/ch32v/src/hals/dma.zig
@@ -159,7 +159,13 @@ pub const Channel = enum(u3) {
                 const Info = @typeInfo(Type);
                 switch (Info) {
                     .@"struct" => return value.addr,
-                    .pointer => return @intFromPtr(value),
+                    .pointer => |ptr| {
+                        switch (ptr.size) {
+                            .slice, .many => return @intFromPtr(value.ptr),
+                            .one => return @intFromPtr(value),
+                            else => comptime unreachable,
+                        }
+                    },
                     else => comptime unreachable,
                 }
             }


### PR DESCRIPTION
Noticed that the `anytype` fields didn't work when making changes to the ch32v dma hal. These were yanked from the rp2xxx version.

The example doesn't catch the issue because the compiler seems to use array fields when it can, I had to call with an intermediate function to force the compiler to create a version where the pointer was a slice type.