### PR TITLE
generate_linker_script: align .data LMA to 4-byte boundary

### DIFF
--- a/tools/generate_linker_script.zig
+++ b/tools/generate_linker_script.zig
@@ -197,6 +197,7 @@ pub fn main() !void {
             \\
             \\  .data :
             \\  {
+            \\    . = ALIGN(4);
             \\    microzig_data_start = .;
             \\    *(.sdata*)
             \\    *(.data*)
@@ -220,14 +221,17 @@ pub fn main() !void {
         }
 
         try writer.interface.print(
+            \\    . = ALIGN(4);
             \\    microzig_data_end = .;
             \\  }} > {s}
             \\
             \\  .bss (NOLOAD):
             \\  {{
+            \\    . = ALIGN(4);
             \\    microzig_bss_start = .;
             \\    *(.sbss*)
             \\    *(.bss*)
+            \\    . = ALIGN(4);
             \\    microzig_bss_end = .;
             \\  }} > {s}
             \\


### PR DESCRIPTION
The startup code for riscv uses word-aligned loads (The `lw` instruction) to copy `.data` from flash to RAM. When the `.text` section ended at an unaligned address, `.data`'s flash location (LMA) became misaligned, causing hardware faults during startup when copying the `.data` section into RAM.

This was triggered by certain code combinations that caused `.text` to end at addresses like 0x1bc1 instead of 0x1bc4. The unaligned load would fault before any user code executed.

```
riscv64-unknown-elf-objdump -h zig-out/firmware/lana_tny_dma.elf | grep data -A2
  2 .data         00000100  20000000  00001bc1  00003000  2**0
```

Fixed by adding `. = ALIGN(4);` at the end of .text section to ensure the next section's load address in flash is properly aligned for word loads.