### PR TITLE
ch32v: Fix: Add clobbers to bss/data loops

### DIFF
--- a/port/wch/ch32v/src/cpus/main.zig
+++ b/port/wch/ch32v/src/cpus/main.zig
@@ -310,7 +310,7 @@ pub const startup_logic = struct {
             \\    addi a1, a1, 4
             \\    blt a1, a2, clear_bss_loop
             \\clear_bss_done:
-        );
+            ::: .{ .x10 = true, .x11 = true, .x12 = true });
 
         // Copy .data from FLASH to RAM.
         asm volatile (
@@ -325,7 +325,7 @@ pub const startup_logic = struct {
             \\    addi a1, a1, 4
             \\    bne a1, a2, copy_data_loop
             \\copy_done:
-        );
+            ::: .{ .x10 = true, .x11 = true, .x12 = true, .x13 = true });
     }
 
     export fn _reset_vector() linksection("microzig_flash_start") callconv(.naked) void {


### PR DESCRIPTION
I noticed that ch32v examples were broken. `git bisect` got me to #868, but some debugging with @kibels suggested something else was going on.

Looks like those changes just exposed a bug where we weren't clobbering properly, so a subsequent CSR, which was using a register, had had it clobbered.

I haven't exactly tracked why this exposed the issue, since the csrwi instructions (only changed ones) are before the problematic function.