### PR TITLE
cortex m0+: Fix bug doing read modify write on set only registers

### DIFF
--- a/core/src/cpus/cortex_m/m0plus.zig
+++ b/core/src/cpus/cortex_m/m0plus.zig
@@ -172,11 +172,11 @@ pub const NestedVectorInterruptController = extern struct {
     }
 
     pub fn enable(nvic: *volatile NestedVectorInterruptController, num: comptime_int) void {
-        nvic.ISER |= 1 << num;
+        nvic.ISER = 1 << num;
     }
 
     pub fn disable(nvic: *volatile NestedVectorInterruptController, num: comptime_int) void {
-        nvic.ICER |= 1 << num;
+        nvic.ICER = 1 << num;
     }
 
     pub fn is_pending(nvic: *volatile NestedVectorInterruptController, num: comptime_int) void {
@@ -184,11 +184,11 @@ pub const NestedVectorInterruptController = extern struct {
     }
 
     pub fn set_pending(nvic: *volatile NestedVectorInterruptController, num: comptime_int) void {
-        nvic.ISPR |= 1 << num;
+        nvic.ISPR = 1 << num;
     }
 
     pub fn clear_pending(nvic: *volatile NestedVectorInterruptController, num: comptime_int) void {
-        nvic.ICPR |= 1 << num;
+        nvic.ICPR = 1 << num;
     }
 };
 


### PR DESCRIPTION
This bug can be especially bad on the NVIC_ICER where a read, modify, write can actually disable all previously enabled interrupts (rather than just the intended interrupt)

I'm not that familiar with the code base but I suspect this is an issue in other places.  I might try to look closer later but I just wanted to get this out there as at least a partial fix for an issue I ran into earlier this year (and worked around at the time).

https://github.com/ZigEmbeddedGroup/microzig/issues/955


Update to do write only rather than read, modify, write since 0 is meaningless and the read-back 1 may not have the desired effect. 