### PR TITLE
nrf5x: fix micro:bit v2 display COL4 pin

### DIFF
--- a/port/nordic/nrf5x/src/boards/microbit.zig
+++ b/port/nordic/nrf5x/src/boards/microbit.zig
@@ -49,7 +49,7 @@ pub const pins = switch (revision) {
                 gpio.num(0, 28),
                 gpio.num(0, 11),
                 gpio.num(0, 31),
-                gpio.num(0, 5),
+                gpio.num(1, 5),
                 gpio.num(0, 30),
             };
 


### PR DESCRIPTION
Hello folks!
This bug was preventing a simple heart example code from rendering correctly. Tested with this code: 

```zig
const microzig = @import("microzig");

const nrf = microzig.hal;
const time = nrf.time;
const microbit = microzig.board;

pub const panic = microzig.panic;
pub const std_options = microzig.std_options(.{});

comptime {
    _ = microzig.export_startup();
}

const heart: [5][5]u1 = .{
    .{ 0, 1, 0, 1, 0 },
    .{ 1, 1, 1, 1, 1 },
    .{ 1, 1, 1, 1, 1 },
    .{ 0, 1, 1, 1, 0 },
    .{ 0, 0, 1, 0, 0 },
};

pub fn main() !void {
    microbit.display.init();

    while (true) {
        microbit.display.render(heart, .from_ms(1000));
        time.sleep_ms(1000);
    }
}
```