### PR TITLE
AS5600: add missing `try` to read2_raw() calls

### DIFF
--- a/drivers/src/root.zig
+++ b/drivers/src/root.zig
@@ -233,6 +233,7 @@ test {
     _ = sensor.TLV493D;
     _ = sensor.TMP117;
     _ = sensor.AHT30;
+    _ = sensor.AS5600;
 
     _ = @import("stepper/common.zig");
     _ = stepper.A4988;

--- a/drivers/src/sensor/AS5600.zig
+++ b/drivers/src/sensor/AS5600.zig
@@ -108,7 +108,7 @@ pub const AS5600 = struct {
     }
 
     pub fn read_zero_position(self: *const Self) !u16 {
-        const zpos = self.read2_raw(register.ZPOS);
+        const zpos = try self.read2_raw(register.ZPOS);
         return zpos & 0xFFF;
     }
 
@@ -120,7 +120,7 @@ pub const AS5600 = struct {
     }
 
     pub fn read_max_position(self: *const Self) !u16 {
-        const mpos = self.read2_raw(register.MPOS);
+        const mpos = try self.read2_raw(register.MPOS);
         return mpos & 0xFFF;
     }
 
@@ -132,7 +132,7 @@ pub const AS5600 = struct {
     }
 
     pub fn read_max_angle(self: *const Self) !u16 {
-        const mang = self.read2_raw(register.MANG);
+        const mang = try self.read2_raw(register.MANG);
         return mang & 0xFFF;
     }
 
@@ -144,7 +144,7 @@ pub const AS5600 = struct {
     }
 
     pub fn read_configuration(self: *const Self) !u16 {
-        const configuration = self.read2_raw(register.CONF);
+        const configuration = try self.read2_raw(register.CONF);
         return @bitCast(configuration);
     }
 


### PR DESCRIPTION
Fix some cases where `read2_raw()` was called without `try`.

From #974 