### PR TITLE
Make UARTs adhere to the std.Io.Reader interface

### DIFF
--- a/port/raspberrypi/rp2xxx/src/hal/uart.zig
+++ b/port/raspberrypi/rp2xxx/src/hal/uart.zig
@@ -177,6 +177,8 @@ pub const UART = enum(u1) {
             .deadline = deadline,
             .interface = .{
                 .buffer = buffer,
+                .seek = 0,
+                .end = 0,
                 .vtable = &.{
                     .stream = stream,
                 },
@@ -206,21 +208,15 @@ pub const UART = enum(u1) {
         return n;
     }
 
-    fn stream(io_reader: *std.Io.Reader, w: *std.Io.Writer, limit: std.Io.Limit) std.Io.Reader.StreamError!usize {
-        const r: *Reader = @fieldParentPtr("interface", io_reader);
+    fn stream(r: *std.Io.Reader, w: *std.Io.Writer, limit: std.Io.Limit) std.Io.Reader.StreamError!usize {
+        const uart_reader: *Reader = @alignCast(@fieldParentPtr("interface", r));
+        const uart = uart_reader.uart;
         return switch (limit) {
             .nothing => 0,
-            else => blk: {
-                var buf: [1]u8 = undefined;
-                const n = r.uart.read_blocking(&buf, null) catch |err| switch (err) {
-                    error.ReceiveError => return error.ReadError,
-                };
-
-                break :blk switch (n) {
-                    0 => 0,
-                    1 => try w.writeByte(buf[0]),
-                    else => unreachable,
-                };
+            else => {
+                const b = uart.read_word_blocking(uart_reader.deadline) catch return error.ReadFailed;
+                try w.writeByte(b);
+                return 1;
             },
         };
     }


### PR DESCRIPTION
When trying to leverage an UART through an `std.Io.Reader` interface I was met with compilation errors such as

```
$ zig build
failed command: /Users/pcollado/.zvm/0.17.0-dev.1158+1d1193aa7/zig build-exe -fno-strip -fsingle-threaded -OReleaseSmall -target thumb-freestanding-eabi -mcpu cortex_m0plus --dep libmodbuz --dep microzig -Mroot=/Users/pcollado/repos/zig/zpi/src/main.zig -OReleaseSmall -target thumb-freestanding-eabi -mcpu cortex_m0plus -Mlibmodbuz=/Users/pcollado/repos/zig/zpi/zig-pkg/modbuz-0.1.0-0Q-9R9XEAgDzydH9_sRFHTaunW6CqI9rsSxKNNETe53K/src/root.zig --dep config --dep drivers --dep cpu --dep chip --dep hal --dep board -Mmicrozig=/Users/pcollado/repos/zig/zpi/../microzig-fork/core/src/microzig.zig -Mconfig=.zig-cache/o/9cc470c215c9d53763a20b54005a414b/options.zig -ODebug --dep link -Mdrivers=/Users/pcollado/repos/zig/zpi/../microzig-fork/drivers/src/root.zig --dep rtt --dep microzig -Mcpu=/Users/pcollado/repos/zig/zpi/../microzig-fork/core/src/cpus/cortex_m.zig --dep microzig -Mchip=.zig-cache/o/a4dc3ed0c6ced3b6b47ac543b2deba81/chips/RP2040.zig --dep bounded-array --dep microzig -Mhal=/Users/pcollado/repos/zig/zpi/../microzig-fork/port/raspberrypi/rp2xxx/src/hal.zig --dep bootloader --dep microzig -Mboard=/Users/pcollado/repos/zig/zpi/../microzig-fork/port/raspberrypi/rp2xxx/src/boards/raspberry_pi_pico.zig -ODebug -Mlink=/Users/pcollado/repos/zig/zpi/../microzig-fork/modules/network/link/link.zig -ODebug -Mrtt=/Users/pcollado/repos/zig/zpi/../microzig-fork/modules/rtt/src/rtt.zig -ODebug -Mbounded-array=/Users/pcollado/repos/zig/zpi/../microzig-fork/modules/bounded-array/src/bounded_array.zig -Mbootloader=.zig-cache/o/01d11e229d79fbdd352e20001304475f/w25q080.bin -ffunction-sections -fdata-sections --gc-sections --cache-dir .zig-cache --global-cache-dir /Users/pcollado/.cache/zig --name zpi -static -fcompiler-rt --script .zig-cache/o/498e1b9ecbd57f16bb8c6a4148dc6d7c/linker.ld --zig-lib-dir /Users/pcollado/.zvm/0.17.0-dev.1158+1d1193aa7/lib/ --listen=-

install
└─ install generated to zpi-dbg.elf
   └─ compile exe zpi-dbg Debug thumb-freestanding-eabi 3 errors
/Users/pcollado/repos/zig/microzig-fork/port/raspberrypi/rp2xxx/src/hal/uart.zig:178:27: error: missing struct field: seek
            .interface = .{
                         ~^
/Users/pcollado/repos/zig/microzig-fork/port/raspberrypi/rp2xxx/src/hal/uart.zig:178:27: note: missing struct field: end
/Users/pcollado/.zvm/0.17.0-dev.1158+1d1193aa7/lib/std/Io/Reader.zig:1:1: note: struct declared here
const Reader = @This();
^~~~~
referenced by:
    init: src/modbus.zig:161:30
    main: src/main.zig:87:16
    6 reference(s) hidden; use '-freference-trace=8' to see all references
/Users/pcollado/repos/zig/microzig-fork/port/raspberrypi/rp2xxx/src/hal/uart.zig:210:28: error: @fieldParentPtr increases pointer alignment
        const r: *Reader = @fieldParentPtr("interface", io_reader);
                           ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/Users/pcollado/repos/zig/microzig-fork/port/raspberrypi/rp2xxx/src/hal/uart.zig:210:28: note: parent pointer type '*hal.uart.UART.Reader' has alignment '2'
/Users/pcollado/repos/zig/microzig-fork/port/raspberrypi/rp2xxx/src/hal/uart.zig:155:24: note: struct field 'interface' limits alignment to '2'
    pub const Reader = struct {
                       ^~~~~~
/Users/pcollado/repos/zig/microzig-fork/port/raspberrypi/rp2xxx/src/hal/uart.zig:210:28: note: use @alignCast to assert pointer alignment
src/modbus.zig:44:30: error: no field or member function named 'take_byte' in '?hal.uart.UART.Reader'
    const count = uart_reader.take_byte() catch |err| {
                  ~~~~~~~~~~~^~~~~~~~~~

$ zig version
0.17.0-dev.1158+1d1193aa7
```

This PR adds changes so that the UART's HAL adheres to the [`std.Io.Reader`](https://ziglang.org/documentation/master/std/#std.Io.Reader) interface whilst also updating the `stream` function.

The reader implementation works on my side when driving the UART for performing Modbus requests.

If there's anything that should be changed don't hesitate to do so: these are my first steps with Zig!

Thanks a ton for your time.