### PR TITLE
printer: update ELF PF flags access for Zig 0.17

### DIFF
--- a/tools/printer/src/Elf.zig
+++ b/tools/printer/src/Elf.zig
@@ -100,15 +100,15 @@ pub fn init(allocator: std.mem.Allocator, file_reader: *std.Io.File.Reader) !Elf
 
     var program_header_iterator = elf_header.iterateProgramHeaders(file_reader);
     while (try program_header_iterator.next()) |phdr| {
-        if (phdr.p_type != std.elf.PT_LOAD) continue;
+        if (phdr.type != std.elf.PT.LOAD) continue;
 
         try loaded_regions.append(allocator, .{
-            .start_address = phdr.p_vaddr,
-            .end_address = phdr.p_vaddr + phdr.p_memsz,
+            .start_address = phdr.vaddr,
+            .end_address = phdr.vaddr + phdr.memsz,
             .flags = .{
-                .read = phdr.p_flags & std.elf.PF_R != 0,
-                .write = phdr.p_flags & std.elf.PF_W != 0,
-                .exec = phdr.p_flags & std.elf.PF_X != 0,
+                .read = phdr.flags.R,
+                .write = phdr.flags.W,
+                .exec = phdr.flags.X,
             },
         });
     }

--- a/tools/printer/tests/test_program.dwarf32.zon
+++ b/tools/printer/tests/test_program.dwarf32.zon
@@ -1,4 +1,4 @@
-.{ .zig_version = "0.17.0-dev.1471+ff10b90bc", .tests = .{
+.{ .zig_version = "0.17.0-dev.1683+5ceec001b", .tests = .{
     .{ .address = 16941056, .expected = .{
         .line = 163,
         .column = 33,

--- a/tools/printer/tests/test_program.dwarf64.zon
+++ b/tools/printer/tests/test_program.dwarf64.zon
@@ -1,4 +1,4 @@
-.{ .zig_version = "0.17.0-dev.1471+ff10b90bc", .tests = .{
+.{ .zig_version = "0.17.0-dev.1683+5ceec001b", .tests = .{
     .{ .address = 16969728, .expected = .{
         .line = 163,
         .column = 33,


### PR DESCRIPTION
printer: update ELF PF flags access for Zig 0.17