### PR TITLE
rp2xxx fixes

### DIFF
--- a/port/raspberrypi/rp2xxx/build.zig
+++ b/port/raspberrypi/rp2xxx/build.zig
@@ -60,7 +60,7 @@ pub fn init(dep: *std.Build.Dependency) Self {
             .name = "RP2040",
             .register_definition = .{ .svd = pico_sdk.path("src/rp2040/hardware_regs/RP2040.svd") },
             .memory_regions = &.{
-                .{ .tag = .flash, .offset = 0x10000000, .length = 2048 * 1024, .access = .rx },
+                .{ .tag = .flash, .offset = 0x10000000, .length = 2 * 1024 * 1024, .access = .rx },
                 .{ .tag = .ram, .offset = 0x20000000, .length = 256 * 1024, .access = .rwx },
             },
             .patch_files = &.{b.path("patches/rp2040.zon")},
@@ -87,7 +87,7 @@ pub fn init(dep: *std.Build.Dependency) Self {
             .name = "RP2350",
             .register_definition = .{ .svd = pico_sdk.path("src/rp2350/hardware_regs/RP2350.svd") },
             .memory_regions = &.{
-                .{ .tag = .flash, .offset = 0x10000000, .length = 2048 * 1024, .access = .rx },
+                .{ .tag = .flash, .offset = 0x10000000, .length = 4 * 1024 * 1024, .access = .rx },
                 .{ .tag = .ram, .offset = 0x20000000, .length = 512 * 1024, .access = .rwx },
                 // TODO: maybe these can be used for stacks
                 .{ .tag = .ram, .offset = 0x20080000, .length = 4 * 1024, .access = .rwx },
@@ -139,7 +139,7 @@ pub fn init(dep: *std.Build.Dependency) Self {
             .name = "RP2350",
             .register_definition = .{ .svd = pico_sdk.path("src/rp2350/hardware_regs/RP2350.svd") },
             .memory_regions = &.{
-                .{ .tag = .flash, .offset = 0x10000000, .length = 2048 * 1024, .access = .rx },
+                .{ .tag = .flash, .offset = 0x10000000, .length = 4 * 1024 * 1024, .access = .rx },
                 .{ .tag = .ram, .offset = 0x20000000, .length = 512 * 1024, .access = .rwx },
                 // TODO: maybe these can be used for stacks
                 .{ .tag = .ram, .offset = 0x20080000, .length = 4 * 1024, .access = .rwx },
@@ -170,6 +170,17 @@ pub fn init(dep: *std.Build.Dependency) Self {
         .boards = .{
             .adafruit = .{
                 .feather_rp2350 = chip_rp2350_arm.derive(.{
+                    .chip = .{
+                        .name = "RP2350",
+                        .register_definition = .{ .svd = pico_sdk.path("src/rp2350/hardware_regs/RP2350.svd") },
+                        .memory_regions = &.{
+                            .{ .tag = .flash, .offset = 0x10000000, .length = 8 * 1024 * 1024, .access = .rx },
+                            .{ .tag = .ram, .offset = 0x20000000, .length = 512 * 1024, .access = .rwx },
+                            .{ .tag = .ram, .offset = 0x20080000, .length = 4 * 1024, .access = .rwx },
+                            .{ .tag = .ram, .offset = 0x20081000, .length = 4 * 1024, .access = .rwx },
+                        },
+                        .patch_files = &.{b.path("patches/rp2350.zon")},
+                    },
                     .board = .{
                         .name = "Adafruit Feather RP2350",
                         .url = "https://www.adafruit.com/product/6000",
@@ -177,6 +188,17 @@ pub fn init(dep: *std.Build.Dependency) Self {
                     },
                 }),
                 .metro_rp2350 = chip_rp2350_arm.derive(.{
+                    .chip = .{
+                        .name = "RP2350",
+                        .register_definition = .{ .svd = pico_sdk.path("src/rp2350/hardware_regs/RP2350.svd") },
+                        .memory_regions = &.{
+                            .{ .tag = .flash, .offset = 0x10000000, .length = 16 * 1024 * 1024, .access = .rx },
+                            .{ .tag = .ram, .offset = 0x20000000, .length = 512 * 1024, .access = .rwx },
+                            .{ .tag = .ram, .offset = 0x20080000, .length = 4 * 1024, .access = .rwx },
+                            .{ .tag = .ram, .offset = 0x20081000, .length = 4 * 1024, .access = .rwx },
+                        },
+                        .patch_files = &.{b.path("patches/rp2350.zon")},
+                    },
                     .board = .{
                         .name = "Adafruit Metro RP2350",
                         .url = "https://www.adafruit.com/product/6267",

--- a/port/raspberrypi/rp2xxx/src/hal.zig
+++ b/port/raspberrypi/rp2xxx/src/hal.zig
@@ -58,11 +58,6 @@ pub const HAL_Options = switch (compatibility.chip) {
     .RP2350 => struct {
         bootmeta: struct {
             image_def_exe_security: bootmeta.ImageDef.ImageTypeFlags.ExeSecurity = .secure,
-
-            /// Next metadata block to link after image_def. **Last block in
-            /// the chain must link back to the first one** (to
-            /// `bootmeta.image_def_block`).
-            next_block: ?*const anyopaque = null,
         } = .{},
 
         /// Enable the DCP and export intrinsics. Leads to faster double

--- a/port/raspberrypi/rp2xxx/src/hal/bootmeta.zig
+++ b/port/raspberrypi/rp2xxx/src/hal/bootmeta.zig
@@ -3,7 +3,7 @@ const std = @import("std");
 const microzig = @import("microzig");
 const arch = @import("compatibility.zig").arch;
 
-pub const image_def_block = if (microzig.config.ram_image and arch == .arm) Block(packed struct {
+pub const image_def_block = if (microzig.config.ram_image and arch == .arm) Block(packed struct(u128) {
     image_def: ImageDef,
     entry_point: EntryPoint(false),
 }){
@@ -24,7 +24,7 @@ pub const image_def_block = if (microzig.config.ram_image and arch == .arm) Bloc
             .sp = microzig.utilities.get_end_of_stack(),
         },
     },
-} else Block(packed struct {
+} else Block(packed struct(u32) {
     image_def: ImageDef,
 }){
     .items = .{

--- a/port/raspberrypi/rp2xxx/src/hal/bootmeta.zig
+++ b/port/raspberrypi/rp2xxx/src/hal/bootmeta.zig
@@ -3,7 +3,7 @@ const std = @import("std");
 const microzig = @import("microzig");
 const arch = @import("compatibility.zig").arch;
 
-pub const image_def_block = if (microzig.config.ram_image and arch == .arm) Block(extern struct {
+pub const image_def_block = if (microzig.config.ram_image and arch == .arm) Block(packed struct {
     image_def: ImageDef,
     entry_point: EntryPoint(false),
 }){
@@ -24,8 +24,7 @@ pub const image_def_block = if (microzig.config.ram_image and arch == .arm) Bloc
             .sp = microzig.utilities.get_end_of_stack(),
         },
     },
-    .link = microzig.options.hal.bootmeta.next_block,
-} else Block(extern struct {
+} else Block(packed struct {
     image_def: ImageDef,
 }){
     .items = .{
@@ -39,7 +38,6 @@ pub const image_def_block = if (microzig.config.ram_image and arch == .arm) Bloc
             },
         },
     },
-    .link = microzig.options.hal.bootmeta.next_block,
 };
 
 comptime {
@@ -55,17 +53,20 @@ pub fn Block(Items: type) type {
         header: u32 = 0xffffded3,
         items: Items,
         last_item: u32 = 0x000000ff | ((@sizeOf(Items) / 4) << 8),
-        link: ?*const anyopaque = null,
+        /// Relative offset from this block's header to the next block's
+        /// header.  Zero means self-loop (single-block chain).
+        link: i32 = 0,
         footer: u32 = 0xab123579,
     };
 }
 
-pub const ImageDef = packed struct {
+pub const ImageDef = packed struct(u32) {
+    // IMAGE_DEF type = 0x42
     item_type: u8 = 0x42,
     block_size: u8 = 0x01,
     image_type_flags: ImageTypeFlags,
 
-    pub const ImageTypeFlags = packed struct {
+    pub const ImageTypeFlags = packed struct(u16) {
         image_type: ImageType,
         exe_security: ExeSecurity,
         reserved0: u2 = 0,
@@ -100,8 +101,8 @@ pub const ImageDef = packed struct {
 
 pub fn EntryPoint(with_stack_limit: bool) type {
     if (with_stack_limit) {
-        return extern struct {
-            header: packed struct {
+        return packed struct(u128) {
+            header: packed struct(u32) {
                 item_type: u8 = 0x44,
                 block_size: u8 = 0x04,
                 padding: u16 = 0,
@@ -111,8 +112,8 @@ pub fn EntryPoint(with_stack_limit: bool) type {
             sp_limit: u32,
         };
     } else {
-        return extern struct {
-            header: packed struct {
+        return packed struct(u96) {
+            header: packed struct(u32) {
                 item_type: u8 = 0x44,
                 block_size: u8 = 0x03,
                 padding: u16 = 0,


### PR DESCRIPTION
1. Flash size was incorrect for pico 2 and some third-party RP2350 boards. Fix them.
2. Fix link type in boot meta: It is an offset, not a pointer.
3. Explicitly set the size of the `Item` types so that we don't accidentally break them.