### PR TITLE
feat: support timeouts and deadlines

### DIFF
--- a/port/raspberrypi/rp2xxx/src/hal/uart.zig
+++ b/port/raspberrypi/rp2xxx/src/hal/uart.zig
@@ -152,28 +152,28 @@ pub const UART = enum(u1) {
 
     pub const Writer = struct {
         uart: UART,
-        timeFrontier: TimeFrontier,
+        time_frontier: TimeFrontier,
         interface: std.Io.Writer,
 
         pub fn set_deadline(self: *Writer, deadline: mdf.time.Deadline) void {
-            self.*.timeFrontier = TimeFrontier{ .deadline = deadline };
+            self.*.time_frontier = TimeFrontier{ .deadline = deadline };
         }
     };
 
     pub const Reader = struct {
         uart: UART,
-        timeFrontier: TimeFrontier,
+        time_frontier: TimeFrontier,
         interface: std.Io.Reader,
 
         pub fn set_deadline(self: *Reader, deadline: mdf.time.Deadline) void {
-            self.*.timeFrontier = TimeFrontier{ .deadline = deadline };
+            self.*.time_frontier = TimeFrontier{ .deadline = deadline };
         }
     };
 
-    pub fn writer(uart: UART, timeFrontier: TimeFrontier, buffer: []u8) Writer {
+    pub fn writer(uart: UART, time_frontier: TimeFrontier, buffer: []u8) Writer {
         return .{
             .uart = uart,
-            .timeFrontier = timeFrontier,
+            .time_frontier = time_frontier,
             .interface = .{
                 .buffer = buffer,
                 .vtable = &.{
@@ -183,10 +183,10 @@ pub const UART = enum(u1) {
         };
     }
 
-    pub fn reader(uart: UART, timeFrontier: TimeFrontier, buffer: []u8) Reader {
+    pub fn reader(uart: UART, time_frontier: TimeFrontier, buffer: []u8) Reader {
         return .{
             .uart = uart,
-            .timeFrontier = timeFrontier,
+            .time_frontier = time_frontier,
             .interface = .{
                 .buffer = buffer,
                 .seek = 0,
@@ -203,7 +203,7 @@ pub const UART = enum(u1) {
         const uart = uart_writer.uart;
 
         var deadline: mdf.time.Deadline = undefined;
-        switch (uart_writer.timeFrontier) {
+        switch (uart_writer.time_frontier) {
             .deadline => |d| deadline = d,
             .timeout_us => |t| deadline = time.deadline_in_us(t),
         }
@@ -232,7 +232,7 @@ pub const UART = enum(u1) {
         const uart = uart_reader.uart;
 
         var deadline: mdf.time.Deadline = undefined;
-        switch (uart_reader.timeFrontier) {
+        switch (uart_reader.time_frontier) {
             .deadline => |d| deadline = d,
             .timeout_us => |t| deadline = time.deadline_in_us(t),
         }

--- a/port/raspberrypi/rp2xxx/src/hal/uart.zig
+++ b/port/raspberrypi/rp2xxx/src/hal/uart.zig
@@ -206,7 +206,6 @@ pub const UART = enum(u1) {
             .deadline => |d| d,
             .timeout_us => |t| time.deadline_in_us(t),
         };
-        // logg.debug("hello from drain with deadline {any}", .{deadline});
 
         // bytes from buffer are not included in count.
         w.end -= uart.write_blocking(w.buffer[0..w.end], deadline) catch |err| switch (err) {
@@ -234,7 +233,6 @@ pub const UART = enum(u1) {
             .deadline => |d| d,
             .timeout_us => |t| time.deadline_in_us(t),
         };
-        // logg.debug("hello from stream with deadline {any}", .{deadline});
 
         return switch (limit) {
             .nothing => 0,

--- a/port/raspberrypi/rp2xxx/src/hal/uart.zig
+++ b/port/raspberrypi/rp2xxx/src/hal/uart.zig
@@ -156,7 +156,7 @@ pub const UART = enum(u1) {
         interface: std.Io.Writer,
 
         pub fn set_deadline(self: *Writer, deadline: mdf.time.Deadline) void {
-            self.*.time_frontier = TimeFrontier{ .deadline = deadline };
+            self.time_frontier = TimeFrontier{ .deadline = deadline };
         }
     };
 
@@ -166,7 +166,7 @@ pub const UART = enum(u1) {
         interface: std.Io.Reader,
 
         pub fn set_deadline(self: *Reader, deadline: mdf.time.Deadline) void {
-            self.*.time_frontier = TimeFrontier{ .deadline = deadline };
+            self.time_frontier = TimeFrontier{ .deadline = deadline };
         }
     };
 

--- a/port/raspberrypi/rp2xxx/src/hal/uart.zig
+++ b/port/raspberrypi/rp2xxx/src/hal/uart.zig
@@ -135,7 +135,10 @@ pub const instance = struct {
     }
 };
 
-pub const TimeFrontier = union(enum) { timeout_us: u64, deadline: mdf.time.Deadline };
+pub const TimeFrontier = union(enum) {
+    timeout_us: u64,
+    deadline: mdf.time.Deadline,
+};
 
 pub const no_deadline: TimeFrontier = .{ .deadline = .no_deadline };
 

--- a/port/raspberrypi/rp2xxx/src/hal/uart.zig
+++ b/port/raspberrypi/rp2xxx/src/hal/uart.zig
@@ -138,9 +138,9 @@ pub const instance = struct {
 pub const TimeFrontier = union(enum) {
     timeout_us: u64,
     deadline: mdf.time.Deadline,
-};
 
-pub const no_deadline: TimeFrontier = .{ .deadline = .no_deadline };
+    pub const no_deadline: TimeFrontier = .{ .deadline = .no_deadline };
+};
 
 /// An API for interacting with the RP2040's UART driver.
 ///
@@ -585,7 +585,7 @@ var uart_logger: ?UART.Writer = null;
 ///     .logFn = hal.uart.log,
 /// };
 pub fn init_logger(uart: UART) void {
-    uart_logger = uart.writer(no_deadline, &.{});
+    uart_logger = uart.writer(.no_deadline, &.{});
     uart_logger.?.interface.writeAll("\r\n================ STARTING NEW LOGGER ================\r\n") catch {};
 }
 

--- a/port/raspberrypi/rp2xxx/src/hal/uart.zig
+++ b/port/raspberrypi/rp2xxx/src/hal/uart.zig
@@ -154,7 +154,7 @@ pub const UART = enum(u1) {
         interface: std.Io.Writer,
 
         pub fn set_deadline(self: *Writer, deadline: mdf.time.Deadline) void {
-            self.*.timeFrontier = TimeFrontier{.deadline = deadline};
+            self.*.timeFrontier = TimeFrontier{ .deadline = deadline };
         }
     };
 
@@ -164,7 +164,7 @@ pub const UART = enum(u1) {
         interface: std.Io.Reader,
 
         pub fn set_deadline(self: *Reader, deadline: mdf.time.Deadline) void {
-            self.*.timeFrontier = TimeFrontier{.deadline = deadline};
+            self.*.timeFrontier = TimeFrontier{ .deadline = deadline };
         }
     };
 
@@ -203,8 +203,9 @@ pub const UART = enum(u1) {
         var deadline: mdf.time.Deadline = undefined;
         switch (uart_writer.timeFrontier) {
             .deadline => |d| deadline = d,
-            .timeout_us => |t| deadline = time.deadline_in_us(t)
+            .timeout_us => |t| deadline = time.deadline_in_us(t),
         }
+        // logg.debug("hello from drain with deadline {any}", .{deadline});
 
         // bytes from buffer are not included in count.
         w.end -= uart.write_blocking(w.buffer[0..w.end], deadline) catch |err| switch (err) {
@@ -231,8 +232,9 @@ pub const UART = enum(u1) {
         var deadline: mdf.time.Deadline = undefined;
         switch (uart_reader.timeFrontier) {
             .deadline => |d| deadline = d,
-            .timeout_us => |t| deadline = time.deadline_in_us(t)
+            .timeout_us => |t| deadline = time.deadline_in_us(t),
         }
+        // logg.debug("hello from stream with deadline {any}", .{deadline});
 
         return switch (limit) {
             .nothing => 0,
@@ -582,7 +584,7 @@ var uart_logger: ?UART.Writer = null;
 ///     .logFn = hal.uart.log,
 /// };
 pub fn init_logger(uart: UART) void {
-    uart_logger = uart.writer(.{.deadline = .no_deadline}, &.{});
+    uart_logger = uart.writer(.{ .deadline = .no_deadline }, &.{});
     uart_logger.?.interface.writeAll("\r\n================ STARTING NEW LOGGER ================\r\n") catch {};
 }
 

--- a/port/raspberrypi/rp2xxx/src/hal/uart.zig
+++ b/port/raspberrypi/rp2xxx/src/hal/uart.zig
@@ -137,6 +137,8 @@ pub const instance = struct {
 
 pub const TimeFrontier = union(enum) { timeout_us: u64, deadline: mdf.time.Deadline };
 
+pub const no_deadline: TimeFrontier = .{ .deadline = .no_deadline };
+
 /// An API for interacting with the RP2040's UART driver.
 ///
 /// Note: Assumes proper GPIO configuration, does NOT configure GPIO pins.
@@ -584,7 +586,7 @@ var uart_logger: ?UART.Writer = null;
 ///     .logFn = hal.uart.log,
 /// };
 pub fn init_logger(uart: UART) void {
-    uart_logger = uart.writer(.{ .deadline = .no_deadline }, &.{});
+    uart_logger = uart.writer(.no_deadline, &.{});
     uart_logger.?.interface.writeAll("\r\n================ STARTING NEW LOGGER ================\r\n") catch {};
 }
 

--- a/port/raspberrypi/rp2xxx/src/hal/uart.zig
+++ b/port/raspberrypi/rp2xxx/src/hal/uart.zig
@@ -135,6 +135,8 @@ pub const instance = struct {
     }
 };
 
+pub const TimeFrontier = union(enum) { timeout_us: u64, deadline: mdf.time.Deadline };
+
 /// An API for interacting with the RP2040's UART driver.
 ///
 /// Note: Assumes proper GPIO configuration, does NOT configure GPIO pins.
@@ -148,20 +150,28 @@ pub const UART = enum(u1) {
 
     pub const Writer = struct {
         uart: UART,
-        deadline: mdf.time.Deadline,
+        timeFrontier: TimeFrontier,
         interface: std.Io.Writer,
+
+        pub fn set_deadline(self: *Writer, deadline: mdf.time.Deadline) void {
+            self.*.timeFrontier = TimeFrontier{.deadline = deadline};
+        }
     };
 
     pub const Reader = struct {
         uart: UART,
-        deadline: mdf.time.Deadline,
+        timeFrontier: TimeFrontier,
         interface: std.Io.Reader,
+
+        pub fn set_deadline(self: *Reader, deadline: mdf.time.Deadline) void {
+            self.*.timeFrontier = TimeFrontier{.deadline = deadline};
+        }
     };
 
-    pub fn writer(uart: UART, deadline: mdf.time.Deadline, buffer: []u8) Writer {
+    pub fn writer(uart: UART, timeFrontier: TimeFrontier, buffer: []u8) Writer {
         return .{
             .uart = uart,
-            .deadline = deadline,
+            .timeFrontier = timeFrontier,
             .interface = .{
                 .buffer = buffer,
                 .vtable = &.{
@@ -171,10 +181,10 @@ pub const UART = enum(u1) {
         };
     }
 
-    pub fn reader(uart: UART, deadline: mdf.time.Deadline, buffer: []u8) Reader {
+    pub fn reader(uart: UART, timeFrontier: TimeFrontier, buffer: []u8) Reader {
         return .{
             .uart = uart,
-            .deadline = deadline,
+            .timeFrontier = timeFrontier,
             .interface = .{
                 .buffer = buffer,
                 .seek = 0,
@@ -190,18 +200,24 @@ pub const UART = enum(u1) {
         const uart_writer: *Writer = @alignCast(@fieldParentPtr("interface", w));
         const uart = uart_writer.uart;
 
+        var deadline: mdf.time.Deadline = undefined;
+        switch (uart_writer.timeFrontier) {
+            .deadline => |d| deadline = d,
+            .timeout_us => |t| deadline = time.deadline_in_us(t)
+        }
+
         // bytes from buffer are not included in count.
-        w.end -= uart.write_blocking(w.buffer[0..w.end], uart_writer.deadline) catch |err| switch (err) {
+        w.end -= uart.write_blocking(w.buffer[0..w.end], deadline) catch |err| switch (err) {
             error.Timeout => unreachable,
         };
         assert(w.end == 0);
 
         var n: usize = 0;
-        n += uart.writev_blocking(data[0 .. data.len - 1], uart_writer.deadline) catch |err| switch (err) {
+        n += uart.writev_blocking(data[0 .. data.len - 1], deadline) catch |err| switch (err) {
             error.Timeout => unreachable,
         };
         for (0..splat) |_|
-            n += uart.write_blocking(data[data.len - 1], uart_writer.deadline) catch |err| switch (err) {
+            n += uart.write_blocking(data[data.len - 1], deadline) catch |err| switch (err) {
                 error.Timeout => unreachable,
             };
 
@@ -211,10 +227,17 @@ pub const UART = enum(u1) {
     fn stream(r: *std.Io.Reader, w: *std.Io.Writer, limit: std.Io.Limit) std.Io.Reader.StreamError!usize {
         const uart_reader: *Reader = @alignCast(@fieldParentPtr("interface", r));
         const uart = uart_reader.uart;
+
+        var deadline: mdf.time.Deadline = undefined;
+        switch (uart_reader.timeFrontier) {
+            .deadline => |d| deadline = d,
+            .timeout_us => |t| deadline = time.deadline_in_us(t)
+        }
+
         return switch (limit) {
             .nothing => 0,
             else => {
-                const b = uart.read_word_blocking(uart_reader.deadline) catch return error.ReadFailed;
+                const b = uart.read_word_blocking(deadline) catch return error.ReadFailed;
                 try w.writeByte(b);
                 return 1;
             },
@@ -559,7 +582,7 @@ var uart_logger: ?UART.Writer = null;
 ///     .logFn = hal.uart.log,
 /// };
 pub fn init_logger(uart: UART) void {
-    uart_logger = uart.writer(.no_deadline, &.{});
+    uart_logger = uart.writer(.{.deadline = .no_deadline}, &.{});
     uart_logger.?.interface.writeAll("\r\n================ STARTING NEW LOGGER ================\r\n") catch {};
 }
 

--- a/port/raspberrypi/rp2xxx/src/hal/uart.zig
+++ b/port/raspberrypi/rp2xxx/src/hal/uart.zig
@@ -582,7 +582,7 @@ var uart_logger: ?UART.Writer = null;
 ///     .logFn = hal.uart.log,
 /// };
 pub fn init_logger(uart: UART) void {
-    uart_logger = uart.writer(.no_deadline, &.{});
+    uart_logger = uart.writer(no_deadline, &.{});
     uart_logger.?.interface.writeAll("\r\n================ STARTING NEW LOGGER ================\r\n") catch {};
 }
 

--- a/port/raspberrypi/rp2xxx/src/hal/uart.zig
+++ b/port/raspberrypi/rp2xxx/src/hal/uart.zig
@@ -202,11 +202,10 @@ pub const UART = enum(u1) {
         const uart_writer: *Writer = @alignCast(@fieldParentPtr("interface", w));
         const uart = uart_writer.uart;
 
-        var deadline: mdf.time.Deadline = undefined;
-        switch (uart_writer.time_frontier) {
-            .deadline => |d| deadline = d,
-            .timeout_us => |t| deadline = time.deadline_in_us(t),
-        }
+        const deadline: mdf.time.Deadline = switch (uart_writer.time_frontier) {
+            .deadline => |d| d,
+            .timeout_us => |t| time.deadline_in_us(t),
+        };
         // logg.debug("hello from drain with deadline {any}", .{deadline});
 
         // bytes from buffer are not included in count.
@@ -231,11 +230,10 @@ pub const UART = enum(u1) {
         const uart_reader: *Reader = @alignCast(@fieldParentPtr("interface", r));
         const uart = uart_reader.uart;
 
-        var deadline: mdf.time.Deadline = undefined;
-        switch (uart_reader.time_frontier) {
-            .deadline => |d| deadline = d,
-            .timeout_us => |t| deadline = time.deadline_in_us(t),
-        }
+        const deadline: mdf.time.Deadline = switch (uart_reader.time_frontier) {
+            .deadline => |d| d,
+            .timeout_us => |t| time.deadline_in_us(t),
+        };
         // logg.debug("hello from stream with deadline {any}", .{deadline});
 
         return switch (limit) {


### PR DESCRIPTION
This commit adds support for specifying deadlines for read and write operations over UARTs in one of two ways:

  1. By providing a deadline as an absolute time in the future as was done before. These deadlines can be 'refreshed' through the `set_deadline` methods.

  2. By providing a timeout with which a new deadline will be computed upon performing a read or write operation.

This allows for a precise handling of deadlines when leveraging the std.Io.{Reader,Writer} interface semantics.

Closes #1017