### PR TITLE
nrf52x: Fix various issues with gpios

### DIFF
--- a/port/nordic/nrf5x/patches/nrf51.zon
+++ b/port/nordic/nrf5x/patches/nrf51.zon
@@ -8,7 +8,7 @@
                 .fields = .{
                     .{ .value = 0x0, .name = "disabled" },
                     .{ .value = 0x1, .name = "down" },
-                    .{ .value = 0x2, .name = "up" },
+                    .{ .value = 0x3, .name = "up" },
                 },
             },
         },

--- a/port/nordic/nrf5x/patches/nrf528xx.zon
+++ b/port/nordic/nrf5x/patches/nrf528xx.zon
@@ -8,7 +8,7 @@
                 .fields = .{
                     .{ .value = 0x0, .name = "disabled" },
                     .{ .value = 0x1, .name = "down" },
-                    .{ .value = 0x2, .name = "up" },
+                    .{ .value = 0x3, .name = "up" },
                 },
             },
         },

--- a/port/nordic/nrf5x/src/hal/gpio.zig
+++ b/port/nordic/nrf5x/src/hal/gpio.zig
@@ -6,11 +6,13 @@ const compatibility = @import("compatibility.zig");
 
 const version: enum {
     nrf51,
-    nrf5283x,
+    nrf52,
+    nrf52833,
     nrf52840,
 } = switch (compatibility.chip) {
     .nrf51 => .nrf51,
-    .nrf52, .nrf52833 => .nrf5283x,
+    .nrf52 => .nrf52,
+    .nrf52833 => .nrf52833,
     .nrf52840 => .nrf52840,
     else => compatibility.unsupported_chip("GPIO"),
 };
@@ -33,7 +35,7 @@ pub const InputBuffer = enum(u1) {
 
 const Regs = switch (version) {
     .nrf51 => microzig.chip.types.peripherals.GPIO,
-    .nrf5283x, .nrf52840 => microzig.chip.types.peripherals.P0,
+    .nrf52, .nrf52833, .nrf52840 => microzig.chip.types.peripherals.P0,
 };
 
 pub const Pull = Regs.Pull;
@@ -52,8 +54,8 @@ pub const Pin = enum(u6) {
     fn get_regs(pin: Pin) *volatile Regs {
         return switch (version) {
             .nrf51 => peripherals.GPIO,
-            .nrf5283x => peripherals.P0,
-            .nrf52840 => if (@backingInt(pin) <= 31)
+            .nrf52 => peripherals.P0,
+            .nrf52833, .nrf52840 => if (@backingInt(pin) <= 31)
                 peripherals.P0
             else
                 peripherals.P1,

--- a/port/nordic/nrf5x/src/hal/gpio.zig
+++ b/port/nordic/nrf5x/src/hal/gpio.zig
@@ -97,7 +97,7 @@ pub const Pin = enum(u6) {
 
     pub inline fn set_sense(pin: Pin, sense: Sense) void {
         const regs = pin.get_regs();
-        regs.PIN_CNF[@backingInt(pin)].modify(.{
+        regs.PIN_CNF[pin.index()].modify(.{
             .SENSE = switch (sense) {
                 .disabled => .Disabled,
                 .high => .High,
@@ -108,7 +108,7 @@ pub const Pin = enum(u6) {
 
     pub inline fn set_input_buffer(pin: Pin, input_buffer: InputBuffer) void {
         const regs = pin.get_regs();
-        regs.PIN_CNF[@backingInt(pin)].modify(.{
+        regs.PIN_CNF[pin.index()].modify(.{
             .INPUT = switch (input_buffer) {
                 .connect => .Connect,
                 .disconnect => .Disconnect,


### PR DESCRIPTION
Fixes #1030, #1029

Also found another bug where we were using `@backingInt` for the index into `PIN_CNF`, which is incorrect if we are using a gpio in P1, since its index would be > 31