### PR TITLE
Update to Zig 0.17.0-dev.1936+5a625d5f3

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -217,6 +217,7 @@ jobs:
         uses: actions/checkout@v7
       - name: Setup Zig
         uses: mlugg/setup-zig@v2
+        working-directory: website
       - name: Build Website
         run: zig build
         working-directory: website

--- a/.github/workflows/publish-github-pages.yml
+++ b/.github/workflows/publish-github-pages.yml
@@ -16,6 +16,7 @@ jobs:
 
       - name: Setup Zig
         uses: mlugg/setup-zig@v2
+        working-directory: website
 
       - name: Download and install GitHub CLI
         run: |

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -3,7 +3,7 @@
     // Note: This should be changed if you fork microzig!
     .fingerprint = 0x605a83a849186d0f,
     .version = "0.15.2",
-    .minimum_zig_version = "0.17.0-dev.1471+ff10b90bc",
+    .minimum_zig_version = "0.17.0-dev.1936+5a625d5f3",
     .dependencies = .{
         .@"build-internals" = .{ .path = "build-internals" },
         .core = .{ .path = "core" },

--- a/modules/freertos/build.zig.zon
+++ b/modules/freertos/build.zig.zon
@@ -19,8 +19,8 @@
             .path = "../foundation-libc/",
         },
         .translate_c = .{
-            .url = "git+https://codeberg.org/ziglang/translate-c#2a6613bcc09c74296d785e660fe98d2eb310d760",
-            .hash = "translate_c-0.0.0-Q_BUWjQ7BwAhlMt3Zf4l3Jw-y0_TOpJWgcK8rk4d0aWv",
+            .url = "git+https://codeberg.org/ziglang/translate-c#32dde9bff199152a6cc4ddc77e0e79cc9a3e57fc",
+            .hash = "translate_c-0.0.0-Q_BUWhc9BwBtLC-dx8AuZH4hp4edEh90v2mqRBxjr3gW",
         },
     },
     .paths = .{ "build.zig", "build.zig.zon", "src", "config" },

--- a/modules/virtual-io/src/root.zig
+++ b/modules/virtual-io/src/root.zig
@@ -173,6 +173,8 @@ const VTable = struct {
             .device_io_control => unreachable,
             .net_receive => .{ .net_receive = .{ error.NetworkDown, 0 } },
             .net_read => .{ .net_read = error.NetworkDown },
+            .net_send => .{ .net_send = .{ error.NetworkDown, 0 } },
+            .net_write => .{ .net_write = error.NetworkDown },
         };
     }
 

--- a/port/nxp/lpc/src/tools/patchelf.zig
+++ b/port/nxp/lpc/src/tools/patchelf.zig
@@ -32,11 +32,11 @@ pub fn main(init: std.process.Init) !u8 {
 
     var iter = header.iterateProgramHeaders(&file_reader);
     while (try iter.next()) |phdr| {
-        if (phdr.p_type != std.elf.PT_LOAD) {
+        if (phdr.type != std.elf.PT.LOAD) {
             continue;
         }
 
-        if (phdr.p_paddr != 0) {
+        if (phdr.paddr != 0) {
             // std.log.warn("LOAD program header is not located at address 0x00000000!", .{});
             break;
         }
@@ -44,15 +44,15 @@ pub fn main(init: std.process.Init) !u8 {
         const boot_sector_items = 8;
         const boot_sector_size = @sizeOf([boot_sector_items]u32);
 
-        if (phdr.p_filesz < boot_sector_size) {
+        if (phdr.filesz < boot_sector_size) {
             std.log.warn("boot header is too small! Expected {} bytes, but sector only has {} bytes!", .{
                 boot_sector_size,
-                phdr.p_filesz,
+                phdr.filesz,
             });
             continue;
         }
 
-        try file_reader.seekTo(phdr.p_offset);
+        try file_reader.seekTo(phdr.offset);
 
         var checksum: u32 = 0;
 

--- a/sim/aviron/src/main.zig
+++ b/sim/aviron/src/main.zig
@@ -89,7 +89,7 @@ fn run_with_mcu(
 
                 var pheaders = header.iterateProgramHeaders(&reader);
                 while (try pheaders.next()) |phdr| {
-                    if (phdr.p_type != std.elf.PT_LOAD)
+                    if (phdr.type != std.elf.PT.LOAD)
                         continue; // Header isn't loaded
 
                     if (phdr.p_memsz == 0)

--- a/sim/aviron/src/testrunner.zig
+++ b/sim/aviron/src/testrunner.zig
@@ -135,7 +135,7 @@ fn run_test(
 
         var pheaders = header.iterateProgramHeaders(&reader);
         while (try pheaders.next()) |phdr| {
-            if (phdr.p_type != std.elf.PT_LOAD)
+            if (phdr.type != std.elf.PT.LOAD)
                 continue; // Header isn't loaded
 
             if (phdr.p_memsz == 0)

--- a/tools/dfu/src/dfuse.zig
+++ b/tools/dfu/src/dfuse.zig
@@ -163,7 +163,7 @@ fn collect_segments(
 
     var it = header.iterateProgramHeaders(reader);
     while (try it.next()) |prog_hdr| {
-        if (prog_hdr.p_type != std.elf.PT_LOAD or prog_hdr.p_filesz == 0) continue;
+        if (prog_hdr.type != std.elf.PT.LOAD or prog_hdr.p_filesz == 0) continue;
 
         const address = std.math.cast(u32, prog_hdr.p_paddr) orelse return error.AddressOverflow;
         const size = std.math.cast(u32, prog_hdr.p_filesz) orelse return error.SegmentTooLarge;

--- a/tools/esp-image/src/elf2image.zig
+++ b/tools/esp-image/src/elf2image.zig
@@ -122,11 +122,11 @@ pub fn main(init: std.process.Init) !void {
         if (cli_args.segments) {
             var it = elf_header.iterateProgramHeaders(&elf_file_reader);
             while (try it.next()) |hdr| {
-                if (hdr.p_type == std.elf.PT_LOAD and hdr.p_memsz > 0 and hdr.p_filesz > 0) {
+                if (hdr.type == std.elf.PT.LOAD and hdr.memsz > 0 and hdr.filesz > 0) {
                     try info_list.append(gpa, .{
-                        .addr = @as(u32, @intCast(hdr.p_paddr)),
-                        .file_offset = @as(u32, @intCast(hdr.p_offset)),
-                        .size = @as(u32, @intCast(hdr.p_filesz)),
+                        .addr = @as(u32, @intCast(hdr.paddr)),
+                        .file_offset = @as(u32, @intCast(hdr.offset)),
+                        .size = @as(u32, @intCast(hdr.filesz)),
                     });
                 }
             }

--- a/tools/printer/src/Elf.zig
+++ b/tools/printer/src/Elf.zig
@@ -26,7 +26,7 @@ pub const SectionTypes = enum {
 pub const Region = struct {
     start_address: u64,
     end_address: u64,
-    flags: Flags,
+    flags: std.elf.PF,
 
     pub const Flags = packed struct {
         read: bool,
@@ -100,16 +100,12 @@ pub fn init(allocator: std.mem.Allocator, file_reader: *std.Io.File.Reader) !Elf
 
     var program_header_iterator = elf_header.iterateProgramHeaders(file_reader);
     while (try program_header_iterator.next()) |phdr| {
-        if (phdr.p_type != std.elf.PT_LOAD) continue;
+        if (phdr.type != std.elf.PT.LOAD) continue;
 
         try loaded_regions.append(allocator, .{
-            .start_address = phdr.p_vaddr,
-            .end_address = phdr.p_vaddr + phdr.p_memsz,
-            .flags = .{
-                .read = phdr.p_flags & std.elf.PF_R != 0,
-                .write = phdr.p_flags & std.elf.PF_W != 0,
-                .exec = phdr.p_flags & std.elf.PF_X != 0,
-            },
+            .start_address = phdr.vaddr,
+            .end_address = phdr.vaddr + phdr.memsz,
+            .flags = phdr.flags,
         });
     }
 
@@ -133,7 +129,7 @@ pub fn deinit(self: *Elf, allocator: std.mem.Allocator) void {
 pub fn is_address_executable(self: Elf, address: u64) bool {
     var inside_memory_map = false;
     for (self.loaded_regions) |region| {
-        if (!region.flags.exec) {
+        if (!region.flags.X) {
             continue;
         }
 

--- a/tools/printer/tests/test_program.dwarf32.zon
+++ b/tools/printer/tests/test_program.dwarf32.zon
@@ -1,4 +1,4 @@
-.{ .zig_version = "0.17.0-dev.1471+ff10b90bc", .tests = .{
+.{ .zig_version = "0.17.0-dev.1936+5a625d5f3", .tests = .{
     .{ .address = 16941056, .expected = .{
         .line = 163,
         .column = 33,

--- a/tools/printer/tests/test_program.dwarf64.zon
+++ b/tools/printer/tests/test_program.dwarf64.zon
@@ -1,4 +1,4 @@
-.{ .zig_version = "0.17.0-dev.1471+ff10b90bc", .tests = .{
+.{ .zig_version = "0.17.0-dev.1936+5a625d5f3", .tests = .{
     .{ .address = 16969728, .expected = .{
         .line = 163,
         .column = 33,

--- a/tools/regz/build.zig.zon
+++ b/tools/regz/build.zig.zon
@@ -10,13 +10,13 @@
     },
     .dependencies = .{
         .libxml2 = .{
-            .url = "git+https://github.com/allyourcodebase/libxml2.git#38fb69d375bc364490a5cc9ac465732d03c836d3",
-            .hash = "libxml2-2.15.1-2-qHdjhjJXAADjFgEs5a_JV1oMyd9G6EsY12PvbfRAZwG-",
+            .url = "git+https://github.com/allyourcodebase/libxml2#f7bab883c713fa60f33cbf5e562696c529812967",
+            .hash = "libxml2-2.15.1-2-qHdjhjJXAAADBouSraVVXa-w--J3KeGvrpVuaW01KpT2",
         },
         .virtual_io = .{ .path = "../../modules/virtual-io" },
         .zqlite = .{
-            .url = "git+https://github.com/karlseguin/zqlite.zig?ref=dev#b6e439d83fe7a06c2c7e8eed8e07bd79c87b0925",
-            .hash = "zqlite-0.0.1-RWLaY8k8nACL-MBb7ZkqdAESSZDG-1aCWwnathuy7Mzb",
+            .url = "git+https://github.com/mattnite/zqlite.zig#48509708f7c965b3f0b5b29ec3d0f56c4a6fb32a",
+            .hash = "zqlite-0.0.1-RWLaY4Q-nAAkr-6kmFrU59kWxesGyFzgXMHJDAxwgLEA",
         },
     },
 }

--- a/tools/uf2/src/uf2.zig
+++ b/tools/uf2/src/uf2.zig
@@ -104,12 +104,12 @@ pub const Archive = struct {
         const header = try std.elf.Header.read(&reader.interface);
         var it = header.iterateProgramHeaders(reader);
         while (try it.next()) |prog_hdr|
-            if (prog_hdr.p_type == std.elf.PT_LOAD and prog_hdr.p_memsz > 0 and prog_hdr.p_filesz > 0) {
+            if (prog_hdr.type == std.elf.PT.LOAD and prog_hdr.memsz > 0 and prog_hdr.filesz > 0) {
                 std.log.debug("segment: {}", .{prog_hdr});
                 try segments.append(self.allocator, .{
-                    .addr = @as(u32, @intCast(prog_hdr.p_paddr)),
-                    .file_offset = @as(u32, @intCast(prog_hdr.p_offset)),
-                    .size = @as(u32, @intCast(prog_hdr.p_memsz)),
+                    .addr = @as(u32, @intCast(prog_hdr.paddr)),
+                    .file_offset = @as(u32, @intCast(prog_hdr.offset)),
+                    .size = @as(u32, @intCast(prog_hdr.memsz)),
                 });
             };
 

--- a/website/build.zig.zon
+++ b/website/build.zig.zon
@@ -2,6 +2,7 @@
     .name = .mz_website,
     .fingerprint = 0xf41bcd0e071e6f03,
     .version = "0.2.0",
+    .minimum_zig_version = "0.17.0-dev.1471+ff10b90bc",
     .paths = .{
         "README.md",
         "build.zig",


### PR DESCRIPTION
Turns out the real meta for this is to base your Zig version off of translate-c.