### PR TITLE
Fix spelling of separate in gpio comment

### DIFF
--- a/port/raspberrypi/rp2xxx/src/hal/gpio.zig
+++ b/port/raspberrypi/rp2xxx/src/hal/gpio.zig
@@ -321,7 +321,7 @@ pub const Pin = enum(u6) {
         const bitshift_val: u5 = switch (chip) {
             .RP2040 => @intCast(@intFromEnum(gpio)),
             .RP2350 =>
-            // There are seperate copies of registers for GPIO32->47 on RP2350,
+            // There are separate copies of registers for GPIO32->47 on RP2350,
             // so upper GPIOs should present as bits 0 -> 15
             if (gpio.is_upper()) @intCast(@intFromEnum(gpio) - 32) else @intCast(@intFromEnum(gpio)),
         };


### PR DESCRIPTION
Small spelling typo in a code comment in `port/raspberrypi/rp2xxx/src/hal/gpio.zig`: "There are seperate copies of registers..." -> "separate".
