### PR TITLE
fix bInterval for usb-hs, units are different between fs and hs

### DIFF
--- a/core/src/core/usb/drivers/CDC.zig
+++ b/core/src/core/usb/drivers/CDC.zig
@@ -122,7 +122,15 @@ pub const Descriptor = extern struct {
                     .master_interface = itf_notifi,
                     .slave_interface_0 = itf_data,
                 },
-                .ep_notifi = .interrupt(alloc.next_ep(.In), 8, 16),
+                // High-speed interrupt intervals are encoded as
+                // 2^(bInterval - 1) microframes, while full-speed intervals
+                // are expressed directly in milliseconds. Keep the intended
+                // polling period at 16 ms for both speeds.
+                .ep_notifi = .interrupt(
+                    alloc.next_ep(.In),
+                    8,
+                    if (max_supported_packet_size > 64) 8 else 16,
+                ),
                 .itf_data = .{
                     .interface_number = itf_data,
                     .alternate_setting = 0,


### PR DESCRIPTION
bInterval has different units for HS compared to FS. This uses max_supported_packet_size as a proxy for FS/HS, which is a slight hack, but it's also never going to change.

Reference is page 271 in the usb 2.0 spec.