### PR TITLE
rp2xxx: fixed bug in get_pwm

### DIFF
--- a/port/raspberrypi/rp2xxx/src/hal/pwm.zig
+++ b/port/raspberrypi/rp2xxx/src/hal/pwm.zig
@@ -67,7 +67,7 @@ pub const Slice = enum(u32) {
 pub fn get_pwm(pinnum: u9) Pwm {
     const tmp_num: u32 = if (pinnum > 15) pinnum - 16 else pinnum;
     const slice_num: u32 = tmp_num >> 1;
-    const chan: Channel = @fromBackingInt(tmp_num & 1);
+    const chan: Channel = @fromBackingInt(@truncate(tmp_num & 1));
     return .{ .channel = chan, .slice_number = slice_num };
 }
 


### PR DESCRIPTION
Without this I get the following error:

```
zig-pkg/microzig-0.15.2-D20YSdG94gDWSUaMverG182uPMyOlXtumPtLxs-uRyQ9/port/raspberrypi/rp2xxx/src/hal/pwm.zig:70:51: error: expected type 'u1', found 'u32'
    const chan: Channel = @fromBackingInt(tmp_num & 1);
                                          ~~~~~~~~^~~
zig-pkg/microzig-0.15.2-D20YSdG94gDWSUaMverG182uPMyOlXtumPtLxs-uRyQ9/port/raspberrypi/rp2xxx/src/hal/pwm.zig:70:51: note: unsigned 1-bit int cannot represent all possible unsigned 32-bit values referenced by:
    main: src/main.zig:49:33
    microzig_main: zig-pkg/microzig-0.15.2-D20YSdG94gDWSUaMverG182uPMyOlXtumPtLxs-uRyQ9/core/src/microzig.zig:151:13
```