### PR TITLE
compile object doesn't support addObjectFile anymore need to refrence the root_module

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -714,7 +714,7 @@ pub fn MicroBuild(port_select: PortSelect) type {
 
             /// Adds an object file to the firmware.
             pub fn add_object_file(fw: *Firmware, source: LazyPath) void {
-                fw.exe.addObjectFile(source);
+                fw.exe.root_module.addObjectFile(source);
             }
         };
 


### PR DESCRIPTION
Removed in zig 0.16

https://codeberg.org/ziglang/zig/commit/39fa8319478e4843d5384e81935520be2dbbadef