### PR TITLE
fix(wifi) wifi scan example fix

### DIFF
--- a/drivers/src/wireless/cyw43/wifi.zig
+++ b/drivers/src/wireless/cyw43/wifi.zig
@@ -297,7 +297,7 @@ pub const CYW43_Wifi = struct {
         };
 
         const max_payload = 1280 - ("escan".len + 1);
-        var payload_buf: [max_payload]u8 = undefined;
+        var payload_buf: [max_payload]u8 align(@alignOf(ScanParamsWire)) = undefined;
 
         const payload = try pack_scan_params(&payload_buf, params, channels);
         try self.transport.set_iovar("escan", payload);


### PR DESCRIPTION
In the Wi-Fi scan example, I encountered the following error: **error: panic: incorrect alignment**. This fix resolves the issue. Tested on Pico 2 W.