### PR TITLE
Esp: Fix allocator usage

### DIFF
--- a/examples/espressif/esp/src/rtos.zig
+++ b/examples/espressif/esp/src/rtos.zig
@@ -39,7 +39,7 @@ fn task1(queue: *rtos.Queue(u32)) void {
 }
 
 pub fn main() !void {
-    var heap = microzig.Allocator.init_with_buffer(&heap_buf);
+    var heap = try microzig.Allocator.init_with_buffer(&heap_buf);
     const gpa = heap.allocator();
 
     var buffer: [1]u32 = undefined;

--- a/examples/espressif/esp/src/tcp_server.zig
+++ b/examples/espressif/esp/src/tcp_server.zig
@@ -60,7 +60,7 @@ var ip: lwip.c.ip_addr_t = undefined;
 
 extern fn netconn_new_with_proto_and_callback(t: lwip.c.enum_netconn_type, proto: lwip.c.u8_t, callback: ?*const anyopaque) [*c]lwip.c.struct_netconn;
 pub fn main() !void {
-    var heap_allocator: microzig.Allocator = .init_with_heap(16384);
+    var heap_allocator: microzig.Allocator = try .init_with_heap(16384);
     const gpa = heap_allocator.allocator();
 
     try radio.wifi.init(gpa, .{});


### PR DESCRIPTION
#861 and #872 were merged around the same time, but the latter changed an api used by #861, so the rtos and tcp server examples broke.
