### PR TITLE
rp2xxx: Fix Adafruit boards

### DIFF
--- a/port/raspberrypi/rp2xxx/src/boards/adafruit_feather_rp2350.zig
+++ b/port/raspberrypi/rp2xxx/src/boards/adafruit_feather_rp2350.zig
@@ -1,4 +1,5 @@
 pub const xosc_freq = 12_000_000;
+pub const xosc_startup_delay_multiplier = 64;
 
 const microzig = @import("microzig");
 const hal = microzig.hal;

--- a/port/raspberrypi/rp2xxx/src/boards/adafruit_metro_rp2350.zig
+++ b/port/raspberrypi/rp2xxx/src/boards/adafruit_metro_rp2350.zig
@@ -1,4 +1,5 @@
 pub const xosc_freq = 12_000_000;
+pub const xosc_startup_delay_multiplier = 64;
 
 pub const has_rp2350b = true; // Uses RP2350B chip with extra I/O pins
 

--- a/port/raspberrypi/rp2xxx/src/hal/clocks/common.zig
+++ b/port/raspberrypi/rp2xxx/src/hal/clocks/common.zig
@@ -16,9 +16,13 @@ pub const xosc_freq = microzig.board.xosc_freq;
 pub const rosc_freq = 6_500_000;
 
 pub const xosc = struct {
+    const startup_delay_multiplier: comptime_int = if (@hasDecl(microzig.board, "xosc_startup_delay_multiplier"))
+        microzig.board.xosc_startup_delay_multiplier
+    else
+        1;
     const startup_delay_ms = 1;
 
-    const startup_delay_value = xosc_freq * startup_delay_ms / 1000 / 256;
+    const startup_delay_value = xosc_freq * startup_delay_ms / 1000 / 256 * startup_delay_multiplier;
     comptime {
         assert(startup_delay_value < (1 << 13));
     }


### PR DESCRIPTION
I noticed that my Adafruit Feather rp2350 worked when I first flashed it, but not after a reset or power cycle.

Digging through some code, I found a commit that added support for the Adafruit Feather to the arduino-pico core:

https://github.com/earlephilhower/arduino-pico/commit/163b209d#diff-d0d48a8d47fd5d31e3bc70b12159bdcb23a5ab82460bb5972cf61776f4d6768aR34-R42

It sets `PICO_XOSC_STARTUP_DELAY_MULTIPLIER=64`.

Seems that these boards have shakier clocks.

This change adds support for an optional
`xosc_startup_delay_multiplier`, which increases the startup_delay_ms when setting up the external oscillator.