### PR TITLE
Fix UART on rp2xxx

### DIFF
--- a/port/raspberrypi/rp2xxx/src/hal/uart.zig
+++ b/port/raspberrypi/rp2xxx/src/hal/uart.zig
@@ -368,6 +368,7 @@ pub const UART = enum(u1) {
         var iter = microzig.utilities.SliceVector([]const u8).init(payloads).iterator();
         while (iter.next_chunk(null)) |payload| {
             var offset: usize = uart.prime_tx_fifo(payload);
+            written += offset;
             while (offset < payload.len) {
                 while (!uart.is_writeable()) {
                     try deadline.check(time.get_time_since_boot());


### PR DESCRIPTION
When trying to run some of the examples at `examples/raspberrypi/rp2xxx/src/usb_cdc.zig` I noticed data was written into the UART in an infinite loop. After looking into it it seems data being primed into the UART TX FIFO is not being taken into account when accumulating the amount of bytes written. This (I believe) throws [`std.Io.Writer.writeAll`](https://ziglang.org/documentation/master/std/#std.Io.Writer.writeAll) into an infinite loop.

This PR simply increments `written` by whatever amount of data is primed into the TX FIFO. At least on my Pico (i.e. RP20240) this makes the UART functional again.

BTW, thanks a million for making microzig :P