### PR TITLE
ch32v: Fix _reset_vector in non-small release modes.

### DIFF
--- a/port/wch/ch32v/src/cpus/main.zig
+++ b/port/wch/ch32v/src/cpus/main.zig
@@ -389,7 +389,7 @@ fn get_hal_default_handler(comptime handler_name: []const u8) ?InterruptHandler 
     return null;
 }
 
-const vector_table: VectorTable = generate_vector_table();
+const vector_table = generate_vector_table();
 
 pub fn export_startup_logic() void {
     @export(&startup_logic._start, .{ .name = "_start" });


### PR DESCRIPTION
@Copper280z noticed that none of the examples worked when build in ReleaseSafe.

I took a look and noticed that the vector table started at 8 instead of 4:
```
pwndbg> x/2wx 4
0x4 <main.startup_logic._reset_vector+4>:       0x00000000      0x00000610
```
vs.
```
pwndbg> x/2wx 4
0x4warning: (Internal error: pc 0x4 in read in CU, but not in symtab.)
warning: (Error: pc 0x4 in address map, but not in symtab.)
 <vector_table>:        0x00000394      0x00000394
```

Looks like it was because `_reset_vector` was a function, the release mode was putting padding around it.

I am not sure if there's a nicer way to avoid this, but I worked around it by emitting the assembly directly.

Strangely, I now get a error

```
✦ ❯ zig build --release=small -Dexample=blinky
error: <inline asm>:4:1: unrecognized instruction mnemonic, did you mean: b?
j _start/8238] Linking
^  └─ LLVM Emit Object
```
I have no idea how this ever emitted a working binary at all.

That said, I came up with a different approach, where instead of trying to get the vector table to start at 4, I just adjust mtvec.base to configure the interrupts to start wherever that table lands.