### PR TITLE
CH32V: Reorganize startup logic

### DIFF
--- a/port/wch/ch32v/src/cpus/main.zig
+++ b/port/wch/ch32v/src/cpus/main.zig
@@ -238,36 +238,6 @@ pub const startup_logic = struct {
         );
     }
 
-    inline fn initialize_system_memories() void {
-        // Clear .bss section.
-        asm volatile (
-            \\    li a0, 0
-            \\    la a1, microzig_bss_start
-            \\    la a2, microzig_bss_end
-            \\    beq a1, a2, clear_bss_done
-            \\clear_bss_loop:
-            \\    sw a0, 0(a1)
-            \\    addi a1, a1, 4
-            \\    blt a1, a2, clear_bss_loop
-            \\clear_bss_done:
-        );
-
-        // Copy .data from FLASH to RAM.
-        asm volatile (
-            \\    la a0, microzig_data_load_start
-            \\    la a1, microzig_data_start
-            \\    la a2, microzig_data_end
-            \\copy_data_loop:
-            \\    beq a1, a2, copy_done
-            \\    lw a3, 0(a0)
-            \\    sw a3, 0(a1)
-            \\    addi a0, a0, 4
-            \\    addi a1, a1, 4
-            \\    bne a1, a2, copy_data_loop
-            \\copy_done:
-        );
-    }
-
     export fn _system_init() callconv(.c) noreturn {
         // NOTE: this can only be called once. Otherwise, we get a linker error for duplicate symbols
         startup_logic.initialize_system_memories();
@@ -326,6 +296,36 @@ pub const startup_logic = struct {
         // user mode.
         asm volatile ("mret");
         unreachable;
+    }
+
+    inline fn initialize_system_memories() void {
+        // Clear .bss section.
+        asm volatile (
+            \\    li a0, 0
+            \\    la a1, microzig_bss_start
+            \\    la a2, microzig_bss_end
+            \\    beq a1, a2, clear_bss_done
+            \\clear_bss_loop:
+            \\    sw a0, 0(a1)
+            \\    addi a1, a1, 4
+            \\    blt a1, a2, clear_bss_loop
+            \\clear_bss_done:
+        );
+
+        // Copy .data from FLASH to RAM.
+        asm volatile (
+            \\    la a0, microzig_data_load_start
+            \\    la a1, microzig_data_start
+            \\    la a2, microzig_data_end
+            \\copy_data_loop:
+            \\    beq a1, a2, copy_done
+            \\    lw a3, 0(a0)
+            \\    sw a3, 0(a1)
+            \\    addi a0, a0, 4
+            \\    addi a1, a1, 4
+            \\    bne a1, a2, copy_data_loop
+            \\copy_done:
+        );
     }
 
     export fn _reset_vector() linksection("microzig_flash_start") callconv(.naked) void {


### PR DESCRIPTION
This PR changes it so that the compiler can no longer reorder statements in _start, which led to bugs.