### PR TITLE
stm: update embassy data dependency

### DIFF
--- a/port/stmicro/stm32/build.zig.zon
+++ b/port/stmicro/stm32/build.zig.zon
@@ -6,7 +6,7 @@
         .@"microzig/build-internals" = .{ .path = "../../../build-internals" },
         .@"microzig/tools/regz" = .{ .path = "../../../tools/regz" },
         .@"stm32-data-generated" = .{
-            .url = "git+https://github.com/embassy-rs/stm32-data-generated.git#5198a6e36b24f6d79c4ac91af5e61e8d54667d88",
+            .url = "git+https://github.com/embassy-rs/stm32-data-generated.git#484e51813ae4817aacb9df1ce3b5b5fd384c6f40",
             .hash = "N-V-__8AAFi8WBlOh-NikHFVBjzQE0F1KixgKjVWYnlijPNm",
         },
         .ClockHelper = .{


### PR DESCRIPTION
Updates the stm32 data reference to include this addition to the [AES.ICR register](https://github.com/embassy-rs/stm32-data/pull/754)