### PR TITLE
esp: Fix startup crash and more

### DIFF
--- a/port/espressif/esp/build.zig
+++ b/port/espressif/esp/build.zig
@@ -90,8 +90,11 @@ pub fn init(dep: *std.Build.Dependency) ?Self {
             .file = generate_linker_script(
                 dep,
                 "final.ld",
-                b.path("ld/esp32_c3/image_boot_sections.ld"),
-                b.path("ld/esp32_c3/rom_functions.ld"),
+                &.{
+                    b.path("ld/esp32_c3/image_boot_sections.ld"),
+                    b.path("ld/esp32_c3/common_sections.ld"),
+                    b.path("ld/esp32_c3/rom_functions.ld"),
+                },
             ),
         },
     };
@@ -120,8 +123,11 @@ pub fn init(dep: *std.Build.Dependency) ?Self {
                     .file = generate_linker_script(
                         dep,
                         "final.ld",
-                        b.path("ld/esp32_c3/direct_boot_sections.ld"),
-                        b.path("ld/esp32_c3/rom_functions.ld"),
+                        &.{
+                            b.path("ld/esp32_c3/direct_boot_sections.ld"),
+                            b.path("ld/esp32_c3/common_sections.ld"),
+                            b.path("ld/esp32_c3/rom_functions.ld"),
+                        },
                     ),
                 },
             }),
@@ -132,8 +138,11 @@ pub fn init(dep: *std.Build.Dependency) ?Self {
                     .file = generate_linker_script(
                         dep,
                         "final.ld",
-                        b.path("ld/esp32_c3/flashless_sections.ld"),
-                        b.path("ld/esp32_c3/rom_functions.ld"),
+                        &.{
+                            b.path("ld/esp32_c3/flashless_sections.ld"),
+                            b.path("ld/esp32_c3/common_sections.ld"),
+                            b.path("ld/esp32_c3/rom_functions.ld"),
+                        },
                     ),
                 },
             }),
@@ -185,15 +194,15 @@ fn get_cpu_config(b: *std.Build, boot_mode: BootMode) *std.Build.Module {
 fn generate_linker_script(
     dep: *std.Build.Dependency,
     output_name: []const u8,
-    base_path: std.Build.LazyPath,
-    rom_functions_path: std.Build.LazyPath,
+    input_paths: []const std.Build.LazyPath,
 ) std.Build.LazyPath {
     const b = dep.builder;
     const cat_exe = dep.artifact("cat");
 
     const run = b.addRunArtifact(cat_exe);
-    run.addFileArg(base_path);
-    run.addFileArg(rom_functions_path);
+    for (input_paths) |path| {
+        run.addFileArg(path);
+    }
     return run.addOutputFileArg(output_name);
 }
 

--- a/port/espressif/esp/ld/esp32_c3/common_sections.ld
+++ b/port/espressif/esp/ld/esp32_c3/common_sections.ld
@@ -1,0 +1,10 @@
+SECTIONS {
+  .eh_frame_hdr (INFO) : AT(0)
+  {
+    *(.eh_frame_hdr)
+  }
+  .eh_frame (INFO) :
+  {
+    *(.eh_frame)
+  }
+}

--- a/port/espressif/esp/ld/esp32_c3/direct_boot_sections.ld
+++ b/port/espressif/esp/ld/esp32_c3/direct_boot_sections.ld
@@ -5,7 +5,6 @@ SECTIONS
     _irom_start = .;
     KEEP(*(microzig_flash_start))
     *(.text*)
-    *(.eh_frame*)
 
     . = ALIGN(8);
   } > IROM

--- a/port/espressif/esp/src/cpus/esp_riscv.zig
+++ b/port/espressif/esp/src/cpus/esp_riscv.zig
@@ -135,9 +135,7 @@ pub const interrupt = struct {
     }
 
     fn get_priority_register_for(int: Interrupt) *volatile u32 {
-        std.debug.assert(@backingInt(int) != 0);
-        const bits = comptime @typeInfo(@typeInfo(Interrupt).@"enum".tag_type).int.bits;
-        const base: *volatile [bits]u32 = @ptrCast(&INTERRUPT_CORE0.CPU_INT_PRI_0);
+        const base: [*]volatile u32 = @ptrCast(&INTERRUPT_CORE0.CPU_INT_PRI_0);
         return &base[@backingInt(int)];
     }
 
@@ -316,9 +314,7 @@ pub const startup_logic = struct {
     else
         "microzig_flash_start";
 
-    fn _start() linksection(_start_link_section) callconv(.c) noreturn {
-        interrupt.disable_interrupts();
-
+    fn _start() linksection(_start_link_section) callconv(.naked) noreturn {
         asm volatile (
             \\.option push
             \\.option norelax
@@ -333,6 +329,14 @@ pub const startup_logic = struct {
             :
             : [eos] "r" (@as(u32, @intFromPtr(eos))),
         );
+
+        asm volatile (
+            \\j _start_c
+        );
+    }
+
+    fn _start_c() callconv(.c) noreturn {
+        interrupt.disable_interrupts();
 
         switch (cpu_config.boot_mode) {
             .direct => microzig.utilities.initialize_system_memories(.all),
@@ -349,6 +353,7 @@ pub const startup_logic = struct {
 
 pub fn export_startup_logic() void {
     @export(&startup_logic._start, .{ .name = "_start" });
+    @export(&startup_logic._start_c, .{ .name = "_start_c" });
 }
 
 /// Gets interrupts into a known state after the bootloader.

--- a/port/espressif/esp/src/cpus/esp_riscv.zig
+++ b/port/espressif/esp/src/cpus/esp_riscv.zig
@@ -331,7 +331,9 @@ pub const startup_logic = struct {
         );
 
         asm volatile (
-            \\j _start_c
+            \\jr %[start_c]
+            :
+            : [start_c] "r" (@as(u32, @intFromPtr(&_start_c))),
         );
     }
 
@@ -353,7 +355,6 @@ pub const startup_logic = struct {
 
 pub fn export_startup_logic() void {
     @export(&startup_logic._start, .{ .name = "_start" });
-    @export(&startup_logic._start_c, .{ .name = "_start_c" });
 }
 
 /// Gets interrupts into a known state after the bootloader.

--- a/port/espressif/esp/src/hal/usb_serial_jtag.zig
+++ b/port/espressif/esp/src/hal/usb_serial_jtag.zig
@@ -2,6 +2,7 @@ const std = @import("std");
 const assert = std.debug.assert;
 const microzig = @import("microzig");
 const USB_SERIAL_JTAG = microzig.chip.peripherals.USB_DEVICE;
+const time = @import("time.zig");
 
 /// Returns `false` if data can be sent.
 pub fn tx_fifo_full() bool {
@@ -25,7 +26,7 @@ pub fn tx_fifo_write(byte: u8) void {
 /// `microzig_options`.
 pub const logger = struct {
     var timed_out: bool = false;
-    var buffer: [256]u8 = undefined;
+    var buffer: [64]u8 = undefined;
     var writer = std.Io.Writer{
         .buffer = &buffer,
         .vtable = &.{
@@ -109,13 +110,17 @@ pub const logger = struct {
         comptime format: []const u8,
         args: anytype,
     ) void {
-        const level_prefix = comptime level.asText();
+        const level_prefix = comptime "[{}.{:0>6}] " ++ level.asText();
         const prefix = comptime level_prefix ++ switch (scope) {
             .default => ": ",
             else => " (" ++ @tagName(scope) ++ "): ",
         };
 
-        // TODO: add timestamp to log message
-        writer.print(prefix ++ format ++ "\r\n", args) catch {};
+        const current_time = time.get_time_since_boot();
+        const seconds = current_time.to_us() / std.time.us_per_s;
+        const microseconds = current_time.to_us() % std.time.us_per_s;
+
+        writer.print(prefix ++ format ++ "\r\n", .{ seconds, microseconds } ++ args) catch {};
+        writer.flush() catch {};
     }
 };

--- a/port/espressif/esp/src/tools/cat.zig
+++ b/port/espressif/esp/src/tools/cat.zig
@@ -14,14 +14,14 @@ pub fn main(init: std.process.Init) !void {
     const output_file = try std.Io.Dir.cwd().createFile(io, dst_path, .{});
     defer output_file.close(io);
 
-    var write_buf: [1024 * 1024]u8 = undefined;
+    var write_buf: [1024]u8 = undefined;
     var file_writer = output_file.writer(io, &write_buf);
     const writer = &file_writer.interface;
     for (src_paths) |src_path| {
         const file = try std.Io.Dir.openFile(.cwd(), io, src_path, .{ .mode = .read_only });
         defer file.close(io);
 
-        var read_buf: [1024 * 1024]u8 = undefined;
+        var read_buf: [1024]u8 = undefined;
         var reader = file.reader(io, &read_buf);
 
         _ = try reader.interface.streamRemaining(writer);


### PR DESCRIPTION
* The eh frame sections used to be flashed, now it is marked as INFO to avoid that (they are still present in the final elf but only as debug_info). In 0.15 they weren't included