### PR TITLE
core: fix minor bugs across arm_semihosting, EchoExample, mmio

### DIFF
--- a/core/src/core/arm_semihosting.zig
+++ b/core/src/core/arm_semihosting.zig
@@ -248,7 +248,7 @@ pub const fs = struct {
     };
 
     pub const FType = enum {
-        FIle,
+        File,
         Device,
     };
     pub const OpenMode = enum(usize) {
@@ -390,7 +390,7 @@ pub const fs = struct {
 
         pub fn get_type(file: File) FileError!FType {
             return switch (sys_istty(&file)) {
-                0 => FType.FIle,
+                0 => FType.File,
                 1 => FType.Device,
                 else => FileError.InvalidFile,
             };

--- a/core/src/core/usb/drivers/EchoExample.zig
+++ b/core/src/core/usb/drivers/EchoExample.zig
@@ -62,7 +62,7 @@ pub fn init(self: *@This(), desc: *const Descriptor, device: *usb.DeviceInterfac
         .device = device,
         .descriptor = desc,
         .packet_buffer = data,
-        .tx_ready = .init(false),
+        .tx_ready = .init(true),
     };
     device.ep_listen(
         desc.ep_out.endpoint.num,

--- a/core/src/mmio.zig
+++ b/core/src/mmio.zig
@@ -70,8 +70,8 @@ pub fn Mmio(comptime Packed: type) type {
                         @as(FieldType, @enumFromInt(@as(U, @intFromEnum(@field(val, field_name))) ^
                             @as(U, @intFromEnum(@as(FieldType, value)))));
                 },
-                else => |T| {
-                    @compileError("unsupported register field type '" ++ @typeName(T) ++ "'");
+                else => {
+                    @compileError("unsupported register field type '" ++ @typeName(FieldType) ++ "'");
                 },
             }
         }


### PR DESCRIPTION
- arm_semihosting: fix FIle -> File typo in FType enum
- EchoExample: init tx_ready to true so first received packet can echo
- mmio: use @typeName(FieldType) instead of @typeName(T) in else branch so compile errors report the actual unsupported type, not 'void'