### PR TITLE
fix spi for esp

### DIFF
--- a/port/espressif/esp/src/hal/spi.zig
+++ b/port/espressif/esp/src/hal/spi.zig
@@ -380,7 +380,7 @@ pub const SPI = enum(u2) {
             }
         }
 
-        //add remaining bytes
+        // Add remaining bytes
         if (len % 4 != 0) {
             fifo[len / 4] = word;
         }

--- a/port/espressif/esp/src/hal/spi.zig
+++ b/port/espressif/esp/src/hal/spi.zig
@@ -224,7 +224,7 @@ pub const SPI = enum(u2) {
         }
 
         if (pins.clk) |clk_pin| {
-            clk_pin.connect_peripheral_to_output(.{ .signal = .spiclk });
+            clk_pin.connect_peripheral_to_output(.{ .signal = .fspiclk });
         }
     }
 
@@ -378,6 +378,11 @@ pub const SPI = enum(u2) {
                 fifo[i / 4] = word;
                 word = 0;
             }
+        }
+
+        //add remaining bytes
+        if (len % 4 != 0) {
+            fifo[len / 4] = word;
         }
     }
 


### PR DESCRIPTION
change that clock_pin connects to the right signal (fspiclk instead of spiclk)

fix the fifo_fill function so that the rest bytes when the length of the message is not divisible by 4 get also transmitted