### PR TITLE
Fix CircularBuffer reporting wrong readable/writable length

### DIFF
--- a/core/src/utilities.zig
+++ b/core/src/utilities.zig
@@ -602,13 +602,14 @@ pub fn CircularBuffer(comptime T: type, comptime len: usize) type {
         pub fn write(buffer: *Self, data: []const u8) error{Full}!void {
             buffer.assert_valid();
             defer buffer.assert_valid();
-
             for (data) |d| {
                 if (buffer.full)
                     return error.Full;
 
                 buffer.items[buffer.end] = d;
                 buffer.increment_end();
+                if (buffer.start == buffer.end)
+                    buffer.full = true;
             }
         }
 
@@ -646,14 +647,17 @@ test "CircularBuffer bounds" {
     const FIFO = CircularBuffer(u8, bufsize);
     var fifo: FIFO = .empty;
     try expectEqual(bufsize, fifo.get_writable_len());
+
     const one_data: [1]u8 = .{42};
     try fifo.write(one_data[0..]);
     try expectEqual(bufsize - 1, fifo.get_writable_len());
+    try expectEqual(1, fifo.get_readable_len());
 
-    var big_data: [100]u8 = undefined;
-    @memset(big_data[0..], 42);
-
-    const maybe_err = fifo.write(big_data[0..]);
+    var buf: [100]u8 = undefined;
+    const big_data = buf[0..];
+    @memset(big_data, 42);
+    try expectEqual(big_data.len, 100);
+    const maybe_err = fifo.write(big_data);
 
     try std.testing.expectError(error.Full, maybe_err);
 }


### PR DESCRIPTION
The CircularBuffer struct was previously reporting the wrong readable/writable length, which allowed the user to overwrite valid parts of the buffer. This is the cause of the rp2xxx usb-cdc example failing to print the whole string.

This adds a test which previously failed, now passes, along with the actual fix, which is just to set the .full member variable to true in the write function when the buffer is full.