### PR TITLE
stm32: fix systick get_time_since_boot() bad value due to non-atomic memory read

### DIFF
--- a/port/stmicro/stm32/src/hals/common/systick.zig
+++ b/port/stmicro/stm32/src/hals/common/systick.zig
@@ -75,10 +75,23 @@ pub fn is_initialized() bool {
 // Low level function to build clock device from it.
 pub fn get_time_since_boot() u64 {
     const reload = systick.LOAD.read().RELOAD;
-    const ticks = @as(u64, @intCast(reload - systick.VAL.read().CURRENT));
-    const all_ticks = @as(u64, @intCast(microzig.cpu.atomic.load(u32, &accumulated_ticks, .acquire))) << 24 | ticks;
-    const ns = all_ticks * ns_per_ticks;
-    return ns >> 10;
+    var high_before = microzig.cpu.atomic.load(u32, &accumulated_ticks, .acquire);
+    while (true) {
+        const ticks = @as(u64, @intCast(reload - systick.VAL.read().CURRENT));
+        const high_after = microzig.cpu.atomic.load(u32, &accumulated_ticks, .acquire);
+        
+        // ensure that 'high' and 'ticks' belong to the same
+        // RELOAD..0 count down cycle
+        if (high_before == high_after) {
+            const all_ticks = (@as(u64, high_after) << 24) | ticks;
+            const ns = all_ticks * ns_per_ticks;
+            return ns >> 10;
+        }
+        else
+        {
+            high_before = high_after;
+        }
+    }
 }
 
 pub fn SysTick_handler() callconv(.c) void {

--- a/port/stmicro/stm32/src/hals/common/systick.zig
+++ b/port/stmicro/stm32/src/hals/common/systick.zig
@@ -79,16 +79,14 @@ pub fn get_time_since_boot() u64 {
     while (true) {
         const ticks = @as(u64, @intCast(reload - systick.VAL.read().CURRENT));
         const high_after = microzig.cpu.atomic.load(u32, &accumulated_ticks, .acquire);
-        
+
         // ensure that 'high' and 'ticks' belong to the same
         // RELOAD..0 count down cycle
         if (high_before == high_after) {
             const all_ticks = (@as(u64, high_after) << 24) | ticks;
             const ns = all_ticks * ns_per_ticks;
             return ns >> 10;
-        }
-        else
-        {
+        } else {
             high_before = high_after;
         }
     }


### PR DESCRIPTION
Based on issue #924 